### PR TITLE
ref PULSEDEV-15386 pdb: Changed Double data type used for oracle columns

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -1567,11 +1567,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
         int i = 1;
         for (Object o : params) {
             try {
-                if (o instanceof byte[]) {
-                    ps.ps.setBytes(i, (byte[]) o);
-                } else {
-                    ps.ps.setObject(i, o);
-                }
+                setParameterValues(ps.ps, i, o);
             } catch (SQLException ex) {
                 if (checkConnection(conn) || !properties.isReconnectOnLost()) {
                     throw new DatabaseEngineException("Could not set parameters", ex);
@@ -1598,11 +1594,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
         }
 
         try {
-            if (param instanceof byte[]) {
-                ps.ps.setBytes(index, (byte[]) param);
-            } else {
-                ps.ps.setObject(index, param);
-            }
+            setParameterValues(ps.ps, index, param);
         } catch (SQLException ex) {
             if (checkConnection(conn) || !properties.isReconnectOnLost()) {
                 throw new DatabaseEngineException("Could not set parameter", ex);
@@ -1850,6 +1842,22 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
             }
 
             injector.injectMembers(o);
+        }
+    }
+
+    /**
+     * Sets the value of a parameter in {@code index} to the value provided in {@code param}.
+     *
+     * @param ps    The {@link PreparedStatement} to insert the association between index and the param.
+     * @param index The index to set the value to.
+     * @param param The value to be set at the provided index.
+     * @throws SQLException If something goes wrong accessing the database.
+     */
+    protected void setParameterValues(final PreparedStatement ps, final int index, final Object param) throws SQLException {
+        if (param instanceof byte[]) {
+            ps.setBytes(index, (byte[]) param);
+        } else {
+            ps.setObject(index, param);
         }
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -924,6 +924,7 @@ public class OracleEngine extends AbstractDatabaseEngine {
                 return DbColumnType.BOOLEAN;
             case "FLOAT":
             case "FLOAT126":
+            case "BINARY_DOUBLE":
                 return DbColumnType.DOUBLE;
             case "LONG":
             case "NUMBER19":

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -23,6 +23,7 @@ import com.feedzai.commons.sql.abstraction.engine.*;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import com.feedzai.commons.sql.abstraction.util.PreparedStatementCapsule;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -147,6 +148,9 @@ public class OracleEngine extends AbstractDatabaseEngine {
                         }
 
                         break;
+                    case DOUBLE:
+                        setParameterValues(ps, i, val);
+                        break;
                     default:
                         ps.setObject(i, ensureNoUnderflow(val));
                 }
@@ -158,6 +162,38 @@ public class OracleEngine extends AbstractDatabaseEngine {
         }
 
         return i - 1;
+    }
+
+    @Override
+    protected void setParameterValues(final PreparedStatement ps, final int index, final Object param) throws SQLException {
+        if (param instanceof byte[]) {
+            ps.setBytes(index, (byte[]) param);
+        } else {
+            if (!(param instanceof Double)) {
+                /**
+                 * If it is not a double it may be:
+                 *  - A String with the special values such as infinity or NaN
+                 *  - A String with some invalid value
+                 *  - An integer/long
+                 *  - Some other invalid type
+                 *
+                 *  In these cases we will invoke the setObject.
+                 */
+                ps.setObject(index, param);
+            } else {
+                /**
+                 * Only Double typed values will execute here.
+                 * They may be:
+                 *  - Regular double number
+                 *  - Double.NaN
+                 *  - Double.{POSITIVE|NEGATIVE}_INFINITY
+                 *
+                 *  In these cases we use the setBinaryDouble specific to the oracle prepared statement.
+                 */
+                final OraclePreparedStatement orclPs = (OraclePreparedStatement) ps;
+                orclPs.setBinaryDouble(index, (Double) ensureNoUnderflow(param));
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
@@ -271,7 +271,7 @@ public class OracleTranslator extends AbstractTranslator {
                         quotize(c.getName()));
 
             case DOUBLE:
-                return "DOUBLE PRECISION";
+                return "BINARY_DOUBLE";
 
             case INT:
                 return "INT";

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
@@ -15,11 +15,10 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
+import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
 import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
+import com.feedzai.commons.sql.abstraction.engine.*;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,9 +26,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.DOUBLE;
+import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.INT;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.*;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 /**
@@ -40,6 +43,11 @@ public abstract class AbstractEngineSchemaTest {
 
     protected DatabaseEngine engine;
     protected Properties properties;
+
+    private static String TABLE_NAME = "TEST_DOUBLE_COLUMN";
+    private static String ID_COL = "ID";
+    private static String DBL_COL = "DBL_COL";
+    private static int PK_VALUE = 1;
 
     protected abstract String getSchema();
 
@@ -78,6 +86,247 @@ public abstract class AbstractEngineSchemaTest {
 
         List<Map<String, ResultColumn>> query = engine.query(select(udf("TimesTwo", k(10)).alias("TIMESTWO")));
         assertEquals("result ok?", 20, (int) query.get(0).get("TIMESTWO").toInt());
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'NaN' should be inserted into the database without any error.
+     */
+    @Test
+    public void testPersisttNan() throws Exception {
+        testPersistSpecialValues("NaN");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'NaN' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertPStNan() throws Exception {
+        testInsertSpecialValuesByPS("NaN");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'NaN' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertPS2tNan() throws Exception {
+        testInsertSpecialValuesByPS2("NaN");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'NaN' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertBatchtNan() throws Exception {
+        testInsertSpecialValuesByBatch("NaN");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testPersistInfinity() throws Exception {
+        testPersistSpecialValues("Infinity");
+    }
+
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertPSInfinity() throws Exception {
+        testInsertSpecialValuesByPS("Infinity");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertPS2Infinity() throws Exception {
+        testInsertSpecialValuesByPS2("Infinity");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertBatchInfinity() throws Exception {
+        testInsertSpecialValuesByBatch("Infinity");
+    }
+
+    /**
+     * The 'randomString' is not a special value for the BINARY_DOUBLE type so it should throw an error.
+     */
+    @Test(expected=Exception.class)
+    public void testPersistRandomValuesDoNoWorkInBinaryDoubleColumn() throws Exception {
+        testPersistSpecialValues("randomString");
+    }
+
+    /**
+     * The 'randomString' is not a special value for the BINARY_DOUBLE type so it should throw an error.
+     */
+    @Test(expected=Exception.class)
+    public void testInsertPSRandomValuesDoNoWorkInBinaryDoubleColumn() throws Exception {
+        testInsertSpecialValuesByPS("randomString");
+    }
+
+    /**
+     * The 'randomString' is not a special value for the BINARY_DOUBLE type so it should throw an error.
+     */
+    @Test(expected=Exception.class)
+    public void testInsertPS2RandomValuesDoNoWorkInBinaryDoubleColumn() throws Exception {
+        testInsertSpecialValuesByPS2("randomString");
+    }
+
+    /**
+     * The 'randomString' is not a special value for the BINARY_DOUBLE type so it should throw an error.
+     */
+    @Test(expected=Exception.class)
+    public void testInsertBatchRandomValuesDoNoWorkInBinaryDoubleColumn() throws Exception {
+        testInsertSpecialValuesByBatch("randomString");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'NaN' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertPSNan() throws Exception {
+        testPersistSpecialValues("NaN");
+    }
+
+
+    /**
+     * Auxiliary method to persist a provided special value.
+     *
+     * @param columnValue The column value.
+     */
+    protected void testPersistSpecialValues(final String columnValue) throws DatabaseEngineException, DatabaseFactoryException {
+        final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
+        try {
+            final DbEntity entity = createSpecialValuesEntity();
+            engine.addEntity(entity);
+            final EntityEntry entry = createSpecialValueEntry(columnValue);
+            engine.persist(entity.getName(), entry);
+            checkResult(engine, entity.getName(), columnValue);
+        } finally {
+            engine.close();
+        }
+    }
+
+    /**
+     * Auxiliary method to insert a provided special value using a prepared statement.
+     *
+     * @param columnValue The column value.
+     */
+    protected void testInsertSpecialValuesByPS(final String columnValue) throws DatabaseEngineException, DatabaseFactoryException, NameAlreadyExistsException, ConnectionResetException {
+        final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
+        final String PSName = "PS_DUMMY";
+        final String preparedStatementQuery = "insert into TEST_DOUBLE_COLUMN(ID, DBL_COL) values (?,?)";
+        try {
+            final DbEntity entity = createSpecialValuesEntity();
+            engine.addEntity(entity);
+            engine.createPreparedStatement(PSName, preparedStatementQuery);
+            engine.clearParameters(PSName);
+            engine.setParameters(PSName, PK_VALUE, columnValue);
+            engine.executePS(PSName);
+            engine.commit();
+            checkResult(engine, TABLE_NAME, columnValue);
+        } finally {
+            engine.close();
+        }
+
+    }
+
+    /**
+     * Auxiliary method to insert a provided special value using a prepared statement.
+     *
+     * @param columnValue The column value.
+     */
+    protected void testInsertSpecialValuesByPS2(final String columnValue) throws DatabaseEngineException, DatabaseFactoryException, NameAlreadyExistsException, ConnectionResetException {
+        final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
+        final String PSName = "PS_DUMMY";
+        final String preparedStatementQuery = "insert into TEST_DOUBLE_COLUMN(ID, DBL_COL) values (?,?)";
+        try {
+            final DbEntity entity = createSpecialValuesEntity();
+            engine.addEntity(entity);
+            engine.createPreparedStatement(PSName, preparedStatementQuery);
+            engine.clearParameters(PSName);
+            engine.setParameter(PSName, 1, PK_VALUE);
+            engine.setParameter(PSName, 2, columnValue);
+            engine.executePS(PSName);
+            engine.commit();
+            checkResult(engine, TABLE_NAME, columnValue);
+        } finally {
+            engine.close();
+        }
+
+    }
+
+    /**
+     * Auxiliary method to insert a provided special value using a batch.
+     *
+     * @param columnValue The column value.
+     */
+    protected void testInsertSpecialValuesByBatch(final String columnValue) throws DatabaseFactoryException, DatabaseEngineException {
+        final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
+        try {
+            final DbEntity entity = createSpecialValuesEntity();
+            engine.addEntity(entity);
+            engine.addBatch(TABLE_NAME, createSpecialValueEntry(columnValue));
+            engine.flush();
+            engine.commit();
+            checkResult(engine, TABLE_NAME, columnValue);
+        } finally {
+            engine.close();
+        }
+    }
+
+    /**
+     * Auxiliary method that checks that the inserted value is indeed the provided column value.
+     *
+     * @param engine      The database engine.
+     * @param entityName  The entity name to check.
+     * @param columnValue The column value persisted in storage.
+     */
+    protected void checkResult(final DatabaseEngine engine, final String entityName, final String columnValue) throws DatabaseEngineException {
+        final List<Map<String, ResultColumn>> dbl = engine.query(select(column(DBL_COL)).from(table(entityName)));
+        final ResultColumn result = dbl.get(0).get(DBL_COL);
+        assertTrue("Should be equal to '"+ columnValue +"'. But was: " + result.toString(), result.toString().equals(columnValue));
+    }
+
+    /**
+     * Auxiliary method that creates the entity that will receive the special values.
+     *
+     * @return The {@link DbEntity} to insert the values.
+     */
+    protected DbEntity createSpecialValuesEntity() {
+        return dbEntity()
+                .name(TABLE_NAME)
+                .addColumn(ID_COL, INT)
+                .addColumn(DBL_COL, DOUBLE)
+                .pkFields(ID_COL)
+                .build();
+    }
+
+    /**
+     * Auxiliary method that creates the entry to insert in the special values entity.
+     *
+     * @param columnValue The value to insert.
+     * @return The {@link EntityEntry} to insert in storage.
+     */
+    protected EntityEntry createSpecialValueEntry(final String columnValue) {
+        return entry()
+                .set(ID_COL, 1)
+                .set(DBL_COL, columnValue)
+                .build();
     }
 
     protected void defineUDFGetOne(DatabaseEngine engine) throws DatabaseEngineException {

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
@@ -102,8 +102,26 @@ public abstract class AbstractEngineSchemaTest {
      * value 'NaN' should be inserted into the database without any error.
      */
     @Test
+    public void testPersisttNanDouble() throws Exception {
+        testPersistSpecialValues(Double.NaN);
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'NaN' should be inserted into the database without any error.
+     */
+    @Test
     public void testInsertPStNan() throws Exception {
         testInsertSpecialValuesByPS("NaN");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'NaN' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertPStNanDouble() throws Exception {
+        testInsertSpecialValuesByPS(Double.NaN);
     }
 
     /**
@@ -120,8 +138,26 @@ public abstract class AbstractEngineSchemaTest {
      * value 'NaN' should be inserted into the database without any error.
      */
     @Test
+    public void testInsertPS2tNanDouble() throws Exception {
+        testInsertSpecialValuesByPS2(Double.NaN);
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'NaN' should be inserted into the database without any error.
+     */
+    @Test
     public void testInsertBatchtNan() throws Exception {
         testInsertSpecialValuesByBatch("NaN");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'NaN' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertBatchtNanDouble() throws Exception {
+        testInsertSpecialValuesByBatch(Double.NaN);
     }
 
     /**
@@ -133,6 +169,23 @@ public abstract class AbstractEngineSchemaTest {
         testPersistSpecialValues("Infinity");
     }
 
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testPersistInfinityDouble() throws Exception {
+        testPersistSpecialValues(Double.POSITIVE_INFINITY);
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testPersistInfinityDoubleNegative() throws Exception {
+        testPersistSpecialValues(Double.NEGATIVE_INFINITY);
+    }
 
     /**
      * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
@@ -141,6 +194,25 @@ public abstract class AbstractEngineSchemaTest {
     @Test
     public void testInsertPSInfinity() throws Exception {
         testInsertSpecialValuesByPS("Infinity");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertPSInfinityDouble() throws Exception {
+        testInsertSpecialValuesByPS(Double.POSITIVE_INFINITY);
+    }
+
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertPSInfinityDoubleNegative() throws Exception {
+        testInsertSpecialValuesByPS(Double.NEGATIVE_INFINITY);
     }
 
     /**
@@ -157,8 +229,44 @@ public abstract class AbstractEngineSchemaTest {
      * value 'Infinity' should be inserted into the database without any error.
      */
     @Test
+    public void testInsertPS2InfinityDouble() throws Exception {
+        testInsertSpecialValuesByPS2(Double.POSITIVE_INFINITY);
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertPS2InfinityDoubleNegative() throws Exception {
+        testInsertSpecialValuesByPS2(Double.NEGATIVE_INFINITY);
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
     public void testInsertBatchInfinity() throws Exception {
         testInsertSpecialValuesByBatch("Infinity");
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertBatchInfinityDouble() throws Exception {
+        testInsertSpecialValuesByBatch(Double.POSITIVE_INFINITY);
+    }
+
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
+    @Test
+    public void testInsertBatchInfinityDoubleNegative() throws Exception {
+        testInsertSpecialValuesByBatch(Double.NEGATIVE_INFINITY);
     }
 
     /**
@@ -194,21 +302,11 @@ public abstract class AbstractEngineSchemaTest {
     }
 
     /**
-     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
-     * value 'NaN' should be inserted into the database without any error.
-     */
-    @Test
-    public void testInsertPSNan() throws Exception {
-        testPersistSpecialValues("NaN");
-    }
-
-
-    /**
      * Auxiliary method to persist a provided special value.
      *
      * @param columnValue The column value.
      */
-    protected void testPersistSpecialValues(final String columnValue) throws DatabaseEngineException, DatabaseFactoryException {
+    protected void testPersistSpecialValues(final Object columnValue) throws DatabaseEngineException, DatabaseFactoryException {
         final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
         try {
             final DbEntity entity = createSpecialValuesEntity();
@@ -226,7 +324,7 @@ public abstract class AbstractEngineSchemaTest {
      *
      * @param columnValue The column value.
      */
-    protected void testInsertSpecialValuesByPS(final String columnValue) throws DatabaseEngineException, DatabaseFactoryException, NameAlreadyExistsException, ConnectionResetException {
+    protected void testInsertSpecialValuesByPS(final Object columnValue) throws DatabaseEngineException, DatabaseFactoryException, NameAlreadyExistsException, ConnectionResetException {
         final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
         final String PSName = "PS_DUMMY";
         final String preparedStatementQuery = "insert into TEST_DOUBLE_COLUMN(ID, DBL_COL) values (?,?)";
@@ -242,7 +340,6 @@ public abstract class AbstractEngineSchemaTest {
         } finally {
             engine.close();
         }
-
     }
 
     /**
@@ -250,7 +347,7 @@ public abstract class AbstractEngineSchemaTest {
      *
      * @param columnValue The column value.
      */
-    protected void testInsertSpecialValuesByPS2(final String columnValue) throws DatabaseEngineException, DatabaseFactoryException, NameAlreadyExistsException, ConnectionResetException {
+    protected void testInsertSpecialValuesByPS2(final Object columnValue) throws DatabaseEngineException, DatabaseFactoryException, NameAlreadyExistsException, ConnectionResetException {
         final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
         final String PSName = "PS_DUMMY";
         final String preparedStatementQuery = "insert into TEST_DOUBLE_COLUMN(ID, DBL_COL) values (?,?)";
@@ -275,7 +372,7 @@ public abstract class AbstractEngineSchemaTest {
      *
      * @param columnValue The column value.
      */
-    protected void testInsertSpecialValuesByBatch(final String columnValue) throws DatabaseFactoryException, DatabaseEngineException {
+    protected void testInsertSpecialValuesByBatch(final Object columnValue) throws DatabaseFactoryException, DatabaseEngineException {
         final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
         try {
             final DbEntity entity = createSpecialValuesEntity();
@@ -296,10 +393,27 @@ public abstract class AbstractEngineSchemaTest {
      * @param entityName  The entity name to check.
      * @param columnValue The column value persisted in storage.
      */
-    protected void checkResult(final DatabaseEngine engine, final String entityName, final String columnValue) throws DatabaseEngineException {
+    protected void checkResult(final DatabaseEngine engine, final String entityName, final Object columnValue) throws DatabaseEngineException {
+        if (columnValue instanceof Double) {
+            checkResultDouble(engine, entityName, (double) columnValue);
+            return;
+        }
         final List<Map<String, ResultColumn>> dbl = engine.query(select(column(DBL_COL)).from(table(entityName)));
         final ResultColumn result = dbl.get(0).get(DBL_COL);
         assertTrue("Should be equal to '"+ columnValue +"'. But was: " + result.toString(), result.toString().equals(columnValue));
+    }
+
+    /**
+     * Auxiliary method that checks that the inserted value is indeed the provided column value.
+     *
+     * @param engine      The database engine.
+     * @param entityName  The entity name to check.
+     * @param columnValue The column value persisted in storage.
+     */
+    protected void checkResultDouble(final DatabaseEngine engine, final String entityName, final double columnValue) throws DatabaseEngineException {
+        final List<Map<String, ResultColumn>> dbl = engine.query(select(column(DBL_COL)).from(table(entityName)));
+        final ResultColumn result = dbl.get(0).get(DBL_COL);
+        assertTrue("Should be equal to '"+ columnValue +"'. But was: " + result.toString(), result.toDouble().equals(columnValue));
     }
 
     /**
@@ -322,7 +436,7 @@ public abstract class AbstractEngineSchemaTest {
      * @param columnValue The value to insert.
      * @return The {@link EntityEntry} to insert in storage.
      */
-    protected EntityEntry createSpecialValueEntry(final String columnValue) {
+    protected EntityEntry createSpecialValueEntry(final Object columnValue) {
         return entry()
                 .set(ID_COL, 1)
                 .set(DBL_COL, columnValue)

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
@@ -17,28 +17,23 @@ package com.feedzai.commons.sql.abstraction.engine.impl.oracle;
 
 
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
-import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
-import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
-import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.DOUBLE;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.INT;
-import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.*;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.dbEntity;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Rafael Marmelo (rafael.marmelo@feedzai.com)
@@ -102,70 +97,6 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
 
             assertFalse("The simulated system generated column should not appear in the table metadata", engine.getMetadata("TEST_SYS_COL").containsKey("SYS_COL1"));
             assertTrue("The regular column should appear in the table metadata", engine.getMetadata("TEST_SYS_COL").containsKey("COL1"));
-        } finally {
-            engine.close();
-        }
-    }
-
-    /**
-     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
-     * value 'NaN' should be inserted into the database without any error.
-     */
-    @Test
-    public void testInsertNan() throws Exception {
-        testInsertSpecialValues("NaN");
-    }
-
-    /**
-     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
-     * value 'Infinity' should be inserted into the database without any error.
-     */
-    @Test
-    public void testInsertInfinity() throws Exception {
-        testInsertSpecialValues("Infinity");
-    }
-
-    /**
-     * The 'randomString' is not a special value for the BINARY_DOUBLE type so it should throw an error.
-     */
-    @Test
-    public void testRandomValuesDoNoWorkInBinaryDoubleColumn() throws Exception {
-        try {
-            testInsertSpecialValues("randomString");
-        } catch (DatabaseEngineException e) {
-            // It is supposed to.
-            return;
-        }
-
-        fail("Should have thrown an exception");
-    }
-
-    /**
-     * Auxiliary method to insert a provided special value for the BINARY_DOUBLE oracle datatype.
-     *
-     * @param columnValue The column value.
-     * @throws Exception If something goes wrong storing data into the database.
-     */
-    private void testInsertSpecialValues(final String columnValue) throws Exception {
-        final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
-        try {
-            final DbEntity entity = dbEntity()
-                    .name("TEST_DOUBLE_COLUMN")
-                    .addColumn("id", INT)
-                    .addColumn("DBL", DOUBLE)
-                    .pkFields("id")
-                    .build();
-            engine.addEntity(entity);
-
-            final EntityEntry entry = entry()
-                    .set("id", 1)
-                    .set("DBL", columnValue)
-                    .build();
-
-            engine.persist(entity.getName(), entry);
-            final List<Map<String, ResultColumn>> dbl = engine.query(select(column("DBL")).from(table(entity.getName())));
-            final ResultColumn result = dbl.get(0).get("DBL");
-            assertTrue("Should be equal to '"+ columnValue +"'. But was: " + result.toString(), result.toString().equals(columnValue));
         } finally {
             engine.close();
         }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
@@ -107,16 +107,27 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
         }
     }
 
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'NaN' should be inserted into the database without any error.
+     */
     @Test
     public void testInsertNan() throws Exception {
         testInsertSpecialValues("NaN");
     }
 
+    /**
+     * After changing the oracle double data type from DOUBLE PRECISION to BINARY_DOUBLE the special
+     * value 'Infinity' should be inserted into the database without any error.
+     */
     @Test
     public void testInsertInfinity() throws Exception {
         testInsertSpecialValues("Infinity");
     }
 
+    /**
+     * The 'randomString' is not a special value for the BINARY_DOUBLE type so it should throw an error.
+     */
     @Test
     public void testRandomValuesDoNoWorkInBinaryDoubleColumn() throws Exception {
         try {
@@ -129,6 +140,12 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
         fail("Should have thrown an exception");
     }
 
+    /**
+     * Auxiliary method to insert a provided special value for the BINARY_DOUBLE oracle datatype.
+     *
+     * @param columnValue The column value.
+     * @throws Exception If something goes wrong storing data into the database.
+     */
     private void testInsertSpecialValues(final String columnValue) throws Exception {
         final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
         try {


### PR DESCRIPTION
To allow the insertion of values such as NaN and infinity the double column data type for oracle was changed to BINARY_DOUBLE (from DOUBLE PRECISION).

This addresses the bug reported in #45 .
The issue description mentioned something about changing code in the `OracleEngine.entityToPreparedStatement` but I didn't see the need for that as far as my understanding goes. Please double check that and warn me if there is other things to do here.

The test is pending for some machines to be up (already sent email) to check if it breaks any test. I should create a new UT afterwards.