### PR TITLE
Implement AutoCloseable in ResultIterator and DatabaseEngine

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultIterator.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * @author Rui Vilao (rui.vilao@feedzai.com)
  * @since 2.0.0
  */
-public abstract class ResultIterator {
+public abstract class ResultIterator implements AutoCloseable {
     /**
      * The logger.
      */
@@ -228,6 +228,7 @@ public abstract class ResultIterator {
     /**
      * Closes the {@link ResultSet} and the {@link Statement} if applicable.
      */
+    @Override
     public void close() {
         // Check for previous closed.
         if (!closed) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -42,10 +42,11 @@ import java.util.Properties;
  * @author Rui Vilao (rui.vilao@feedzai.com)
  * @since 2.0.0
  */
-public interface DatabaseEngine {
+public interface DatabaseEngine extends AutoCloseable {
     /**
      * Closes the connection to the database.
      */
+    @Override
     void close();
 
     /**


### PR DESCRIPTION
…to enable try-with-resources

This also adds tests to ensure the close method is being used when
declaring those types in a try-with-resources's resource specification
header.

This PR is a(n attempted) continuation of https://github.com/feedzai/pdb/pull/63
and https://github.com/feedzai/pdb/pull/4 .