### PR TITLE
Fix #12 - Added support to add entities to the connection without perfor...

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -325,7 +325,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
         }
     }
 
-    private void recover() throws DatabaseEngineException, NameAlreadyExistsException {
+    private synchronized void recover() throws DatabaseEngineException, NameAlreadyExistsException {
         // Recover entities.
         final Map<String, MappedEntity> niw = new HashMap<String, MappedEntity>(entities);
         // clear the entities

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -62,6 +62,21 @@ public interface DatabaseEngine {
     void addEntity(DbEntity entity) throws DatabaseEngineException;
 
     /**
+     * Loads an entity into the engine.
+     * <p>
+     * No DDL commands will be executed, only prepared statements will be created in order to {@link #persist(String, com.feedzai.commons.sql.abstraction.entry.EntityEntry) persist}
+     * data into the entities.
+     *
+     * @param entity The entity to load into the connection.
+     * @throws DatabaseEngineException If something goes wront while loading the entity.
+     * @implSpec The invocation of this method multiple times is allowed. If the entity already exists, the invocation is a no-op.
+     * @implNote The implementation is similar to the {@link #addEntity(com.feedzai.commons.sql.abstraction.ddl.DbEntity) addEntity} that configured with
+     * {@link com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties#SCHEMA_POLICY SCHEMA_POLICY} of none.
+     * @since 2.1.2
+     */
+    void loadEntity(DbEntity entity) throws DatabaseEngineException;
+
+    /**
      * <p>
      * Updates an entity in the engine.
      * </p>


### PR DESCRIPTION
...ming DDL operations.

 Using DatabaseEngine#loadEntity a new entity can be added to the system without performing any type of DDL even that the schema policy is set to create.

 Changed the recover method to use loadEntity since every time the recover is performed, the entities are already created in the database.