### PR TITLE
Update postgresql to 42.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>9.4-1206-jdbc42</version>
+        <version>42.0.0</version>
       </dependency>
       <!-- Needed for compilation even if don't want use Oracle. -->
       <dependency>


### PR DESCRIPTION
This is particularly useful to avoid "Missing prepared statement XXX" after a connection recovery. The relevant PR is https://github.com/pgjdbc/pgjdbc/pull/449.