### PR TITLE
Rolls back the transaction on batch flush failure

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -58,11 +57,23 @@ public abstract class AbstractBatch implements Runnable {
     protected static final int salt = 100;
 
     /**
-     * Lock used for concurrent access to the flush buffer
+     * Lock used for concurrent access to the flush buffer.
      *
      * @since 2.1.4
      */
-    private final Lock flushLock = new ReentrantLock();
+    private final Lock bufferLock = new ReentrantLock();
+
+    /**
+     * Lock used for concurrent access to the flush transaction.
+     * <p>
+     * We are not using the {@link #bufferLock} because the
+     * {@link #add(BatchEntry)} calls would block while a flush
+     * transaction is in progress.
+     *
+     * @since 2.1.5
+     */
+    private final Lock flushTransactionLock = new ReentrantLock();
+
     /**
      * The database engine.
      */
@@ -163,12 +174,12 @@ public abstract class AbstractBatch implements Runnable {
      * @throws DatabaseEngineException If an error with the database occurs.
      */
     public void add(BatchEntry batchEntry) throws DatabaseEngineException {
-        flushLock.lock();
+        bufferLock.lock();
         try {
             buffer.add(batchEntry);
             batch--;
         } finally {
-            flushLock.unlock();
+            bufferLock.unlock();
         }
         if (batch <= 0) {
             flush();
@@ -192,7 +203,7 @@ public abstract class AbstractBatch implements Runnable {
     public void flush() {
         List<BatchEntry> temp;
 
-        flushLock.lock();
+        bufferLock.lock();
         try {
             // Reset the last flush timestamp, even if the batch is empty or flush fails
             lastFlush = System.currentTimeMillis();
@@ -211,10 +222,11 @@ public abstract class AbstractBatch implements Runnable {
             buffer = new LinkedList<>();
 
         } finally {
-            flushLock.unlock();
+            bufferLock.unlock();
         }
 
         try {
+            flushTransactionLock.lock();
             final long start = System.currentTimeMillis();
 
             // begin the transaction before the addBatch calls in order to force the retry
@@ -222,19 +234,13 @@ public abstract class AbstractBatch implements Runnable {
             // the addBatch call that uses a prepared statement will fail
             de.beginTransaction();
 
-            try {
-                for (BatchEntry entry : temp) {
-                    de.addBatch(entry.getTableName(), entry.getEntityEntry());
-                }
-
-                de.flush();
-                de.commit();
-                logger.trace("[{}] Batch flushed. Took {} ms, {} rows.", name, (System.currentTimeMillis() - start), temp.size());
-            } finally {
-                if (de.isTransactionActive()) {
-                    de.rollback();
-                }
+            for (BatchEntry entry : temp) {
+                de.addBatch(entry.getTableName(), entry.getEntityEntry());
             }
+
+            de.flush();
+            de.commit();
+            logger.trace("[{}] Batch flushed. Took {} ms, {} rows.", name, (System.currentTimeMillis() - start), temp.size());
         } catch (Exception e) {
             logger.error(dev, "[{}] Error occurred while flushing.", name, e);
             /*
@@ -247,6 +253,15 @@ public abstract class AbstractBatch implements Runnable {
              * and buffer will have the events right after the failure.
              */
             onFlushFailure(temp.toArray(new BatchEntry[temp.size()]));
+        } finally {
+            try {
+                if (de.isTransactionActive()) {
+                    de.rollback();
+                }
+            } catch (Exception e) {
+                logger.trace("[{}] Batch failed to check the flush transaction state", name);
+            }
+            flushTransactionLock.unlock();
         }
 
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -222,12 +222,12 @@ public abstract class AbstractBatch implements Runnable {
             // the addBatch call that uses a prepared statement will fail
             de.beginTransaction();
 
-            // This has to be separate because it accesses to the database.
-            for (BatchEntry entry : temp) {
-                de.addBatch(entry.getTableName(), entry.getEntityEntry());
-            }
-
             try {
+                // This has to be separate because it accesses to the database.
+                for (BatchEntry entry : temp) {
+                    de.addBatch(entry.getTableName(), entry.getEntityEntry());
+                }
+
                 de.flush();
                 de.commit();
                 logger.trace("[{}] Batch flushed. Took {} ms, {} rows.", name, (System.currentTimeMillis() - start), temp.size());

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -223,7 +223,6 @@ public abstract class AbstractBatch implements Runnable {
             de.beginTransaction();
 
             try {
-                // This has to be separate because it accesses to the database.
                 for (BatchEntry entry : temp) {
                     de.addBatch(entry.getTableName(), entry.getEntityEntry());
                 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -210,6 +210,14 @@ public class BatchUpdateTest {
         assertEquals("Entries were added to failed", batch.getFailedEntries().size(), numTestEntries);
     }
 
+    @Test
+    public void flushFreesConnectionOnFailure() throws DatabaseEngineException {
+        final DefaultBatch batch = DefaultBatch.create(engine, "flushFreesConnectionOnFailure", 2, 1000, 1000000);
+        batch.add("unknown_table", entry().build()); // This will only fail when flushing
+        batch.flush();
+        assertFalse("Flush failed but the transaction is still active", engine.isTransactionActive());
+    }
+
     /**
      * Create test table.
      */

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -170,7 +170,7 @@ public class BatchUpdateTest {
         MockedBatch batch = MockedBatch.create(engine, "batchInsertWithDBConnDownTest", numTestEntries, 100000, 1000000);
 
         // Simulate failures in beginTransaction() for flush to fail
-        new Expectations() {{
+        new NonStrictExpectations() {{
             engine.beginTransaction(); result = new DatabaseEngineRuntimeException("Error !");
         }};
 
@@ -195,7 +195,7 @@ public class BatchUpdateTest {
         MockedBatch batch = MockedBatch.create(engine, "batchInsertWithDBConnDownTest", numTestEntries + 1, batchTimeout, 1000000);
 
         // Simulate failures in beginTransaction() for flush to fail
-        new Expectations() {{
+        new NonStrictExpectations() {{
             engine.beginTransaction(); result = new DatabaseEngineRuntimeException("Error !");
         }};
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -210,6 +210,11 @@ public class BatchUpdateTest {
         assertEquals("Entries were added to failed", batch.getFailedEntries().size(), numTestEntries);
     }
 
+    /**
+     * Ensures that the batch transaction is rolled back when the flush fails.
+     *
+     * @since 2.1.5
+     */
     @Test
     public void flushFreesConnectionOnFailure() throws DatabaseEngineException {
         final DefaultBatch batch = DefaultBatch.create(engine, "flushFreesConnectionOnFailure", 2, 1000, 1000000);


### PR DESCRIPTION
Before this fix, when flushing the batch, if the addBatch call failed the transaction
would not be rolled back because the roll back was only being done in the inner try-catch.
This PR just moves the addBatch loop to inside the inner try-catch. It also adds a regression
unit-test.