### PR TITLE
ref PULSEDEV-16501 pdb: Improve the performance of writing to Oracle …

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
 import oracle.jdbc.OraclePreparedStatement;
 import oracle.jdbc.OracleTypes;
 
-import java.io.StringReader;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -131,8 +130,7 @@ public class OracleEngine extends AbstractDatabaseEngine {
                         }
 
                         if (val instanceof String) {
-                            StringReader sr = new StringReader((String) val);
-                            ps.setClob(i, sr);
+                            ((OraclePreparedStatement) ps).setStringForClob(i, (String) val);
                         } else {
                             throw new DatabaseEngineException("Cannot convert " + val.getClass().getSimpleName() + " to String. CLOB columns only accept Strings.");
                         }


### PR DESCRIPTION
…CLOB columns

The usage of PreparedStatement#setClob in Oracle 11g was yielding overheads of 3x
to 1000x (depending on the batch size) when compared to using plain
PreparedStatement#setObject for columns backed by VARCHAR2.

With this change we downcast the PreparedStatement to OraclePreparedStatement and
use its setStringForClob method that yields equivalent performance to the VARCHAR2
case for Strings whose length is 32KB or less.