### PR TITLE
ref PULSEDEV-18139 pdb: Fix incorrect shutdown in AbstractBatch

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -101,7 +101,7 @@ public abstract class AbstractBatch implements Runnable {
     /**
      * Timestamp of the last flush.
      */
-    protected long lastFlush;
+    protected volatile long lastFlush;
     /**
      * EntityEntry buffer.
      */

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -153,13 +153,21 @@ public abstract class AbstractBatch implements Runnable {
      */
     public void destroy() {
         logger.trace("{} - Destroy called on Batch", name);
-        scheduler.shutdownNow();
+        scheduler.shutdown();
 
         try {
             if (!scheduler.awaitTermination(maxAwaitTimeShutdown, TimeUnit.MILLISECONDS)) {
-                logger.warn("Could not terminate batch within {}", DurationFormatUtils.formatDurationWords(maxAwaitTimeShutdown, true, true));
+                logger.warn(
+                        "Could not terminate batch within {}. Forcing shutdown.",
+                        DurationFormatUtils.formatDurationWords(
+                                maxAwaitTimeShutdown,
+                                true,
+                                true
+                        )
+                );
+                scheduler.shutdownNow();
             }
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             logger.debug("Interrupted while waiting.", e);
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -151,7 +151,7 @@ public abstract class AbstractBatch implements Runnable {
     /**
      * Destroys this batch.
      */
-    public synchronized void destroy() {
+    public void destroy() {
         logger.trace("{} - Destroy called on Batch", name);
         scheduler.shutdownNow();
 
@@ -302,7 +302,7 @@ public abstract class AbstractBatch implements Runnable {
     }
 
     @Override
-    public synchronized void run() {
+    public void run() {
         if (System.currentTimeMillis() - lastFlush >= batchTimeout) {
             logger.trace("[{}] Flush timeout occurred", name);
             flush();

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -294,7 +294,8 @@ public class BatchUpdateTest {
      * call run while it another thread was already inside `destroy` but had not yet called shutdown on the scheduler.
      * Since those two methods were synchronized, the `run` would not finish while destroy was waiting for all tasks in
      * the Executor to finish.
-     *
+     * For this test to properly work it is critical that the batch is configured to wait more for the scheduler termination
+     * than the test timeout.
      *
      * @since 2.1.10
      * @throws DatabaseEngineException If the operations on the engine fail.
@@ -313,6 +314,7 @@ public class BatchUpdateTest {
 
 
         for (int i = 0; i < 40; i++) {
+            // The maxAwaitTimeShutdown parameter must be larger than the test timeout.
             final MockedBatch batch = MockedBatch.create(engine, "test", 5, 10L, 50000);
             batch.add("TEST", entry().set("COL1", 1).build());
 


### PR DESCRIPTION
This change fixes a small concurrency issue that was occurring in AbstractBatch
when the batch scheduler was scheduling a run while the destroy
method had just been called, leading to an unexpected long wait for the
destroy method to return.
Since those two methods were `synchronized`
the following could happen:
   - Thread A entered `destroy` thus acquiring the implicit lock
   - The scheduler period would expire and a new task would be
   launched but since the `run` method was synchronized the task's
   thread (B)  would not proceed
   - Thread A would now call `shutdownNow` on the ExecutorService and
   await termination.
   - Since Thread B was waiting on the implicit lock to enter `run` the
     `destroy` code would wait until the timeout expired before
     returning.

There was no reason to keep the methods synchronized as synchronization was
already being performed at a different level.