### PR TITLE
Add "pdb.compress_lobs" option to allow the compression of BLOBS and CLOBS

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
@@ -35,7 +35,7 @@ import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_RECONNE
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_RETRY_INTERVAL;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SCHEMA_POLICY;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SECRET_LOCATION;
-import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SHOULD_COMPRESS_LOBS;
+import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_COMPRESS_LOBS;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_VARCHAR_SIZE;
 
 /**
@@ -137,7 +137,7 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
     /**
      * Property that indicates the lobs should be compressed. This depends on the database implementation.
      */
-    public static final String SHOULD_COMPRESS_LOBS = "pdb.compress_lobs";
+    public static final String COMPRESS_LOBS = "pdb.compress_lobs";
 
     /**
      * Creates a new instance of an empty {@link PdbProperties}.
@@ -168,7 +168,7 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
             setProperty(ALLOW_COLUMN_DROP, DEFAULT_ALLOW_COLUMN_DROP);
             setProperty(FETCH_SIZE, DEFAULT_FETCH_SIZE);
             setProperty(MAXIMUM_TIME_BATCH_SHUTDOWN, DEFAULT_MAXIMUM_TIME_BATCH_SHUTDOWN);
-            setProperty(SHOULD_COMPRESS_LOBS, DEFAULT_SHOULD_COMPRESS_LOBS);
+            setProperty(COMPRESS_LOBS, DEFAULT_COMPRESS_LOBS);
         }
     }
 
@@ -354,7 +354,7 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
      * @return {@code true} if LOBS should be compressed, {@code false} otherwise.
      */
     public boolean shouldCompressLobs() {
-        return Boolean.parseBoolean(getProperty(SHOULD_COMPRESS_LOBS));
+        return Boolean.parseBoolean(getProperty(COMPRESS_LOBS));
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
@@ -35,6 +35,7 @@ import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_RECONNE
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_RETRY_INTERVAL;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SCHEMA_POLICY;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SECRET_LOCATION;
+import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SHOULD_COMPRESS_LOBS;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_VARCHAR_SIZE;
 
 /**
@@ -133,6 +134,10 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
      * Property that indicates how much time to wait for a batch to shutdown.
      */
     public static final String MAXIMUM_TIME_BATCH_SHUTDOWN = "pdb.maximum_await_time_batch";
+    /**
+     * Property that indicates the lobs should be compressed. This depends on the database implementation.
+     */
+    public static final String SHOULD_COMPRESS_LOBS = "pdb.compress_lobs";
 
     /**
      * Creates a new instance of an empty {@link PdbProperties}.
@@ -163,6 +168,7 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
             setProperty(ALLOW_COLUMN_DROP, DEFAULT_ALLOW_COLUMN_DROP);
             setProperty(FETCH_SIZE, DEFAULT_FETCH_SIZE);
             setProperty(MAXIMUM_TIME_BATCH_SHUTDOWN, DEFAULT_MAXIMUM_TIME_BATCH_SHUTDOWN);
+            setProperty(SHOULD_COMPRESS_LOBS, DEFAULT_SHOULD_COMPRESS_LOBS);
         }
     }
 
@@ -340,6 +346,15 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
      */
     public boolean isReconnectOnLost() {
         return Boolean.parseBoolean(getProperty(RECONNECT_ON_LOST));
+    }
+
+    /**
+     * Checks if LOBS columns should be compressed.
+     *
+     * @return {@code true} if LOBS should be compressed, {@code false} otherwise.
+     */
+    public boolean shouldCompressLobs() {
+        return Boolean.parseBoolean(getProperty(SHOULD_COMPRESS_LOBS));
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -307,7 +307,7 @@ public class OracleEngine extends AbstractDatabaseEngine {
                 if (ex.getMessage().startsWith(NAME_ALREADY_EXISTS)) {
                     logger.debug(dev, "'{}' is already defined", entity.getName());
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_ALREADY_EXISTS), ex);
-                    break; // Name already exists, we cannot do anything so we exit
+                    return; // Name already exists, we cannot do anything so we exit
                 } else if (ex.getMessage().startsWith(SECUREFILE_NOT_ASSM)) {
                     logger.warn("Secure file LOBS cannot be used in non-ASSM tablespace. Creating table " +
                                         "without compressed lobs");

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -78,5 +78,5 @@ public final class Constants {
      * Indicates that the LOBS columns should be compressed. This is only possible on implementations that allow
      * this behavior.
      */
-    public static final boolean DEFAULT_SHOULD_COMPRESS_LOBS = true;
+    public static final boolean DEFAULT_COMPRESS_LOBS = true;
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -74,4 +74,9 @@ public final class Constants {
      * The default maximum amount of time to wait when batches are shutting down. 5 minutes.
      */
     public static final long DEFAULT_MAXIMUM_TIME_BATCH_SHUTDOWN = TimeUnit.MINUTES.toMillis(5);
+    /**
+     * Indicates that the LOBS columns should be compressed. This is only possible on implementations that allow
+     * this behavior.
+     */
+    public static final boolean DEFAULT_SHOULD_COMPRESS_LOBS = true;
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
@@ -45,6 +45,7 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.in;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.k;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.select;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.table;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.COMPRESS_LOBS;
 import static com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest.Ieee754Support.SUPPORTED_STRINGS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -140,6 +141,8 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
 
         final String compression = "COMPRESSION";
         final String secureFile = "SECUREFILE";
+
+        properties.setProperty(COMPRESS_LOBS, Boolean.toString(true));
 
         final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
 


### PR DESCRIPTION
This commit adds a new option to compress LOB columns. Currently, only the
Oracle implementation is supported.