### PR TITLE
ref PULSEDEV-12907 pdb: Support complex fields as JSON/JSONB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>9.3-1100-jdbc41</version>
+        <version>9.4-1206-jdbc42</version>
       </dependency>
       <!-- Needed for compilation even if don't want use Oracle. -->
       <dependency>
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <!-- Oracle -->
     <dependency>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/ddl/DbColumnType.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/ddl/DbColumnType.java
@@ -51,6 +51,11 @@ public enum DbColumnType {
      */
     CLOB,
     /**
+     * The json type
+     * @since 2.1.6
+     */
+    JSON,
+    /**
      * A type that is not mapped.
      */
     UNMAPPED;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/ddl/DbColumnType.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/ddl/DbColumnType.java
@@ -51,8 +51,9 @@ public enum DbColumnType {
      */
     CLOB,
     /**
-     * The json type
-     * @since 2.1.6
+     * The json type. This is not supported by all engines; engines not
+     * supporting it use the CLOB type.
+     * @since 2.1.5
      */
     JSON,
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/PostgreSqlResultColumn.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/PostgreSqlResultColumn.java
@@ -39,11 +39,12 @@ public class PostgreSqlResultColumn extends ResultColumn {
      * Overrides default behaviour for JSON values, that are converted to strings.
      *
      * @param o The object in need of some kind of processing before being set.
-     * @return
+     * @return  The processed object.
+     * @since 2.1.5
      */
     @Override
     protected Object processObject(Object o) {
-        if (o != null  && o instanceof PGobject &&
+        if (o instanceof PGobject &&
                         ((PGobject)o).getType().equals("jsonb")) {
             return ((PGobject) o).getValue();
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/PostgreSqlResultColumn.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/PostgreSqlResultColumn.java
@@ -15,6 +15,8 @@
  */
 package com.feedzai.commons.sql.abstraction.dml.result;
 
+import org.postgresql.util.PGobject;
+
 /**
  * The PostgreSql column result implementation.
  *
@@ -31,5 +33,20 @@ public class PostgreSqlResultColumn extends ResultColumn {
      */
     public PostgreSqlResultColumn(final String name, final Object val) {
         super(name, val);
+    }
+
+    /**
+     * Overrides default behaviour for JSON values, that are converted to strings.
+     *
+     * @param o The object in need of some kind of processing before being set.
+     * @return
+     */
+    @Override
+    protected Object processObject(Object o) {
+        if (o != null  && o instanceof PGobject &&
+                        ((PGobject)o).getType().equals("jsonb")) {
+            return ((PGobject) o).getValue();
+        }
+        return super.processObject(o);
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -1360,6 +1360,8 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * Maps the database type to {@link DbColumnType}. If there's no mapping a {@link DbColumnType#UNMAPPED} is returned.
      *
      * @param type The SQL type from {@link java.sql.Types}.
+     * @param typeName  The native database type name.  It provides additional information for
+     *                  derived classes to resolve types unmapped here.
      * @return The {@link DbColumnType}.
      */
     protected DbColumnType toPdbType(final int type, final String typeName) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -418,6 +418,20 @@ public interface DatabaseEngine {
     void setParameter(final String name, final int index, final Object param) throws DatabaseEngineException, ConnectionResetException;
 
     /**
+     * Sets the parameter on the specified index given its type. This is for situations where the java type of the parameter
+     * alone is not enough to determine the correspondent database type.
+     *
+     * @param name  The prepared statement name.
+     * @param index The index to set.
+     * @param param The parameter to set.
+     * @param paramType The type of the parameter being set.
+     * @throws DatabaseEngineException  If something occurs setting the parameters.
+     * @throws ConnectionResetException If the connection was reset while trying to set the parameter.
+     * @since 2.1.6
+     */
+    void setParameter(final String name, final int index, final Object param, DbColumnType paramType) throws DatabaseEngineException, ConnectionResetException;
+
+    /**
      * Executes the specified prepared statement.
      *
      * @param name The prepared statement name.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -419,7 +419,9 @@ public interface DatabaseEngine {
 
     /**
      * Sets the parameter on the specified index given its type. This is for situations where the java type of the parameter
-     * alone is not enough to determine the correspondent database type.
+     * alone is not enough to determine the corresponding database type; for example, Strings can be used to represent both
+     * actual Strings and Json values, so if we have an update statement that updates a json column we need to specify that
+     * the bind parameter is of type json.
      *
      * @param name  The prepared statement name.
      * @param index The index to set.
@@ -427,7 +429,7 @@ public interface DatabaseEngine {
      * @param paramType The type of the parameter being set.
      * @throws DatabaseEngineException  If something occurs setting the parameters.
      * @throws ConnectionResetException If the connection was reset while trying to set the parameter.
-     * @since 2.1.6
+     * @since 2.1.5
      */
     void setParameter(final String name, final int index, final Object param, DbColumnType paramType) throws DatabaseEngineException, ConnectionResetException;
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -107,7 +107,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 }
                 switch (column.getDbColumnType()) {
                     /*
-                     * CLOB and BLOB are handled the same way in DB2 since CLOB is not supported.
+                     * CLOB, BLOB and and JSON are handled the same way in DB2 since neither CLOB nor JSON are supported.
                      */
                     case JSON:
                     case CLOB:

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -109,6 +109,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                     /*
                      * CLOB and BLOB are handled the same way in DB2 since CLOB is not supported.
                      */
+                    case JSON:
                     case CLOB:
                     case BLOB:
                         ps.setBytes(i, objectToArray(val));

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -328,6 +328,7 @@ public class DB2Translator extends AbstractTranslator {
                 return format("VARCHAR(%s)", c.isSizeSet() ? c.getSize().toString() : properties.getProperty(VARCHAR_SIZE));
 
             /* DB2 does not support CLOB (or at least the Java driver is not implemented. */
+            case JSON:
             case CLOB:
             case BLOB:
                 if (properties.isMaxBlobSizeSet()) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -327,7 +327,7 @@ public class DB2Translator extends AbstractTranslator {
             case STRING:
                 return format("VARCHAR(%s)", c.isSizeSet() ? c.getSize().toString() : properties.getProperty(VARCHAR_SIZE));
 
-            /* DB2 does not support CLOB (or at least the Java driver is not implemented. */
+            /* DB2 does not support CLOB nor JSON (or at least the Java driver is not implemented. */
             case JSON:
             case CLOB:
             case BLOB:

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -123,6 +123,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                         ps.setBytes(i, objectToArray(val));
 
                         break;
+                    case JSON:
                     case CLOB:
                         if (val == null) {
                             ps.setNull(i, Types.CLOB);

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
@@ -294,7 +294,9 @@ public class H2Translator extends AbstractTranslator {
                 return "BLOB";
 
             case CLOB:
+            case JSON:
                 return "CLOB";
+
             default:
                 throw new DatabaseEngineRuntimeException(format("Mapping not found for '%s'. Please report this error.", c.getDbColumnType()));
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -113,6 +113,7 @@ public class MySqlEngine extends AbstractDatabaseEngine {
                         ps.setBytes(i, objectToArray(val));
 
                         break;
+                    case JSON:
                     case CLOB:
                         if (val == null) {
                             ps.setNull(i, Types.CLOB);

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
@@ -276,7 +276,9 @@ public class MySqlTranslator extends AbstractTranslator {
                 return format("VARCHAR(%s)", c.isSizeSet() ? c.getSize().toString() : properties.getProperty(VARCHAR_SIZE));
 
             case CLOB:
+            case JSON:
                 return "LONGTEXT";
+
             case BLOB:
                 //return format("VARBINARY(%s)", properties.getProperty(MAX_BLOB_SIZE));
                 return format("LONGBLOB");

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -122,6 +122,7 @@ public class OracleEngine extends AbstractDatabaseEngine {
                         ps.setBytes(i, objectToArray(val));
 
                         break;
+                    case JSON:
                     case CLOB:
                         if (val == null) {
                             ps.setNull(i, Types.CLOB);

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
@@ -283,6 +283,7 @@ public class OracleTranslator extends AbstractTranslator {
                 return format("VARCHAR(%s)", c.isSizeSet() ? c.getSize().toString() : properties.getProperty(VARCHAR_SIZE));
 
             case CLOB:
+            case JSON:
                 return "CLOB";
 
             case BLOB:

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -139,6 +139,14 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         super.setParameter(name, index, param);
     }
 
+    /**
+     * Converts a String value into a PG JSON value ready to be assigned to bind variables in Prepared Statements.
+     *
+     * @param val   The String representation of the JSON value.
+     * @return      The correspondent JSON value
+     * @throws DatabaseEngineException if there is an error creating the value. It should never be thrown.
+     * @since 2.1.5
+     */
     private Object getJSONValue(String val) throws DatabaseEngineException {
         try {
             PGobject dataObject = new PGobject();
@@ -146,7 +154,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
             dataObject.setValue(val);
             return dataObject;
         } catch (SQLException ex) {
-            throw new DatabaseEngineException("Error while mapping variables to database", ex);
+            throw new DatabaseEngineException("Error while mapping variables to database, value = " + val, ex);
         }
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
@@ -307,6 +307,9 @@ public class PostgreSqlTranslator extends AbstractTranslator {
             case BLOB:
                 return format("BYTEA");
 
+            case JSON:
+                return "JSONB";
+
             default:
                 throw new DatabaseEngineRuntimeException(format("Mapping not found for '%s'. Please report this error.", c.getDbColumnType()));
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -106,6 +106,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
 
                         break;
 
+                    case JSON:
                     case CLOB:
                         if (val == null) {
                             ps.setNull(i, Types.CLOB);

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -319,6 +319,7 @@ public class SqlServerTranslator extends AbstractTranslator {
             case STRING:
                 return format("NVARCHAR(%s)", c.isSizeSet() ? c.getSize().toString() : properties.getProperty(VARCHAR_SIZE));
 
+            case JSON:
             case CLOB:
                 return "NVARCHAR(MAX)";
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/JSonTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/JSonTest.java
@@ -107,11 +107,7 @@ public class JSonTest {
     }
 
     /**
-<<<<<<< HEAD
      * Scenario for an insert of a correct json value using persist().
-=======
-     * Scenario for an insert using persist().
->>>>>>> 51455aad63197a0b518e9740ef5fb74e6579982c
      */
     @Test
     public void normalInsertTest() throws DatabaseFactoryException, DatabaseEngineException {

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/UnderflowTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/UnderflowTest.java
@@ -29,10 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.*;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.*;
@@ -127,9 +124,10 @@ public class UnderflowTest {
     @Test
     public void testUnderflowPreparedStatement1() throws Exception {
         String PS_NAME = "MyPS";
+        String escapeChar = dbEngine.escapeCharacter();
         String insertQuery =
             "INSERT INTO " + quotize("TEST_TBL")
-                    + "(" + quotize(PK_COL) + "," + quotize(ERROR_COL) + "," + quotize(NORMAL_COL) +") "
+                    + "(" + quotize(PK_COL, escapeChar) + "," + quotize(ERROR_COL, escapeChar) + "," + quotize(NORMAL_COL, escapeChar) +") "
                     + "VALUES (?,?,?)";
         dbEngine.beginTransaction();
         dbEngine.createPreparedStatement(PS_NAME, insertQuery);
@@ -146,9 +144,10 @@ public class UnderflowTest {
     @Test
     public void testUnderflowPreparedStatement2() throws Exception {
         String PS_NAME = "MyPS";
+        String escapeChar = dbEngine.escapeCharacter();
         String insertQuery =
                 "INSERT INTO " + quotize("TEST_TBL")
-                        + "(" + quotize(PK_COL) + "," + quotize(ERROR_COL) + "," + quotize(NORMAL_COL) +") "
+                        + "(" + quotize(PK_COL, escapeChar) + "," + quotize(ERROR_COL, escapeChar) + "," + quotize(NORMAL_COL, escapeChar) +") "
                         + "VALUES (?,?,?)";
         dbEngine.beginTransaction();
         dbEngine.createPreparedStatement(PS_NAME, insertQuery);


### PR DESCRIPTION
-  Added DbColumnType.JSON, that is mapped either to a native JSON type whenever the engine supports it or to a CLOB otherwise.
-  Added method setParameter(final String name, final int index, final Object param, DbColumnType paramType) to DatabaseEngine, that allows specifying the intended type of a PreparedStatement parameter.  This is meant only for when it is not possible to figure this out from the Java type, which may happen now on String values: by default they represent String values (as before the change), but they may also represent JSON values.
 -  Fixed UnderflowTest unit test, that had hardcoded SQL on prepared statements that was not portable across DB engines.