### PR TITLE
ref PULSEDEV-14916 pdb: Added support for synchronous/serial execution of AbstractBacth#flush

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -203,27 +203,7 @@ public abstract class AbstractBatch implements Runnable {
      * @implSpec Same as {@link #flush(boolean)} with {@link false}.
      */
     public void flush() {
-        flush(false);
-    }
-
-    /**
-     * Flushes the pending messages.
-     * <p>
-     * If {@param sync} is {@literal true} it waits for other pending flush operations.
-     * <p>
-     * If {@param sync} is {@literal false} it can return directly if the buffer if the batch is empty.
-     *
-     * @param sync {@literal true} if it should wait for other {@link #flush()} operations.
-     * @implSpec It is possible that two threads might execute in competing order and sync execution acquires the flushTransactionLock before a non synchronous one leading
-     * to a non serial execution.
-     * @since 2.1.6
-     */
-    public void flush(boolean sync) {
         List<BatchEntry> temp;
-
-        if (sync) {
-            flushTransactionLock.lock();
-        }
 
         bufferLock.lock();
         try {
@@ -285,7 +265,31 @@ public abstract class AbstractBatch implements Runnable {
             }
             flushTransactionLock.unlock();
         }
+    }
 
+    /**
+     * Flushes the pending messages.
+     * <p>
+     * If {@param sync} is {@literal true} it waits for other pending flush operations.
+     * <p>
+     * If {@param sync} is {@literal false} it can return directly if the buffer if the batch is empty.
+     *
+     * @param sync {@literal true} if it should wait for other {@link #flush()} operations.
+     * @implSpec It is possible that two threads might execute in competing order and sync execution acquires the flushTransactionLock before a non synchronous one leading
+     * to a non serial execution.
+     * @since 2.1.6
+     */
+    public void flush(boolean sync) {
+        if (!sync) {
+            flush();
+        } else {
+            try {
+                flushTransactionLock.lock();
+                flush();
+            } finally {
+                flushTransactionLock.unlock();
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -199,9 +199,31 @@ public abstract class AbstractBatch implements Runnable {
 
     /**
      * Flushes the pending batches.
+     *
+     * @implSpec Same as {@link #flush(boolean)} with {@link false}.
      */
     public void flush() {
+        flush(false);
+    }
+
+    /**
+     * Flushes the pending messages.
+     * <p>
+     * If {@param sync} is {@literal true} it waits for other pending flush operations.
+     * <p>
+     * If {@param sync} is {@literal false} it can return directly if the buffer if the batch is empty.
+     *
+     * @param sync {@literal true} if it should wait for other {@link #flush()} operations.
+     * @implSpec It is possible that two threads might execute in competing order and sync execution acquires the flushTransactionLock before a non synchronous one leading
+     * to a non serial execution.
+     * @since 2.1.6
+     */
+    public void flush(boolean sync) {
         List<BatchEntry> temp;
+
+        if (sync) {
+            flushTransactionLock.lock();
+        }
 
         bufferLock.lock();
         try {


### PR DESCRIPTION
 - When executing #flush(true) the batch will wait for other batches executing.