### PR TITLE
Add indexes when a new column is added to an entity

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -294,12 +294,8 @@ public class DB2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addIndexes(final DbEntity entity) throws DatabaseEngineException {
-        List<DbIndex> indexes = entity.getIndexes();
-
+    protected void addIndexes(final DbEntity entity, final List<DbIndex> indexes) throws DatabaseEngineException {
         for (DbIndex index : indexes) {
-
-
             List<String> createIndex = new ArrayList<String>();
             createIndex.add("CREATE");
             if (index.isUnique()) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -288,9 +288,7 @@ public class H2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addIndexes(final DbEntity entity) throws DatabaseEngineException {
-        List<DbIndex> indexes = entity.getIndexes();
-
+    protected void addIndexes(final DbEntity entity, final List<DbIndex> indexes) throws DatabaseEngineException {
         for (DbIndex index : indexes) {
 
             List<String> createIndex = new ArrayList<String>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -284,14 +284,11 @@ public class MySqlEngine extends AbstractDatabaseEngine {
             }
         }
     }
-
     @Override
-    protected void addIndexes(final DbEntity entity) throws DatabaseEngineException {
+    protected void addIndexes(final DbEntity entity, final List<DbIndex> indexes) throws DatabaseEngineException {
         if (entity.getIndexes().isEmpty()) {
             return;
         }
-
-        List<DbIndex> indexes = entity.getIndexes();
 
         for (DbIndex index : indexes) {
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -353,12 +353,8 @@ public class OracleEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addIndexes(final DbEntity entity) throws DatabaseEngineException {
-        List<DbIndex> indexes = entity.getIndexes();
-
+    protected void addIndexes(final DbEntity entity, final List<DbIndex> indexes) throws DatabaseEngineException {
         for (DbIndex index : indexes) {
-
-
             List<String> createIndex = new ArrayList<String>();
             createIndex.add("CREATE");
             if (index.isUnique()) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -258,11 +258,8 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addIndexes(final DbEntity entity) throws DatabaseEngineException {
-        List<DbIndex> indexes = entity.getIndexes();
-
+    protected void addIndexes(final DbEntity entity, final List<DbIndex> indexes) throws DatabaseEngineException {
         for (DbIndex index : indexes) {
-
             List<String> createIndex = new ArrayList<String>();
             createIndex.add("CREATE");
             if (index.isUnique()) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -303,9 +303,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addIndexes(final DbEntity entity) throws DatabaseEngineException {
-        List<DbIndex> indexes = entity.getIndexes();
-
+    protected void addIndexes(final DbEntity entity, final List<DbIndex> indexes) throws DatabaseEngineException {
         for (DbIndex index : indexes) {
 
             List<String> createIndex = new ArrayList<String>();


### PR DESCRIPTION
When a column is being added to a table that already exists, it's indexes
were being left out. This patch fixes that by adding the indexes that
consider the new column(s).

A new `addIndexes` method was added to `AbstractDatabaseEngine` that
creates specific indexes. I didn't want to change the existing method
not to break the interface.

Missing on this patch:
* Wasn't able to test this, missing dependencies and couldn't find
  instructions
* Would like a unit test for this, but don't have the env and wouldn't
  know how to achieve it for this scenario

Related possible future work:
* Implement drop indexes
* When we remove columns, we should also remove related indexes
  (I guess it would throw an exception otherwise).
* Use the same logic for FKs. ATM we're droping/adding them all when
  adding or removing new fields. That could be very slow on large tables