### PR TITLE
[BugFix] - Fix documentation on ORDER BY Clause.

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ results = engine.query(
 	.from(table("streams"))
 	.where(eq(column("provider_id"), k(4)))
 	.groupby(column("data_type_id"))
-	.orderby(column("data_type_id")).asc());
+	.orderby(column("data_type_id").asc());
 ```
 |Function|Description|
 |:---|:---|


### PR DESCRIPTION
There is a typo regarding how PDB's `ORDER BY` Clause should be used together with the `ASC` argument. Currently, the documentation exemplifies the usage of both with the following expression: `orderby(column("data_type_id")).asc())`. However, such expression is not correct and thus it was fixed to: `orderby(column("data_type_id").asc())`.
