### PR TITLE
Fix DDL change detection for PostgreSqlEngine

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -608,7 +608,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
 
 
             DatabaseMetaData meta = conn.getMetaData();
-            rsColumns = meta.getColumns(null, "public", name, null);
+            rsColumns = meta.getColumns(null, getSchema(), name, null);
             while (rsColumns.next()) {
                 metaMap.put(rsColumns.getString("COLUMN_NAME"), toPdbType(rsColumns.getInt("DATA_TYPE")));
             }


### PR DESCRIPTION
PostgreSqlEngine always fetches metadata from the "public" schema when trying to detect table changes, regardless of the schema configured for the Database Engine. This hotfix corrects this behaviour.