### PR TITLE
Upgrade from Apache Commons-lang 2.X to 3.X

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,9 +106,9 @@
                 <version>1.7.25</version>
             </dependency>
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.7</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
@@ -181,10 +181,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <!-- Commons-lang -->
+        <!-- Commons-lang 3 -->
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <!-- Commons-codec -->
         <dependency>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -21,7 +21,7 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import org.apache.commons.lang.time.DurationFormatUtils;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
@@ -15,8 +15,8 @@
  */
 package com.feedzai.commons.sql.abstraction.dml;
 
+import com.feedzai.commons.sql.abstraction.util.StringUtils;
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.lang.StringEscapeUtils;
 
 import java.util.Set;
 
@@ -102,7 +102,7 @@ public class Function extends Expression {
      * @param exp      The expression.
      */
     public Function(final String function, final Expression exp) {
-        this.function = StringEscapeUtils.escapeSql(function);
+        this.function = StringUtils.escapeSql(function);
         this.exp = exp;
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Join.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Join.java
@@ -15,7 +15,7 @@
  */
 package com.feedzai.commons.sql.abstraction.dml;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import com.feedzai.commons.sql.abstraction.util.StringUtils;
 
 /**
  * Represents a SQL join operator.
@@ -45,7 +45,7 @@ public class Join extends Expression {
      * @param joinExpr  The join expression.
      */
     public Join(final String join, final Expression joinTable, final Expression joinExpr) {
-        this.join = StringEscapeUtils.escapeSql(join);
+        this.join = StringUtils.escapeSql(join);
         this.joinTable = joinTable;
         this.joinExpr = joinExpr;
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Name.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Name.java
@@ -15,7 +15,7 @@
  */
 package com.feedzai.commons.sql.abstraction.dml;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import com.feedzai.commons.sql.abstraction.util.StringUtils;
 
 
 /**
@@ -58,8 +58,8 @@ public class Name extends Expression {
      * @param name      The name.
      */
     public Name(final String tableName, final String name) {
-        this.environment = StringEscapeUtils.escapeSql(tableName);
-        this.name = StringEscapeUtils.escapeSql(name);
+        this.environment = StringUtils.escapeSql(tableName);
+        this.name = StringUtils.escapeSql(name);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/View.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/View.java
@@ -15,7 +15,7 @@
  */
 package com.feedzai.commons.sql.abstraction.dml;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import com.feedzai.commons.sql.abstraction.util.StringUtils;
 
 /**
  * Represents a SQL view.
@@ -43,7 +43,7 @@ public class View extends Expression {
      * @param name The name of the view.
      */
     public View(final String name) {
-        this.name = StringEscapeUtils.escapeSql(name);
+        this.name = StringUtils.escapeSql(name);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -37,7 +37,7 @@ import com.feedzai.commons.sql.abstraction.util.InitiallyReusableByteArrayOutput
 import com.feedzai.commons.sql.abstraction.util.PreparedStatementCapsule;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
@@ -38,13 +38,13 @@ import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.google.common.base.Joiner;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static com.feedzai.commons.sql.abstraction.util.StringUtils.escapeSql;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.singleQuotize;
 
@@ -252,7 +252,7 @@ public abstract class AbstractTranslator {
             if (!k.isQuote()) {
                 result = o.toString();
             } else if (o instanceof String) {
-                result = singleQuotize(StringEscapeUtils.escapeSql((String) o));
+                result = singleQuotize(escapeSql((String) o));
             } else if (o instanceof Boolean) {
                 result = (Boolean) o ? translateTrue() : translateFalse();
             } else {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseFactory.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseFactory.java
@@ -21,7 +21,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.util.Providers;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Constructor;
 import java.util.Properties;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
@@ -18,7 +18,7 @@ package com.feedzai.commons.sql.abstraction.engine.configuration;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 import com.google.common.base.Enums;
 import com.google.common.base.Optional;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
 import java.util.EnumSet;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -37,7 +37,7 @@ import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import com.feedzai.commons.sql.abstraction.util.Constants;
 import com.feedzai.commons.sql.abstraction.util.PreparedStatementCapsule;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -54,7 +54,7 @@ import java.util.Optional;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
-import static org.apache.commons.lang.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.join;
 
 /**
  * DB2 specific database implementation.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -45,7 +45,7 @@ import java.util.List;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
-import static org.apache.commons.lang.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.join;
 
 /**
  * H2 specific database implementation.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
@@ -21,7 +21,7 @@ import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -31,7 +31,7 @@ import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.StringReader;
 import java.sql.Connection;
@@ -51,7 +51,7 @@ import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
 import static java.sql.ResultSet.CONCUR_READ_ONLY;
 import static java.sql.ResultSet.TYPE_FORWARD_ONLY;
-import static org.apache.commons.lang.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.join;
 
 /**
  * MySQL specific database implementation.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
@@ -21,7 +21,7 @@ import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -52,7 +52,7 @@ import java.util.Optional;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
-import static org.apache.commons.lang.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.join;
 
 /**
  * Oracle specific database implementation.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
@@ -126,9 +126,9 @@ public class OracleTranslator extends AbstractTranslator {
         });
 
         if (rd.isEnclosed()) {
-            return "(" + org.apache.commons.lang.StringUtils.join(all, delimiter) + ")";
+            return "(" + org.apache.commons.lang3.StringUtils.join(all, delimiter) + ")";
         } else {
-            return org.apache.commons.lang.StringUtils.join(all, delimiter);
+            return org.apache.commons.lang3.StringUtils.join(all, delimiter);
         }
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -51,7 +51,7 @@ import java.util.Map;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
-import static org.apache.commons.lang.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.join;
 
 /**
  * PostgreSQL specific database implementation.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -47,7 +47,7 @@ import java.util.List;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
-import static org.apache.commons.lang.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.join;
 
 /**
  * SQLServer specific database implementation.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -164,9 +164,9 @@ public class SqlServerTranslator extends AbstractTranslator {
         }
 
         if (rd.isEnclosed()) {
-            return "(" + org.apache.commons.lang.StringUtils.join(all, delimiter) + ")";
+            return "(" + org.apache.commons.lang3.StringUtils.join(all, delimiter) + ")";
         } else {
-            return org.apache.commons.lang.StringUtils.join(all, delimiter);
+            return org.apache.commons.lang3.StringUtils.join(all, delimiter);
         }
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/StringUtils.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/StringUtils.java
@@ -21,6 +21,8 @@ import java.io.InputStreamReader;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import static org.apache.commons.lang3.StringUtils.replace;
+
 /**
  * String Utilities.
  *
@@ -59,7 +61,7 @@ public class StringUtils {
     }
 
     /**
-     * Generates de MD5 checksum for the specified message.
+     * Generates the MD5 checksum for the specified message.
      *
      * @param message The message.
      * @return The hexadecimal checksum.
@@ -129,5 +131,38 @@ public class StringUtils {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Apache Commons-Lang 2.X contained StringEscapeUtils#escapeSql, but this method was removed in 3.X as discussed
+     * here: https://commons.apache.org/proper/commons-lang/article3_0.html#StringEscapeUtils.escapeSql
+     *
+     * For this reason, the source code has been copied from 2.X to here so that we can continue to use the logic and
+     * possibly build on it in the future.
+     *
+     * ***************** Copied from commons-lang:commons-lang:2.6 ****************
+     *
+     * <p>Escapes the characters in a <code>String</code> to be suitable to pass to
+     * an SQL query.</p>
+     *
+     * <p>For example,
+     * <pre>statement.executeQuery("SELECT * FROM MOVIES WHERE TITLE='" +
+     *   StringEscapeUtils.escapeSql("McHale's Navy") +
+     *   "'");</pre>
+     * </p>
+     *
+     * <p>At present, this method only turns single-quotes into doubled single-quotes
+     * (<code>"McHale's Navy"</code> => <code>"McHale''s Navy"</code>). It does not
+     * handle the cases of percent (%) or underscore (_) for use in LIKE clauses.</p>
+     *
+     * see http://www.jguru.com/faq/view.jsp?EID=8881
+     * @param str  the string to escape, may be null
+     * @return a new String, escaped for SQL, <code>null</code> if null string input
+     */
+    public static String escapeSql(String str) {
+        if (str == null) {
+            return null;
+        }
+        return replace(str, "'", "''");
     }
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/testconfig/DatabaseTestUtil.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/testconfig/DatabaseTestUtil.java
@@ -16,7 +16,7 @@
 package com.feedzai.commons.sql.abstraction.engine.testconfig;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.FileInputStream;
 import java.io.InputStream;

--- a/src/test/java/com/feedzai/commons/sql/abstraction/util/StringUtilsTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/util/StringUtilsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.feedzai.commons.sql.abstraction.util;
+
+import com.google.common.base.Charsets;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests functions from {@link StringUtils}.
+ *
+ * @author Case Walker (case.walker@feedzai.com)
+ * @since 2.1.12
+ */
+public class StringUtilsTest {
+    /**
+     * Test that quotizing returns a double-quoted string.
+     */
+    @Test
+    public void quotize() {
+        assertEquals("Quotizing a string should add double quotes",
+                "\"string\"",
+                StringUtils.quotize("string"));
+    }
+
+    /**
+     * Test that single-quotizing returns a single-quoted string.
+     */
+    @Test
+    public void singleQuotize() {
+        assertEquals("SingleQuotizing a string should add single quotes",
+                "'string'",
+                StringUtils.singleQuotize("string"));
+    }
+
+    /**
+     * Test that md5 returns the expected md5 calculation.
+     */
+    @Test
+    public void md5() {
+        assertEquals("md5 should create the right output",
+                "b45cffe084dd3d20d928bee85e7b0f21",
+                StringUtils.md5("string"));
+    }
+
+    /**
+     * Test that readString can read from an input stream.
+     *
+     * @throws IOException if there is a problem with readString.
+     */
+    @Test
+    public void readStringTest() throws IOException {
+        String string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+
+        assertEquals("readString should get the whole input",
+                string,
+                StringUtils.readString(new ByteArrayInputStream(string.getBytes(Charsets.US_ASCII))));
+    }
+
+    /**
+     * Test that escapeSql handles null input.
+     */
+    @Test
+    public void escapeSqlNull() {
+        assertNull("escapeSql should handle null", StringUtils.escapeSql(null));
+    }
+
+
+    /**
+     * Test that escapeSql escapes single quotes.
+     */
+    @Test
+    public void escapeSql() {
+        assertEquals("escapeSql should handle single-quotes",
+                "McHale''s Navy",
+                StringUtils.escapeSql("McHale's Navy"));
+    }
+}


### PR DESCRIPTION
The upgrade included losing the function StringEscapeUtils.escapeSql(String), so
I imported the logic to com.feedzai.commons.sql.abstraction.util.StringUtils and
added some tests.