### PR TITLE
Clear batch data when rolling back a transaction to ensure ACID properties

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -720,6 +720,12 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
          * Reconnect on this method does not make sense since a new connection will have nothing to rollback.
          */
         try {
+            // While rolling back, the entities can still have batch data which needs to be cleared.
+            for (final MappedEntity mappedEntity : entities.values()) {
+                mappedEntity.getInsert().clearBatch();
+                mappedEntity.getInsertReturning().clearBatch();
+                mappedEntity.getInsertWithAutoInc().clearBatch();
+            }
             conn.rollback();
             conn.setAutoCommit(true);
         } catch (SQLException ex) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -368,17 +368,17 @@ public class MySqlEngine extends AbstractDatabaseEngine {
     @Override
     protected MappedEntity createPreparedStatementForInserts(final DbEntity entity) throws DatabaseEngineException {
 
-        List<String> insertInto = new ArrayList<>();
+        final List<String> insertInto = new ArrayList<>();
         insertInto.add("INSERT INTO");
         insertInto.add(quotize(entity.getName(), escapeCharacter()));
-        List<String> insertIntoWithAutoInc = new ArrayList<>();
+        final List<String> insertIntoWithAutoInc = new ArrayList<>();
         insertIntoWithAutoInc.add("INSERT INTO");
         insertIntoWithAutoInc.add(quotize(entity.getName(), escapeCharacter()));
-        List<String> columns = new ArrayList<>();
-        List<String> values = new ArrayList<>();
-        List<String> columnsWithAutoInc = new ArrayList<>();
-        List<String> valuesWithAutoInc = new ArrayList<>();
-        for (DbColumn column : entity.getColumns()) {
+        final List<String> columns = new ArrayList<>();
+        final List<String> values = new ArrayList<>();
+        final List<String> columnsWithAutoInc = new ArrayList<>();
+        final List<String> valuesWithAutoInc = new ArrayList<>();
+        for (final DbColumn column : entity.getColumns()) {
             columnsWithAutoInc.add(quotize(column.getName(), escapeCharacter()));
             valuesWithAutoInc.add("?");
             if (!column.isAutoInc()) {
@@ -395,18 +395,22 @@ public class MySqlEngine extends AbstractDatabaseEngine {
 
 
         final String statement = join(insertInto, " ");
+        // The MySQL DB doesn't implement INSERT RETURNING. Therefore, we just create a dummy statement, which will
+        // never be invoked by this implementation.
+        final String insertReturnStatement = "";
         final String statementWithAutoInt = join(insertIntoWithAutoInc, " ");
 
         logger.trace(statement);
         logger.trace(statementWithAutoInt);
 
-        PreparedStatement ps, psWithAutoInc;
+        final PreparedStatement ps, psReturn, psWithAutoInc;
         try {
             ps = conn.prepareStatement(statement, Statement.RETURN_GENERATED_KEYS);
+            psReturn = conn.prepareStatement(insertReturnStatement);
             psWithAutoInc = conn.prepareStatement(statementWithAutoInt);
 
-            return new MappedEntity().setInsert(ps).setInsertWithAutoInc(psWithAutoInc);
-        } catch (SQLException ex) {
+            return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc);
+        } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }
     }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -42,6 +42,7 @@ import com.feedzai.commons.sql.abstraction.engine.testconfig.BlobTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.After;
@@ -62,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.CountDownLatch;
 
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint.NOT_NULL;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.BLOB;
@@ -126,6 +128,7 @@ import static org.junit.Assert.fail;
  */
 @RunWith(Parameterized.class)
 public class EngineGeneralTest {
+
 
     protected DatabaseEngine engine;
     protected Properties properties;
@@ -679,6 +682,73 @@ public class EngineGeneralTest {
 
         assertTrue("COL5 exists", query.get(1).containsKey("COL5"));
         assertEquals("COL5  ok?", "OLA", query.get(1).get("COL5").toString());
+    }
+
+    /**
+     * Tests that on a rollback situation, the prepared statement batches are cleared.
+     *
+     * The steps performed on this test are:
+     * <ol>
+     *     <li>Add batch to transaction and purposely fail to flush</li>
+     *     <li>Ensure the existence of the Exception and rollback transaction</li>
+     *     <li>Flush again successfully an ensure that the DB table doesn't have any rows</li>
+     * </ol>
+     *
+     * This is a regression test.
+     *
+     * @throws DatabaseEngineException If there is a problem on {@link DatabaseEngine} operations.
+     * @since 2.1.12
+     */
+    @Test
+    public void batchInsertRollback() throws DatabaseEngineException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final DbEntity entity = dbEntity()
+                .name("TEST")
+                .addColumn("COL1", INT)
+                .build();
+
+        new MockUp<AbstractDatabaseEngine>() {
+            @Mock
+            public synchronized void flush(final Invocation invocation) throws DatabaseEngineException {
+                if (latch.getCount() == 1) {
+                    throw new DatabaseEngineException("");
+                }
+                invocation.proceed();
+            }
+        };
+
+        DatabaseEngineException expectedException = null;
+
+        engine.addEntity(entity);
+        engine.beginTransaction();
+
+        try {
+            final EntityEntry entry = entry().set("COL1", 1).build();
+
+            engine.addBatch("TEST", entry);
+            engine.flush();
+        } catch (final DatabaseEngineException e) {
+            expectedException = e;
+        } finally {
+            if (engine.isTransactionActive()) {
+                engine.rollback();
+            }
+        }
+
+        // Ensure we had an exception and therefore we didn't insert anything on the DB and that we cleared the batches.
+        assertNotNull("DB returned exception when flushing", expectedException);
+
+        latch.countDown();
+        engine.beginTransaction();
+        engine.flush();
+        engine.commit();
+
+        final List<Map<String, ResultColumn>> query = engine.query(select(all()).from(table("TEST")).orderby(column("COL1").asc()));
+
+        // Previously, we rolled back the transaction; now we are trying the flush an empty transaction.
+        // Therefore, we shouldn't have any rows on the table.
+        assertEquals("There is no rows on table TEST", query.size(), 0);
     }
 
     @Test

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -691,7 +691,7 @@ public class EngineGeneralTest {
      * <ol>
      *     <li>Add batch to transaction and purposely fail to flush</li>
      *     <li>Ensure the existence of the Exception and rollback transaction</li>
-     *     <li>Flush again successfully an ensure that the DB table doesn't have any rows</li>
+     *     <li>Flush again successfully and ensure that the DB table doesn't have any rows</li>
      * </ol>
      *
      * This is a regression test.
@@ -728,6 +728,7 @@ public class EngineGeneralTest {
 
             engine.addBatch("TEST", entry);
             engine.flush();
+            fail("Was expecting the flush operation to fail");
         } catch (final DatabaseEngineException e) {
             expectedException = e;
         } finally {
@@ -744,11 +745,13 @@ public class EngineGeneralTest {
         engine.flush();
         engine.commit();
 
-        final List<Map<String, ResultColumn>> query = engine.query(select(all()).from(table("TEST")).orderby(column("COL1").asc()));
+        final List<Map<String, ResultColumn>> query = engine.query(select(all())
+                                                                           .from(table("TEST"))
+                                                                           .orderby(column("COL1").asc()));
 
         // Previously, we rolled back the transaction; now we are trying the flush an empty transaction.
         // Therefore, we shouldn't have any rows on the table.
-        assertEquals("There is no rows on table TEST", query.size(), 0);
+        assertEquals("There are no rows on table TEST", 0, query.size());
     }
 
     @Test


### PR DESCRIPTION
Currently, a transaction rollback executes a rollback statement on the
database. However, PDB might still have prepared statements with batch data that,
unless cleared, can still be saved on the database, thereby violating the ACID
properties. This commit ensures that the prepared statements are cleared when
rolling back a transaction.