### PR TITLE
ref PULSEDEV-15861: Reverted Allowed column drop default value.

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -64,10 +64,8 @@ public final class Constants {
     public static final String DEFAULT_SECRET_LOCATION = "secret.key";
     /**
      * By default allow column drops.
-     *
-     * @implNote Changed to {@code false} since 2.1.8
      */
-    public static final boolean DEFAULT_ALLOW_COLUMN_DROP = false;
+    public static final boolean DEFAULT_ALLOW_COLUMN_DROP = true;
     /**
      * The default fetch size.
      */


### PR DESCRIPTION
The change in PR #47 caused some problems on components using the pdb. So the value was reverted to true again. Any other desired value for this property should be configured to override this setting.

Rewrote the unit test to check that without configuration the default is to drop columns.