### PR TITLE
Add configurable flush retry logic to AbstractBatch

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -153,10 +153,9 @@ public abstract class AbstractBatch implements Runnable {
      * @param batchTimeout         The batch timeout.
      * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
      * @param failureListener      The listener that will be invoked whenever some batch operation fail to persist.
-     * @param maxFlushRetries      The number of times to retry a batch flush upon failure. Defaults to
-     *                             {@value NO_RETRY}. When set to 0, no retries will be attempted.
-     * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries. Defaults to
-     *                             {@value DEFAULT_RETRY_INTERVAL}.
+     * @param maxFlushRetries      The number of times to retry a batch flush upon failure. When set to 0, no retries
+     *                             will be attempted.
+     * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries.
      *
      * @since 2.1.12
      */
@@ -354,7 +353,7 @@ public abstract class AbstractBatch implements Runnable {
             logger.trace("[{}] Batch flushed. Took {} ms, {} rows.", name, (System.currentTimeMillis() - start), temp.size());
         } catch (final Exception e) {
             if (this.maxFlushRetries > 0) {
-                logger.debug(dev, "[{}] Error occurred while flushing. Retrying.", name, e);
+                logger.warn(dev, "[{}] Error occurred while flushing. Retrying.", name, e);
             }
 
             boolean success = false;
@@ -383,7 +382,7 @@ public abstract class AbstractBatch implements Runnable {
 
                     success = true;
                 } catch (final Exception exc) {
-                    logger.debug(dev, "[{}] Error occurred while flushing (retry attempt {}).", name, retryCount + 1, exc);
+                    logger.warn(dev, "[{}] Error occurred while flushing (retry attempt {}).", name, retryCount + 1, exc);
                 }
             }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/DefaultBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/DefaultBatch.java
@@ -39,7 +39,8 @@ public class DefaultBatch extends AbstractBatch {
      * @param batchTimeout         The timeout.
      * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
      */
-    protected DefaultBatch(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout, final long maxAwaitTimeShutdown) {
+    protected DefaultBatch(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout,
+                           final long maxAwaitTimeShutdown) {
         super(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown);
     }
 
@@ -53,8 +54,28 @@ public class DefaultBatch extends AbstractBatch {
      * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
      * @param listener             The listener that will be invoked when batch fails to persist at least one data row.
      */
-    protected DefaultBatch(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout, final long maxAwaitTimeShutdown, final FailureListener listener) {
+    protected DefaultBatch(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout,
+                           final long maxAwaitTimeShutdown, final FailureListener listener) {
         super(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener);
+    }
+
+    /**
+     * Creates a new instance of {@link DefaultBatch}.
+     *
+     * @param de                   The database engine reference.
+     * @param name                 The batch name.
+     * @param batchSize            The batch size.
+     * @param batchTimeout         The timeout.
+     * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
+     * @param listener             The listener that will be invoked when batch fails to persist at least one data row.
+     * @param maxFlushRetries      The number of times to retry a batch flush upon failure. Defaults to
+     *                             {@value NO_RETRY}. When set to 0, no retries will be attempted.
+     * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries. Defaults to
+     *                             {@value DEFAULT_RETRY_INTERVAL}.     */
+    protected DefaultBatch(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout,
+                           final long maxAwaitTimeShutdown, final FailureListener listener, final int maxFlushRetries,
+                           final long flushRetryDelay) {
+        super(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener, maxFlushRetries, flushRetryDelay);
     }
 
     /**
@@ -68,8 +89,8 @@ public class DefaultBatch extends AbstractBatch {
      * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
      * @return The Batch.
      */
-    public static DefaultBatch create(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout,
-                                      final long maxAwaitTimeShutdown) {
+    public static DefaultBatch create(final DatabaseEngine de, final String name, final int batchSize,
+                                      final long batchTimeout, final long maxAwaitTimeShutdown) {
         final DefaultBatch b = new DefaultBatch(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown);
         b.start();
 
@@ -93,6 +114,43 @@ public class DefaultBatch extends AbstractBatch {
     public static DefaultBatch create(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout,
                                       final long maxAwaitTimeShutdown, final FailureListener listener) {
         final DefaultBatch b = new DefaultBatch(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener);
+        b.start();
+
+        return b;
+    }
+
+    /**
+     * <p>Creates a new instance of {@link DefaultBatch} with a {@link FailureListener}.</p>
+     * <p>Starts the timertask.</p>
+     *
+     * @param de                   The database engine.
+     * @param name                 The batch name.
+     * @param batchSize            The batch size.
+     * @param batchTimeout         The batch timeout.
+     * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
+     * @param listener             The listener that will be invoked when batch fails to persist at least one data row.
+     * @param maxFlushRetries      The number of times to retry a batch flush upon failure. Defaults to
+     *                             {@value NO_RETRY}. When set to 0, no retries will be attempted.
+     * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries. Defaults to
+     *                             {@value DEFAULT_RETRY_INTERVAL}.
+     * @return The Batch.
+     *
+     * @since 2.1.12
+     */
+    public static DefaultBatch create(final DatabaseEngine de, final String name, final int batchSize,
+                                      final long batchTimeout, final long maxAwaitTimeShutdown,
+                                      final FailureListener listener, final int maxFlushRetries,
+                                      final long flushRetryDelay) {
+        final DefaultBatch b = new DefaultBatch(
+                de,
+                name,
+                batchSize,
+                batchTimeout,
+                maxAwaitTimeShutdown,
+                listener,
+                maxFlushRetries,
+                flushRetryDelay
+        );
         b.start();
 
         return b;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/DefaultBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/DefaultBatch.java
@@ -71,7 +71,10 @@ public class DefaultBatch extends AbstractBatch {
      * @param maxFlushRetries      The number of times to retry a batch flush upon failure. Defaults to
      *                             {@value NO_RETRY}. When set to 0, no retries will be attempted.
      * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries. Defaults to
-     *                             {@value DEFAULT_RETRY_INTERVAL}.     */
+     *                             {@value DEFAULT_RETRY_INTERVAL}.
+     *
+     * @since 2.1.12
+     */
     protected DefaultBatch(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout,
                            final long maxAwaitTimeShutdown, final FailureListener listener, final int maxFlushRetries,
                            final long flushRetryDelay) {


### PR DESCRIPTION
Currently, whenever the AbstractBatch.flush() method encounters an error, it fails immediately. This was because we do not know what caused the error and it might not make sense to retry.
However, some projects have run into errors while flushing that can be worked around simply by retrying the flush, avoiding having to write the failed batch to a dump file.
This pull request adds support for such workarounds by creating a configurable retry mechanism (which is disabled by default for retro-compatibility).