### PR TITLE
Fix md5 max size implementation when the max size is above the hash size

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/StringUtils.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/StringUtils.java
@@ -95,7 +95,8 @@ public class StringUtils {
      * @return The hexadecimal checksum with the specified maximum number of chars.
      */
     public static String md5(final String message, final int nchar) {
-        return md5(message).substring(0, nchar);
+        final String hash = md5(message);
+        return nchar > hash.length() ? hash : hash.substring(0, nchar);
     }
 
     /**

--- a/src/test/java/com/feedzai/commons/sql/abstraction/util/StringUtilsTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/util/StringUtilsTest.java
@@ -56,9 +56,23 @@ public class StringUtilsTest {
      */
     @Test
     public void md5() {
+        final String hash = "b45cffe084dd3d20d928bee85e7b0f21";
+
         assertEquals("md5 should create the right output",
-                "b45cffe084dd3d20d928bee85e7b0f21",
+                hash,
                 StringUtils.md5("string"));
+
+        assertEquals("md5 should create the right output when max size is below hash size",
+                hash.substring(0, hash.length() - 1),
+                StringUtils.md5("string", hash.length() - 1));
+
+        assertEquals("md5 should create the right output when max size equals hash size",
+                hash,
+                StringUtils.md5("string", hash.length()));
+
+        assertEquals("md5 should create the right output when max size is above hash size",
+                hash,
+                StringUtils.md5("string", hash.length() + 1));
     }
 
     /**


### PR DESCRIPTION
This is necessary to allow identifiers longer than 32 chars.