### PR TITLE
Loss of precision when using ResultColumn.toLong()

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultColumn.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultColumn.java
@@ -133,7 +133,17 @@ public abstract class ResultColumn implements Serializable {
             return null;
         }
 
-        return (long) Double.parseDouble(val.toString());
+        try {
+            // In most cases the value either doesn't have decimals or they
+            // are zero (e.g., 13.0), and in this case Long.parseLong() is ok.
+            return Long.parseLong(val.toString());
+
+        } catch (NumberFormatException e) {
+            // We get here if the double has decimal digits (e.g, 13.5) and in this
+            // case there is no precision overflow on using an intermediate Double
+            // before because it means the value was not stored as a long.
+            return (long) Double.parseDouble(val.toString());
+        }
     }
 
     /**

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/UnderflowTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/UnderflowTest.java
@@ -165,6 +165,7 @@ public class UnderflowTest {
      */
     @Test
     public void testUnderflowBatch() throws DatabaseFactoryException, DatabaseEngineException {
+        EntityEntry.Builder entryBuilder = new EntityEntry.Builder();
         dbEngine.addBatch(TEST_TABLE, getTestEntry());
         dbEngine.flush();
         dbEngine.commit();

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/UnderflowTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/UnderflowTest.java
@@ -29,13 +29,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.*;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.*;
+import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -114,6 +112,7 @@ public class UnderflowTest {
      */
     @Test
     public void testUnderflowNormal() throws DatabaseFactoryException, DatabaseEngineException {
+        dbEngine.beginTransaction();
         dbEngine.persist(TEST_TABLE, getTestEntry());
         dbEngine.commit();
         checkInsertedValue();
@@ -125,7 +124,12 @@ public class UnderflowTest {
     @Test
     public void testUnderflowPreparedStatement1() throws Exception {
         String PS_NAME = "MyPS";
-        String insertQuery = "insert into TEST_TBL(PK_COL,ERROR_COL,VALUE_COL) values (?,?,?)";
+        String escapeChar = dbEngine.escapeCharacter();
+        String insertQuery =
+            "INSERT INTO " + quotize("TEST_TBL")
+                    + "(" + quotize(PK_COL, escapeChar) + "," + quotize(ERROR_COL, escapeChar) + "," + quotize(NORMAL_COL, escapeChar) +") "
+                    + "VALUES (?,?,?)";
+        dbEngine.beginTransaction();
         dbEngine.createPreparedStatement(PS_NAME, insertQuery);
         dbEngine.clearParameters(PS_NAME);
         dbEngine.setParameters(PS_NAME, PK_VALUE, ERROR_VALUE, NORMAL_VALUE);
@@ -140,7 +144,12 @@ public class UnderflowTest {
     @Test
     public void testUnderflowPreparedStatement2() throws Exception {
         String PS_NAME = "MyPS";
-        String insertQuery = "insert into TEST_TBL(PK_COL,ERROR_COL,VALUE_COL) values (?,?,?)";
+        String escapeChar = dbEngine.escapeCharacter();
+        String insertQuery =
+                "INSERT INTO " + quotize("TEST_TBL")
+                        + "(" + quotize(PK_COL, escapeChar) + "," + quotize(ERROR_COL, escapeChar) + "," + quotize(NORMAL_COL, escapeChar) +") "
+                        + "VALUES (?,?,?)";
+        dbEngine.beginTransaction();
         dbEngine.createPreparedStatement(PS_NAME, insertQuery);
         dbEngine.clearParameters(PS_NAME);
         dbEngine.setParameter(PS_NAME, 1, PK_VALUE);


### PR DESCRIPTION
Removed usage of the intermediate double when the stored value has no decimal fields.  When it has decimal fields, the intermediate double can be used as before because it means the value was not stored as a long.