### PR TITLE
fixes #73 - Fix schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
                                             <port>3306:3306</port>
                                         </ports>
                                         <env>
-                                            <MYSQL_ROOT_PASSWORD>my-secret-pw</MYSQL_ROOT_PASSWORD>
+                                            <MYSQL_ROOT_PASSWORD>AaBb12.#</MYSQL_ROOT_PASSWORD>
                                         </env>
                                         <cmd>--max-allowed-packet=16000000 --innodb-log-file-size=160000000</cmd>
                                         <wait>
@@ -470,7 +470,7 @@
                                         </ports>
                                         <env>
                                             <ACCEPT_EULA>Y</ACCEPT_EULA>
-                                            <SA_PASSWORD>AAaa11!!</SA_PASSWORD>
+                                            <SA_PASSWORD>AaBb12.#</SA_PASSWORD>
                                         </env>
                                         <wait>
                                             <time>40000</time>
@@ -514,7 +514,7 @@
                                             <port>5432:5432</port>
                                         </ports>
                                         <env>
-                                            <POSTGRES_PASSWORD>pgpassword</POSTGRES_PASSWORD>
+                                            <POSTGRES_PASSWORD>AaBb12.#</POSTGRES_PASSWORD>
                                         </env>
                                         <wait>
                                             <time>40000</time>
@@ -620,7 +620,7 @@
                                         </ports>
                                         <env>
                                             <LICENSE>accept</LICENSE>
-                                            <DB2INST1_PASSWORD>db2inst1-pwd</DB2INST1_PASSWORD>
+                                            <DB2INST1_PASSWORD>AaBb12.#</DB2INST1_PASSWORD>
                                         </env>
                                         <entrypoint>
                                             <arg>/bin/bash</arg>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/DB2ResultColumn.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/DB2ResultColumn.java
@@ -45,7 +45,7 @@ public class DB2ResultColumn extends ResultColumn {
         if (o instanceof Blob) {
             try {
                 return new ObjectInputStream(((Blob) o).getBinaryStream()).readObject();
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 throw new DatabaseEngineRuntimeException("Error eagerly converting blob to object", e);
             }
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/OracleResultColumn.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/OracleResultColumn.java
@@ -70,7 +70,7 @@ public class OracleResultColumn extends ResultColumn {
             ObjectInputStream ois = new ObjectInputStream(((Blob) val).getBinaryStream());
 
             return (T) ois.readObject();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new DatabaseEngineRuntimeException("Error converting blob to object", e);
         }
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultColumn.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultColumn.java
@@ -138,7 +138,7 @@ public abstract class ResultColumn implements Serializable {
             // are zero (e.g., 13.0), and in this case Long.parseLong() is ok.
             return Long.parseLong(val.toString());
 
-        } catch (NumberFormatException e) {
+        } catch (final NumberFormatException e) {
             // We get here if the double has decimal digits (e.g, 13.5) and in this
             // case there is no precision overflow on using an intermediate Double
             // before because it means the value was not stored as a long.
@@ -186,7 +186,7 @@ public abstract class ResultColumn implements Serializable {
         if (val instanceof Blob) {
             try {
                 is = ((Blob) val).getBinaryStream();
-            } catch (SQLException e) {
+            } catch (final SQLException e) {
                 throw new DatabaseEngineRuntimeException("Error getting blob input stream", e);
             }
         } else if (val instanceof byte[]) {
@@ -198,7 +198,7 @@ public abstract class ResultColumn implements Serializable {
         try {
             ObjectInputStream ois = new ObjectInputStream(is);
             return (T) ois.readObject();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new DatabaseEngineRuntimeException("Error converting blob to object", e);
         }
     }
@@ -218,7 +218,7 @@ public abstract class ResultColumn implements Serializable {
                 result.append(buff, 0, read);
             }
             return result.toString();
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             throw new DatabaseEngineRuntimeException("Unable to get string from clob", ex);
         }
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultIterator.java
@@ -96,7 +96,7 @@ public abstract class ResultIterator implements AutoCloseable {
                 columnNames.add(meta.getColumnLabel(i));
             }
 
-        } catch (Exception e) {
+        } catch (final Exception e) {
             close();
             throw new DatabaseEngineException("Could not process result set.", e);
         }
@@ -159,7 +159,7 @@ public abstract class ResultIterator implements AutoCloseable {
             }
 
             return temp;
-        } catch (Exception e) {
+        } catch (final Exception e) {
             close();
             throw new DatabaseEngineException("Could not fetch data.", e);
         }
@@ -201,7 +201,7 @@ public abstract class ResultIterator implements AutoCloseable {
                 temp[i] = createResultColumn(columnNames.get(i), resultSet.getObject(i + 1));
             }
             return temp;
-        } catch (Exception e) {
+        } catch (final Exception e) {
             close();
             throw new DatabaseEngineException("Could not fetch data.", e);
         }
@@ -236,13 +236,13 @@ public abstract class ResultIterator implements AutoCloseable {
                 if (resultSet != null) {
                     resultSet.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.warn("Could not close result set.", e);
             }
             if (statementCloseable && statement != null) {
                 try {
                     statement.close();
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.warn("Could not close statement.", e);
                 }
             }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -133,9 +133,7 @@ public interface DatabaseEngine extends AutoCloseable {
     void dropEntity(final DbEntity entity) throws DatabaseEngineException;
 
     /**
-     * <p>
      * Persists a given entry. Persisting a query implies executing the statement.
-     * </p>
      * <p>
      * If you are inside of an explicit transaction, changes will only be visible upon explicit commit, otherwise a
      * commit will immediately take place.
@@ -314,7 +312,7 @@ public interface DatabaseEngine extends AutoCloseable {
     List<Map<String, ResultColumn>> query(final String query) throws DatabaseEngineException;
 
     /**
-     * Gets the database entities.
+     * Gets the database entities for the current schema.
      *
      * @return The list of database entities and types (tables, views, and so on).
      * @throws DatabaseEngineException If something occurs getting the existing tables.
@@ -322,12 +320,38 @@ public interface DatabaseEngine extends AutoCloseable {
     Map<String, DbEntityType> getEntities() throws DatabaseEngineException;
 
     /**
-     * Gets the table metadata.
+     * Gets the database entities for the specified schema.
      *
+     * @param schemaPattern A schema name pattern; must match the schema name as it is stored in the database;
+     *                      {@code ""} retrieves those without a schema; {@code null} means that the schema name
+     *                      should not be used to narrow the search.
+     * @return The list of database entities and types (tables, views, and so on).
+     * @throws DatabaseEngineException If something occurs getting the existing tables.
+     * @since 2.1.13
+     */
+    Map<String, DbEntityType> getEntities(final String schemaPattern) throws DatabaseEngineException;
+
+    /**
+     * Gets the table metadata (table must be in the current schema).
+     *
+     * @param tableNamePattern A table name pattern; must match the table name as it is stored in the database.
      * @return A representation of the table columns and types.
      * @throws DatabaseEngineException If something occurs getting the metadata.
      */
-    Map<String, DbColumnType> getMetadata(final String name) throws DatabaseEngineException;
+    Map<String, DbColumnType> getMetadata(final String tableNamePattern) throws DatabaseEngineException;
+
+    /**
+     * Gets the table metadata (table must be in the current schema).
+     *
+     * @param tableNamePattern A table name pattern; must match the table name as it is stored in the database.
+     * @param schemaPattern    A schema name pattern; must match the schema name as it is stored in the database;
+     *                         {@code ""} retrieves those without a schema; {@code null} means that the schema name
+     *                         should not be used to narrow the search.
+     * @return A representation of the table columns and types.
+     * @throws DatabaseEngineException If something occurs getting the metadata.
+     * @since 2.1.13
+     */
+    Map<String, DbColumnType> getMetadata(final String schemaPattern, final String tableNamePattern) throws DatabaseEngineException;
 
     /**
      * Gets the query metadata.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseFactory.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseFactory.java
@@ -81,9 +81,9 @@ public final class DatabaseFactory {
             injector.injectMembers(de);
 
             return de;
-        } catch (DatabaseFactoryException e) {
+        } catch (final DatabaseFactoryException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new DatabaseFactoryException(e);
         }
     }
@@ -117,7 +117,7 @@ public final class DatabaseFactory {
             try {
                 bind(PdbProperties.class).toProvider(Providers.of(pdbProperties));
                 bind(AbstractTranslator.class).toInstance(translator.newInstance());
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 Throwables.propagate(e);
             }
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
@@ -46,6 +46,12 @@ import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_VARCHAR
  * @since 2.0.0
  */
 public class PdbProperties extends Properties implements com.feedzai.commons.sql.abstraction.util.Cloneable<PdbProperties> {
+
+    /**
+     * The serial version UID of this class.
+     */
+    private static final long serialVersionUID = -4948574874005506022L;
+
     /**
      * The JDBC property name.
      */

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -148,7 +148,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                     default:
                         ps.setObject(i, val);
                 }
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
                 throw new DatabaseEngineException("Error while mapping variables to database", ex);
             }
 
@@ -192,7 +192,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
         try {
             s = conn.createStatement();
             s.executeUpdate(createTableStatement);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getMessage().startsWith(NAME_ALREADY_EXISTS)) {
                 logger.debug(dev, "'{}' is already defined", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_ALREADY_EXISTS), ex);
@@ -204,7 +204,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -258,7 +258,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
             logger.trace(reorg);
             s = conn.createStatement();
             s.executeUpdate(reorg);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getMessage().startsWith(TABLE_CAN_ONLY_HAVE_ONE_PRIMARY_KEY)) {
                 logger.debug(dev, "'{}' already has a primary key", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.PRIMARY_KEY_ALREADY_EXISTS), ex);
@@ -270,7 +270,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -346,7 +346,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
             try {
                 s = conn.createStatement();
                 s.executeUpdate(statement);
-            } catch (SQLException ex) {
+            } catch (final SQLException ex) {
                 if (ex.getMessage().startsWith(NAME_ALREADY_EXISTS)) {
                     logger.debug(dev, "'{}' is already defined", idxName);
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.INDEX_ALREADY_EXISTS), ex);
@@ -358,7 +358,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                     if (s != null) {
                         s.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -402,7 +402,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
             try {
                 s = conn.createStatement();
                 s.executeUpdate(statement);
-            } catch (SQLException ex) {
+            } catch (final SQLException ex) {
                 if (ex.getMessage().startsWith(NAME_ALREADY_EXISTS)) {
                     logger.debug(dev, "'{}' is already defined", sequenceName);
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.SEQUENCE_ALREADY_EXISTS), ex);
@@ -414,7 +414,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                     if (s != null) {
                         s.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -489,7 +489,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
             psWithAutoInc = conn.prepareStatement(insertWithAutoInc);
 
             return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc).setAutoIncColumn(returning);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }
     }
@@ -510,7 +510,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 drop = conn.createStatement();
                 logger.trace(stmt);
                 drop.executeUpdate(stmt);
-            } catch (SQLException ex) {
+            } catch (final SQLException ex) {
                 if (ex.getMessage().startsWith(SEQUENCE_DOES_NOT_EXIST)) {
                     logger.debug(dev, "Sequence '{}' does not exist", sequenceName);
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.SEQUENCE_DOES_NOT_EXIST), ex);
@@ -522,7 +522,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                     if (drop != null) {
                         drop.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -537,7 +537,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
             final String query = format("DROP TABLE %s", quotize(entity.getName()));
             logger.trace(query);
             drop.executeUpdate(query);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getMessage().startsWith(TABLE_OR_VIEW_DOES_NOT_EXIST)) {
                 logger.debug(dev, "Table '{}' does not exist", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_DOES_NOT_EXIST), ex);
@@ -549,7 +549,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 if (drop != null) {
                     drop.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -580,7 +580,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
             logger.trace(reorg);
             reorgStatement = conn.createStatement();
             reorgStatement.executeUpdate(reorg);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getMessage().startsWith(TABLE_OR_VIEW_DOES_NOT_EXIST)) {
                 logger.debug(dev, "Table '{}' does not exist", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.COLUMN_DOES_NOT_EXIST), ex);
@@ -592,14 +592,14 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 if (drop != null) {
                     drop.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
             try {
                 if (reorgStatement != null) {
                     reorgStatement.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -614,7 +614,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
         super.updateEntity(entity);
         try (Statement reorg = conn.createStatement()) {
             reorg.executeUpdate(reorg(entity.getName()));
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             throw new DatabaseEngineException("Error reorganizing table '" + entity.getName() + "'", e);
         }
     }
@@ -658,21 +658,21 @@ public class DB2Engine extends AbstractDatabaseEngine {
             reorgStatement = conn.createStatement();
             reorgStatement.executeUpdate(reorg);
 
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         } finally {
             try {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
             try {
                 if (reorgStatement != null) {
                     reorgStatement.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -756,7 +756,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
 
 
             return ret == 0 ? null : ret;
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             throw new DatabaseEngineException("Something went wrong persisting the entity", ex);
         }
     }
@@ -798,7 +798,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 logger.trace(reorg);
                 reorgStatement = conn.createStatement();
                 reorgStatement.executeUpdate(reorg);
-            } catch (SQLException ex) {
+            } catch (final SQLException ex) {
                 if (ex.getMessage().startsWith(FOREIGN_ALREADY_EXISTS)) {
                     logger.debug(dev, "Foreign key for table '{}' already exists. Error code: {}.", entity.getName(), ex.getMessage());
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.FOREIGN_KEY_ALREADY_EXISTS), ex);
@@ -810,14 +810,14 @@ public class DB2Engine extends AbstractDatabaseEngine {
                     if (alterTableStmt != null) {
                         alterTableStmt.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
                 try {
                     if (reorgStatement != null) {
                         reorgStatement.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -832,7 +832,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
             s.executeQuery("SELECT 1 FROM sysibm.sysdummy1");
 
             return true;
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             logger.debug("Connection is down.", e);
             return false;
         } finally {
@@ -840,7 +840,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -852,27 +852,74 @@ public class DB2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    public synchronized Map<String, DbColumnType> getMetadata(final String name) throws DatabaseEngineException {
+    protected String getSchema() throws DatabaseEngineException {
+        try (final Statement stmt = conn.createStatement();
+             final ResultSet resultSet = stmt.executeQuery("VALUES(CURRENT SCHEMA)")) {
+
+            if (!resultSet.next()) {
+                return null;
+            }
+
+            final String schema = resultSet.getString(1);
+            // result needs to be trimmed because it has padding spaces
+            return schema == null ? null : schema.trim();
+        } catch (final Exception e) {
+            throw new DatabaseEngineException("Could not get current schema", e);
+        }
+    }
+
+    @Override
+    protected void setSchema(final String schema) throws DatabaseEngineException {
+        final boolean schemaExists;
+
+        try (final PreparedStatement ps = conn.prepareStatement("SELECT count(*) FROM syscat.schemata WHERE SCHEMANAME = ?")) {
+            ps.setString(1, schema);
+
+            try (final ResultSet resultSet = ps.executeQuery()) {
+                schemaExists = resultSet.next() && resultSet.getInt(1) == 1;
+            }
+
+        } catch (final Exception e) {
+            throw new DatabaseEngineException(String.format("Could not set current schema to '%s'", schema), e);
+        }
+
+        if (!schemaExists) {
+            throw new DatabaseEngineException(String.format("Could not set current schema to non existing '%s'", schema));
+        }
+
+        try (final PreparedStatement ps = conn.prepareStatement("SET CURRENT SCHEMA ?")) {
+            ps.setString(1, schema);
+            ps.execute();
+        } catch (final Exception e) {
+            throw new DatabaseEngineException(String.format("Could not set current schema to '%s'", schema), e);
+        }
+
+    }
+
+    @Override
+    public synchronized Map<String, DbColumnType> getMetadata(final String schemaPattern,
+                                                              final String tableNamePattern) throws DatabaseEngineException {
         final Map<String, DbColumnType> metaMap = new LinkedHashMap<>();
 
-        Statement s = null;
+        PreparedStatement ps = null;
         ResultSet rsColumns = null;
         try {
             getConnection();
 
-            s = conn.createStatement();
-            rsColumns = s.executeQuery(
-                String.format("SELECT NAME, COLTYPE,SCALE  FROM sysibm.SYSCOLUMNS WHERE tbname='%s' and TBCREATOR=UPPER('%s')",
-                    name, Optional.ofNullable(properties.getSchema()).orElse(properties.getUsername()))
-            );
+            ps = conn.prepareStatement(
+                    "SELECT NAME, COLTYPE, SCALE FROM sysibm.SYSCOLUMNS WHERE tbname LIKE ? AND TBCREATOR LIKE ?");
+            ps.setString(1, tableNamePattern == null ? "%" : tableNamePattern);
+            ps.setString(2, schemaPattern == null ? "%" : schemaPattern);
+
+            rsColumns = ps.executeQuery();
 
             while (rsColumns.next()) {
-                String columnType = rsColumns.getString("COLTYPE").trim();
+                final String columnType = rsColumns.getString("COLTYPE").trim();
 
                 int scale = 0;
                 try {
                     scale = Integer.parseInt(rsColumns.getString("SCALE"));
-                } catch (NumberFormatException e) {
+                } catch (final NumberFormatException e) {
                     /* swallow - scale is already 0*/
                 }
 
@@ -880,22 +927,22 @@ public class DB2Engine extends AbstractDatabaseEngine {
             }
 
             return metaMap;
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new DatabaseEngineException("Could not get metadata", e);
         } finally {
             try {
                 if (rsColumns != null) {
                     rsColumns.close();
                 }
-            } catch (Exception a) {
+            } catch (final Exception a) {
                 logger.trace("Error closing result set.", a);
             }
 
             try {
-                if (s != null) {
-                    s.close();
+                if (ps != null) {
+                    ps.close();
                 }
-            } catch (Exception a) {
+            } catch (final Exception a) {
                 logger.trace("Error closing statement.", a);
             }
         }
@@ -951,7 +998,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 } else {
                     setObjectParameter(ps, i, o);
                 }
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
                 if (checkConnection(conn) || !properties.isReconnectOnLost()) {
                     throw new DatabaseEngineException("Could not set parameters", ex);
                 }
@@ -959,7 +1006,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 // At this point maybe it is an error with the connection, so we try to re-establish it.
                 try {
                     getConnection();
-                } catch (Exception e2) {
+                } catch (final Exception e2) {
                     throw new DatabaseEngineException("Connection is down", e2);
                 }
 
@@ -982,7 +1029,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
             } else {
                 setObjectParameter(ps, index, param);
             }
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             if (checkConnection(conn) || !properties.isReconnectOnLost()) {
                 throw new DatabaseEngineException("Could not set parameter", ex);
             }
@@ -990,7 +1037,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
             // At this point maybe it is an error with the connection, so we try to re-establish it.
             try {
                 getConnection();
-            } catch (Exception e2) {
+            } catch (final Exception e2) {
                 throw new DatabaseEngineException("Connection is down", e2);
             }
 
@@ -1011,7 +1058,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
     private void setObjectParameter(PreparedStatementCapsule ps, int index, Object o) throws Exception {
         try {
             ps.ps.setObject(index, o);
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             if (!(o instanceof String)) {
                 throw e;
             }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -15,8 +15,20 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl;
 
-import com.feedzai.commons.sql.abstraction.ddl.*;
-import com.feedzai.commons.sql.abstraction.dml.*;
+import com.feedzai.commons.sql.abstraction.ddl.AlterColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
+import com.feedzai.commons.sql.abstraction.ddl.DropPrimaryKey;
+import com.feedzai.commons.sql.abstraction.ddl.Rename;
+import com.feedzai.commons.sql.abstraction.dml.Expression;
+import com.feedzai.commons.sql.abstraction.dml.Function;
+import com.feedzai.commons.sql.abstraction.dml.Join;
+import com.feedzai.commons.sql.abstraction.dml.Modulo;
+import com.feedzai.commons.sql.abstraction.dml.Name;
+import com.feedzai.commons.sql.abstraction.dml.Query;
+import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
+import com.feedzai.commons.sql.abstraction.dml.Truncate;
+import com.feedzai.commons.sql.abstraction.dml.View;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 import com.feedzai.commons.sql.abstraction.util.Constants;
@@ -108,13 +120,13 @@ public class DB2Translator extends AbstractTranslator {
         if (Function.AVG.equalsIgnoreCase(function)) {
            /* DB2 AVG is type sensitive - avg of int returns int (why IBM???)*/
             return "AVG(" + expTranslated + "+0.0)";
+        }
+
+        // if it is a user-defined function
+        if (f.isUDF() && properties.isSchemaSet()) {
+            return quotize(properties.getSchema(), translateEscape()) + "." + function + "(" + expTranslated + ")";
         } else {
-            // if it is a user-defined function
-            if (f.isUDF() && properties.isSchemaSet()) {
-                return properties.getSchema() + "." + function + "(" + expTranslated + ")";
-            } else {
-                return function + "(" + expTranslated + ")";
-            }
+            return function + "(" + expTranslated + ")";
         }
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -81,9 +81,16 @@ public class H2Engine extends AbstractDatabaseEngine {
     public static final String TABLE_OR_VIEW_DOES_NOT_EXIST = "42S02";
 
     /**
-     * Table or view does not exist.
+     * Constraint name already exists.
      */
     public static final String CONSTRAINT_NAME_ALREADY_EXISTS = "90045";
+
+    /**
+     * An optional feature is not implemented by the driver or not supported by the DB.
+     *
+     * @since 2.1.13
+     */
+    public static final String OPTIONAL_FEATURE_NOT_SUPPORTED = "HYC00";
 
     /**
      * Creates a new PostgreSql connection.
@@ -152,7 +159,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                     default:
                         ps.setObject(i, val);
                 }
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
                 throw new DatabaseEngineException("Error while mapping variables to database", ex);
             }
 
@@ -234,7 +241,7 @@ public class H2Engine extends AbstractDatabaseEngine {
         try {
             s = conn.createStatement();
             s.executeUpdate(createTableStatement);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getSQLState().startsWith(NAME_ALREADY_EXISTS)) {
                 logger.debug(dev, "'{}' is already defined", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_ALREADY_EXISTS), ex);
@@ -246,7 +253,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -281,7 +288,7 @@ public class H2Engine extends AbstractDatabaseEngine {
         try {
             s = conn.createStatement();
             s.executeUpdate(addPrimaryKey);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getSQLState().startsWith(TABLE_CAN_ONLY_HAVE_ONE_PRIMARY_KEY) || ex.getSQLState().startsWith(CONSTRAINT_NAME_ALREADY_EXISTS)) {
                 logger.debug(dev, "'{}' already has a primary key", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.PRIMARY_KEY_ALREADY_EXISTS), ex);
@@ -293,7 +300,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -332,7 +339,7 @@ public class H2Engine extends AbstractDatabaseEngine {
             try {
                 s = conn.createStatement();
                 s.executeUpdate(statement);
-            } catch (SQLException ex) {
+            } catch (final SQLException ex) {
                 if (ex.getSQLState().startsWith(INDEX_ALREADY_EXISTS)) {
                     logger.debug(dev, "'{}' is already defined", idxName);
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.INDEX_ALREADY_EXISTS), ex);
@@ -344,7 +351,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                     if (s != null) {
                         s.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -422,7 +429,7 @@ public class H2Engine extends AbstractDatabaseEngine {
             final String query = format("DROP TABLE %s CASCADE", quotize(entity.getName()));
             logger.trace(query);
             drop.executeUpdate(query);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getSQLState().startsWith(TABLE_OR_VIEW_DOES_NOT_EXIST)) {
                 logger.debug(dev, "Table '{}' does not exist", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_DOES_NOT_EXIST), ex);
@@ -434,7 +441,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                 if (drop != null) {
                     drop.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -451,7 +458,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                 logger.trace(query);
                 drop.executeUpdate(query);
             }
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getSQLState().startsWith(TABLE_OR_VIEW_DOES_NOT_EXIST)) {
                 logger.debug(dev, "Table '{}' does not exist", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.COLUMN_DOES_NOT_EXIST), ex);
@@ -463,7 +470,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                 if (drop != null) {
                     drop.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -495,14 +502,14 @@ public class H2Engine extends AbstractDatabaseEngine {
                 s.executeUpdate(query);
             }
 
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         } finally {
             try {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -552,14 +559,14 @@ public class H2Engine extends AbstractDatabaseEngine {
             }
 
             return ret == 0 ? null : ret;
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             throw new DatabaseEngineException("Something went wrong persisting the entity", ex);
         } finally {
             try {
                 if (generatedKeys != null) {
                     generatedKeys.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing result set.", e);
             }
         }
@@ -596,7 +603,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                 alterTableStmt = conn.createStatement();
                 logger.trace(alterTable);
                 alterTableStmt.executeUpdate(alterTable);
-            } catch (SQLException ex) {
+            } catch (final SQLException ex) {
                 if (ex.getSQLState().equals(CONSTRAINT_NAME_ALREADY_EXISTS)) {
                     logger.debug(dev, "Foreign key for table '{}' already exists. Error code: {}.", entity.getName(), ex.getSQLState());
                 } else {
@@ -607,7 +614,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                     if (alterTableStmt != null) {
                         alterTableStmt.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -623,7 +630,7 @@ public class H2Engine extends AbstractDatabaseEngine {
             s.executeQuery("select 1");
 
             return true;
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             logger.debug("Connection is down.", e);
             return false;
         } finally {
@@ -631,9 +638,57 @@ public class H2Engine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
+        }
+    }
+
+    @Override
+    protected String getSchema() throws DatabaseEngineException {
+        try {
+            return this.conn.getSchema();
+
+        } catch (final Exception ex) {
+            if (ex instanceof SQLException && OPTIONAL_FEATURE_NOT_SUPPORTED.equals(((SQLException) ex).getSQLState())) {
+                // if connection is remote, getSchema() may not be supported; try again
+                try (final Statement stmt = conn.createStatement();
+                     final ResultSet resultSet = stmt.executeQuery("SELECT SCHEMA()")) {
+
+                    if (!resultSet.next()) {
+                        return null;
+                    }
+
+                    return resultSet.getString(1);
+
+                } catch (final Exception queryEx) {
+                    throw new DatabaseEngineException("Could not get current schema", queryEx);
+                }
+            }
+
+            throw new DatabaseEngineException("Could not get current schema", ex);
+        }
+    }
+
+    @Override
+    protected void setSchema(final String schema) throws DatabaseEngineException {
+        try {
+            this.conn.setSchema(schema);
+
+        } catch (final Exception ex) {
+            if (ex instanceof SQLException && OPTIONAL_FEATURE_NOT_SUPPORTED.equals(((SQLException) ex).getSQLState())) {
+                // if connection is remote, getSchema() may not be supported; try again
+                try (final PreparedStatement ps = conn.prepareStatement("SET SCHEMA ?")) {
+                    ps.setString(1, schema);
+                    ps.execute();
+                    return;
+
+                } catch (final Exception queryEx) {
+                    throw new DatabaseEngineException(String.format("Could not set current schema to '%s'", schema), queryEx);
+                }
+            }
+
+            throw new DatabaseEngineException(String.format("Could not set current schema to '%s'", schema), ex);
         }
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
@@ -85,12 +85,7 @@ public class H2Translator extends AbstractTranslator {
             expTranslated = String.format("CONVERT(%s, DOUBLE PRECISION)", expTranslated);
         }
 
-        // if it is a user-defined function
-        if (f.isUDF() && properties.isSchemaSet()) {
-            return properties.getSchema() + "." + function + "(" + expTranslated + ")";
-        } else {
-            return function + "(" + expTranslated + ")";
-        }
+        return function + "(" + expTranslated + ")";
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
@@ -87,12 +87,7 @@ public class MySqlTranslator extends AbstractTranslator {
             function = "STDDEV_SAMP";
         }
 
-        // if it is a user-defined function
-        if (f.isUDF() && properties.isSchemaSet()) {
-            return properties.getSchema() + "." + function + "(" + expTranslated + ")";
-        } else {
-            return function + "(" + expTranslated + ")";
-        }
+        return function + "(" + expTranslated + ")";
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
@@ -90,12 +90,7 @@ public class OracleTranslator extends AbstractTranslator {
             expTranslated = exp.translate();
         }
 
-        // if it is a user-defined function
-        if (f.isUDF() && properties.isSchemaSet()) {
-            return properties.getSchema() + "." + function + "(" + expTranslated + ")";
-        } else {
-            return function + "(" + expTranslated + ")";
-        }
+        return function + "(" + expTranslated + ")";
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -37,14 +37,12 @@ import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import org.postgresql.util.PGobject;
 
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -137,7 +135,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                     default:
                         ps.setObject(i, val);
                 }
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
                 throw new DatabaseEngineException("Error while mapping variables to database", ex);
             }
 
@@ -169,7 +167,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
             dataObject.setType("jsonb");
             dataObject.setValue(val);
             return dataObject;
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             throw new DatabaseEngineException("Error while mapping variables to database, value = " + val, ex);
         }
     }
@@ -208,7 +206,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         try {
             s = conn.createStatement();
             s.executeUpdate(createTableStatement);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getSQLState().startsWith(NAME_ALREADY_EXISTS)) {
                 logger.debug(dev, "'{}' is already defined", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_ALREADY_EXISTS), ex);
@@ -220,7 +218,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -255,7 +253,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         try {
             s = conn.createStatement();
             s.executeUpdate(addPrimaryKey);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getSQLState().startsWith(TABLE_CAN_ONLY_HAVE_ONE_PRIMARY_KEY)) {
                 logger.debug(dev, "'{}' already has a primary key", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.PRIMARY_KEY_ALREADY_EXISTS), ex);
@@ -267,7 +265,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -306,7 +304,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
             try {
                 s = conn.createStatement();
                 s.executeUpdate(statement);
-            } catch (SQLException ex) {
+            } catch (final SQLException ex) {
                 if (ex.getSQLState().startsWith(NAME_ALREADY_EXISTS)) {
                     logger.debug(dev, "'{}' is already defined", idxName);
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.INDEX_ALREADY_EXISTS), ex);
@@ -318,7 +316,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                     if (s != null) {
                         s.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -387,7 +385,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
             psWithAutoInc = conn.prepareStatement(statementWithAutoInt);
 
             return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc).setAutoIncColumn(returning);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }
     }
@@ -408,7 +406,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
             final String query = format("DROP TABLE %s CASCADE", quotize(entity.getName()));
             logger.trace(query);
             drop.executeUpdate(query);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getSQLState().startsWith(TABLE_OR_VIEW_DOES_NOT_EXIST)) {
                 logger.debug(dev, "Table '{}' does not exist", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_DOES_NOT_EXIST), ex);
@@ -420,7 +418,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                 if (drop != null) {
                     drop.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -444,7 +442,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
             final String query = join(removeColumns, " ");
             logger.trace(query);
             drop.executeUpdate(query);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getMessage().startsWith(TABLE_OR_VIEW_DOES_NOT_EXIST)) {
                 logger.debug(dev, "Table '{}' does not exist", entity.getName());
             } else {
@@ -455,7 +453,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                 if (drop != null) {
                     drop.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -493,14 +491,14 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         try {
             s = conn.createStatement();
             s.executeUpdate(addColumnsStatement);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         } finally {
             try {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -562,14 +560,14 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
             }
 
             return ret == 0 ? null : ret;
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             throw new DatabaseEngineException("Something went wrong persisting the entity", ex);
         } finally {
             try {
                 if (generatedKeys != null) {
                     generatedKeys.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing result set.", e);
             }
         }
@@ -606,7 +604,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                 alterTableStmt = conn.createStatement();
                 logger.trace(alterTable);
                 alterTableStmt.executeUpdate(alterTable);
-            } catch (SQLException ex) {
+            } catch (final SQLException ex) {
                 if (ex.getSQLState().equals(CONSTRAINT_NAME_ALREADY_EXISTS)) {
                     logger.debug(dev, "Foreign key for table '{}' already exists. Error code: {}.", entity.getName(), ex.getSQLState());
                 } else {
@@ -617,7 +615,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                     if (alterTableStmt != null) {
                         alterTableStmt.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -633,7 +631,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
             s.executeQuery("select 1");
 
             return true;
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             logger.debug("Connection is down.", e);
             return false;
         } finally {
@@ -641,40 +639,25 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
     }
 
     @Override
-    public synchronized Map<String, DbColumnType> getMetadata(final String name) throws DatabaseEngineException {
-        final Map<String, DbColumnType> metaMap = new LinkedHashMap<>();
+    protected void setSchema(final String schema) throws DatabaseEngineException {
+        super.setSchema(schema);
 
-        ResultSet rsColumns = null;
+        final boolean isSchemaSet;
         try {
-            getConnection();
+            isSchemaSet = this.conn.getSchema() != null;
+        } catch (final Exception e) {
+            throw new DatabaseEngineException(String.format("Could not set current schema to '%s'", schema), e);
+        }
 
-
-            DatabaseMetaData meta = conn.getMetaData();
-            rsColumns = meta.getColumns(null, getSchema(), name, null);
-            while (rsColumns.next()) {
-                metaMap.put(rsColumns.getString("COLUMN_NAME"),
-                        toPdbType(rsColumns.getInt("DATA_TYPE"), rsColumns.getString("TYPE_NAME")));
-            }
-
-            return metaMap;
-        } catch (Exception e) {
-            throw new DatabaseEngineException("Could not get metadata", e);
-        } finally {
-            try {
-                if (rsColumns != null) {
-                    rsColumns.close();
-                }
-
-            } catch (Exception a) {
-                logger.trace("Error closing result set.", a);
-            }
+        if (!isSchemaSet) {
+            throw new DatabaseEngineException(String.format("Schema '%s' doesn't exist", schema));
         }
     }
 
@@ -682,7 +665,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     protected DbColumnType toPdbType(final int type, final String typeName) {
         DbColumnType pdbType = super.toPdbType(type, typeName);
         if (pdbType == DbColumnType.UNMAPPED && typeName.equals("jsonb")) {
-            pdbType = DbColumnType.JSON;
+            return DbColumnType.JSON;
         }
         return pdbType;
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
@@ -97,12 +97,7 @@ public class PostgreSqlTranslator extends AbstractTranslator {
             expTranslated = exp.translate();
         }
 
-        // if it is a user-defined function
-        if (f.isUDF() && properties.isSchemaSet()) {
-            return properties.getSchema() + "." + function + "(" + expTranslated + ")";
-        } else {
-            return function + "(" + expTranslated + ")";
-        }
+        return function + "(" + expTranslated + ")";
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -147,7 +147,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                     default:
                         ps.setObject(i, val);
                 }
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
                 throw new DatabaseEngineException("Error while mapping variables to database", ex);
             }
 
@@ -204,7 +204,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
         try {
             s = conn.createStatement();
             s.executeUpdate(createTableStatement);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getErrorCode() == NAME_ALREADY_EXISTS) {
                 logger.debug(dev, "'{}' is already defined", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_ALREADY_EXISTS), ex);
@@ -216,7 +216,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -262,14 +262,14 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                     try {
                         s = conn.createStatement();
                         s.executeUpdate(alterTable);
-                    } catch (SQLException ex) {
+                    } catch (final SQLException ex) {
                         throw new DatabaseEngineException("Something went wrong altering the table. This shouldn't have happened", ex);
                     } finally {
                         try {
                             if (s != null) {
                                 s.close();
                             }
-                        } catch (Exception e) {
+                        } catch (final Exception e) {
                             logger.trace("Error closing statement.", e);
                         }
                     }
@@ -297,7 +297,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
         try {
             s = conn.createStatement();
             s.executeUpdate(addPrimaryKey);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getErrorCode() == TABLE_CAN_ONLY_HAVE_ONE_PRIMARY_KEY) {
                 logger.debug(dev, "'{}' already has a primary key", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.PRIMARY_KEY_ALREADY_EXISTS), ex);
@@ -309,7 +309,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -348,7 +348,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
             try {
                 s = conn.createStatement();
                 s.executeUpdate(statement);
-            } catch (SQLException ex) {
+            } catch (final SQLException ex) {
                 if (ex.getErrorCode() == INDEX_ALREADY_EXISTS) {
                     logger.debug(dev, "'{}' is already defined", idxName);
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.INDEX_ALREADY_EXISTS), ex);
@@ -360,7 +360,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                     if (s != null) {
                         s.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -414,7 +414,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
             psWithAutoInc = conn.prepareStatement(statementWithAutoInt);
 
             return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }
     }
@@ -437,7 +437,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
             final String query = format("DROP TABLE %s", quotize(entity.getName()));
             logger.trace(query);
             drop.executeUpdate(query);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getErrorCode() == TABLE_OR_VIEW_DOES_NOT_EXIST) {
                 logger.debug("Table '{}' does not exist", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_DOES_NOT_EXIST), ex);
@@ -449,7 +449,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                 if (drop != null) {
                     drop.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -474,7 +474,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
             final String query = join(removeColumns, " ");
             logger.trace(query);
             drop.executeUpdate(query);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             if (ex.getErrorCode() == TABLE_OR_VIEW_DOES_NOT_EXIST) {
                 logger.debug(dev, "Table '{}' does not exist", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.COLUMN_DOES_NOT_EXIST), ex);
@@ -486,7 +486,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                 if (drop != null) {
                     drop.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -525,14 +525,14 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
         try {
             s = conn.createStatement();
             s.executeUpdate(addColumnsStatement);
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         } finally {
             try {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
         }
@@ -595,7 +595,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
             }
 
             return ret == 0 ? null : ret;
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             throw new DatabaseEngineException("Something went wrong persisting the entity", ex);
         } finally {
             try {
@@ -608,7 +608,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                         getConnection().createStatement().execute("SET IDENTITY_INSERT \"" + name + "\" OFF");
                     }
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing result set.", e);
             }
         }
@@ -646,7 +646,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                 alterTableStmt = conn.createStatement();
                 logger.trace(alterTable);
                 alterTableStmt.executeUpdate(alterTable);
-            } catch (SQLException ex) {
+            } catch (final SQLException ex) {
                 if (ex.getErrorCode() == NAME_ALREADY_EXISTS) {
                     logger.debug(dev, "Foreign key for table '{}' already exists. Error code: {}.", entity.getName(), ex.getErrorCode());
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.FOREIGN_KEY_ALREADY_EXISTS), ex);
@@ -658,7 +658,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                     if (alterTableStmt != null) {
                         alterTableStmt.close();
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -700,32 +700,32 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                     logger.trace(dropFkString);
                     dropFk.executeUpdate(dropFkString);
 
-                } catch (SQLException ex) {
+                } catch (final SQLException ex) {
                     logger.debug(format("Unable to drop constraint '%s' in table '%s'", dependentTables.getString(2), dependentTables.getString(1)), ex);
                 } finally {
                     if (dropFk != null) {
                         try {
                             dropFk.close();
-                        } catch (Exception e) {
+                        } catch (final Exception e) {
                             logger.trace("Error closing statement.", e);
                         }
                     }
                 }
             }
-        } catch (SQLException ex) {
+        } catch (final SQLException ex) {
             throw new DatabaseEngineException(format("Unable to drop foreign keys of the tables that depend on '%s'", entity.getName()), ex);
         } finally {
             if (dependentTables != null) {
                 try {
                     dependentTables.close();
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing result set.", e);
                 }
             }
             if (s != null) {
                 try {
                     s.close();
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     logger.trace("Error closing statement.", e);
                 }
             }
@@ -758,7 +758,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
             s.executeQuery("select 1");
 
             return true;
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             logger.debug("Connection is down.", e);
             return false;
         } finally {
@@ -766,9 +766,18 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                 if (s != null) {
                     s.close();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 logger.trace("Error closing statement.", e);
             }
+        }
+    }
+
+    @Override
+    protected void setSchema(final String schema) throws DatabaseEngineException {
+        if (!properties.getSchema().equals(getSchema())) {
+            throw new DatabaseEngineException(
+                "Microsoft Sql Server doesn't support setting a schema for the session! Use a different user or database instead."
+            );
         }
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -15,8 +15,20 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl;
 
-import com.feedzai.commons.sql.abstraction.ddl.*;
-import com.feedzai.commons.sql.abstraction.dml.*;
+import com.feedzai.commons.sql.abstraction.ddl.AlterColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
+import com.feedzai.commons.sql.abstraction.ddl.DropPrimaryKey;
+import com.feedzai.commons.sql.abstraction.ddl.Rename;
+import com.feedzai.commons.sql.abstraction.dml.Expression;
+import com.feedzai.commons.sql.abstraction.dml.Function;
+import com.feedzai.commons.sql.abstraction.dml.Join;
+import com.feedzai.commons.sql.abstraction.dml.Modulo;
+import com.feedzai.commons.sql.abstraction.dml.Name;
+import com.feedzai.commons.sql.abstraction.dml.Query;
+import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
+import com.feedzai.commons.sql.abstraction.dml.Update;
+import com.feedzai.commons.sql.abstraction.dml.View;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 import com.feedzai.commons.sql.abstraction.util.StringUtils;
@@ -98,8 +110,10 @@ public class SqlServerTranslator extends AbstractTranslator {
         }
 
         // if it is a user-defined function
-        if (f.isUDF() && properties.isSchemaSet()) {
-            return properties.getSchema() + "." + function + "(" + expTranslated + ")";
+        if (f.isUDF()) {
+            // a schema must always be used for functions, use default SQL Server schema "dbo" if no schema is set
+            final String schema = properties.isSchemaSet() ? quotize(properties.getSchema(), translateEscape())  : "dbo";
+            return schema + "." + function + "(" + expTranslated + ")";
         } else {
             return function + "(" + expTranslated + ")";
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/AESHelper.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/AESHelper.java
@@ -49,7 +49,7 @@ public final class AESHelper {
             byte[] encoded = cipher.doFinal(c.getBytes());
             return new String(Hex.encodeHex(encoded));
 
-        } catch (Exception e) {
+        } catch (final Exception e) {
             logger.warn("Could not encrypt string", e);
             return null;
         }
@@ -70,7 +70,7 @@ public final class AESHelper {
             byte[] encoded = cipher.doFinal(c);
             return new String(Hex.encodeHex(encoded));
 
-        } catch (Exception e) {
+        } catch (final Exception e) {
             logger.warn("Could not encrypt byte[]", e);
             return null;
         }
@@ -90,7 +90,7 @@ public final class AESHelper {
             cipher.init(Cipher.DECRYPT_MODE, skeySpec);
             byte[] decoded = cipher.doFinal(Hex.decodeHex(c.toCharArray()));
             return new String(decoded);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             logger.warn("Could not decrypt string", e);
             return null;
         }
@@ -109,7 +109,7 @@ public final class AESHelper {
             Cipher cipher = Cipher.getInstance("AES");
             cipher.init(Cipher.DECRYPT_MODE, skeySpec);
             return cipher.doFinal(Hex.decodeHex((new String(c).toCharArray())));
-        } catch (Exception e) {
+        } catch (final Exception e) {
             logger.warn("Could not decrypt byte[]", e);
             return null;
         }
@@ -126,7 +126,7 @@ public final class AESHelper {
         try {
             byte[] buf = readFile(path);
             return decrypt(buf, key);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             logger.warn("Could not decrypt file {}", path, e);
             return null;
         }
@@ -144,7 +144,7 @@ public final class AESHelper {
             FileOutputStream fos = new FileOutputStream(path);
             fos.write(encrypt(buf, key).getBytes());
             fos.close();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             logger.warn("Could not encrypt to file {}", path, e);
         }
     }
@@ -166,7 +166,7 @@ public final class AESHelper {
             if (f != null) {
                 try {
                     f.close();
-                } catch (IOException ignored) {
+                } catch (final IOException ignored) {
                 }
             }
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/StringUtils.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/StringUtils.java
@@ -75,7 +75,7 @@ public class StringUtils {
             instance.update(message.getBytes());
             res = instance.digest();
 
-        } catch (NoSuchAlgorithmException ex) {
+        } catch (final NoSuchAlgorithmException ex) {
             throw new RuntimeException(ex);
         }
 
@@ -125,7 +125,7 @@ public class StringUtils {
             if (br != null) {
                 try {
                     br.close();
-                } catch (IOException ex) {
+                } catch (final IOException ex) {
                 }
             }
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
@@ -57,6 +57,7 @@ import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assume.assumeThat;
 
 /**
@@ -92,19 +93,18 @@ public abstract class AbstractEngineSchemaTest {
 
     private static final String IEE754_SUPPORT_MESSAGE = "Test not supported for this engine - skipped";
 
-    protected DatabaseEngine engine;
     protected Properties properties;
 
     @Parameterized.Parameter
     public DatabaseConfiguration config;
 
-    private static String TABLE_NAME = "TEST_DOUBLE_COLUMN";
-    private static String ID_COL = "ID";
-    private static String DBL_COL = "DBL_COL";
-    private static int PK_VALUE = 1;
+    private static final String TABLE_NAME = "TEST_DOUBLE_COLUMN";
+    private static final String ID_COL = "ID";
+    private static final String DBL_COL = "DBL_COL";
+    private static final int PK_VALUE = 1;
 
     @Before
-    public void init() throws Exception {
+    public void init() {
         properties = new Properties() {
             {
                 setProperty(JDBC, config.jdbc);
@@ -112,17 +112,11 @@ public abstract class AbstractEngineSchemaTest {
                 setProperty(PASSWORD, config.password);
                 setProperty(ENGINE, config.engine);
                 setProperty(SCHEMA_POLICY, "drop-create");
-                setProperty(SCHEMA, getDefaultSchema());
+                if (config.schema != null) {
+                    setProperty(SCHEMA, config.schema);
+                }
             }
         };
-    }
-
-    protected String getDefaultSchema() {
-        return "";
-    }
-
-    protected String getSchema() {
-        return "";
     }
 
     /**
@@ -137,6 +131,17 @@ public abstract class AbstractEngineSchemaTest {
         return UNSUPPORTED;
     }
 
+
+    /**
+     * Gets the test schema to be used in tests that need a schema other then the default/configured.
+     *
+     * @return The test schema.
+     * @since 2.1.13
+     */
+    protected String getTestSchema() {
+        return "myschema";
+    }
+
     /**
      * Tests a query including an UDF {@link com.feedzai.commons.sql.abstraction.dml.Expression},
      * using the default schema.
@@ -146,11 +151,12 @@ public abstract class AbstractEngineSchemaTest {
     @Test
     public void udfGetOneTest() throws Exception {
         // engine using the default schema
-        engine = DatabaseFactory.getConnection(properties);
-        defineUDFGetOne(engine);
+        try (final DatabaseEngine engine = DatabaseFactory.getConnection(properties)) {
+            defineUDFGetOne(engine);
 
-        List<Map<String, ResultColumn>> query = engine.query(select(udf("GetOne").alias("ONE")));
-        assertEquals("result ok?", 1, (int) query.get(0).get("ONE").toInt());
+            final List<Map<String, ResultColumn>> query = engine.query(select(udf("GetOne").alias("ONE")));
+            assertEquals("result ok?", 1, (int) query.get(0).get("ONE").toInt());
+        }
     }
 
     /**
@@ -161,14 +167,18 @@ public abstract class AbstractEngineSchemaTest {
      */
     @Test
     public void udfTimesTwoTest() throws Exception {
-        // engine using the default schema
-        this.properties.setProperty(SCHEMA, getSchema());
-        engine = DatabaseFactory.getConnection(properties);
+        dropCreateTestSchema();
 
-        defineUDFTimesTwo(engine);
+        final Properties otherProperties = (Properties) properties.clone();
+        otherProperties.setProperty(SCHEMA, getTestSchema());
 
-        List<Map<String, ResultColumn>> query = engine.query(select(udf("TimesTwo", k(10)).alias("TIMESTWO")));
-        assertEquals("result ok?", 20, (int) query.get(0).get("TIMESTWO").toInt());
+        // engine using the defined test schema
+        try (final DatabaseEngine engine = DatabaseFactory.getConnection(otherProperties)) {
+            defineUDFTimesTwo(engine);
+
+            final List<Map<String, ResultColumn>> query = engine.query(select(udf("TimesTwo", k(10)).alias("TIMESTWO")));
+            assertEquals("result ok?", 20, (int) query.get(0).get("TIMESTWO").toInt());
+        }
     }
 
     /**
@@ -410,16 +420,13 @@ public abstract class AbstractEngineSchemaTest {
      * @param columnValue The column value.
      */
     protected void testPersistSpecialValues(final Object columnValue) throws DatabaseEngineException, DatabaseFactoryException {
-        final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
-
-        try {
+        try (final DatabaseEngine engine = DatabaseFactory.getConnection(properties)) {
             final DbEntity entity = createSpecialValuesEntity();
             engine.addEntity(entity);
+
             final EntityEntry entry = createSpecialValueEntry(columnValue);
             engine.persist(entity.getName(), entry);
             checkResult(engine, entity.getName(), columnValue);
-        } finally {
-            engine.close();
         }
     }
 
@@ -583,6 +590,101 @@ public abstract class AbstractEngineSchemaTest {
     }
 
     /**
+     * Tests that an entity can be created/dropped/checked in different schemas without conflicts, and the operation
+     * works as expected.
+     *
+     * @throws DatabaseEngineException  If anything goes wrong with database operations.
+     * @throws DatabaseFactoryException If anything goes wrong connecting to the database.
+     * @since 2.1.13
+     */
+    @Test
+    public void testCreateSameEntityDifferentSchemas() throws DatabaseEngineException, DatabaseFactoryException {
+        assertNotEquals("Other 'test schema' and original schema should be different", config.schema, getTestSchema());
+
+        final DbEntity entity = dbEntity()
+            .name("TEST1")
+            .addColumn("COL1", INT)
+            .pkFields("COL1")
+            .build();
+
+        final DbEntity otherEntity = dbEntity()
+            .name("TEST2")
+            .addColumn("COL1", INT)
+            .pkFields("COL1")
+            .build();
+
+        dropCreateTestSchema();
+
+        final Properties otherProperties = (Properties) properties.clone();
+        otherProperties.setProperty(SCHEMA, getTestSchema());
+
+        try (final DatabaseEngine originalEngine = DatabaseFactory.getConnection(properties);
+             final DatabaseEngine otherEngine = DatabaseFactory.getConnection(otherProperties)) {
+            originalEngine.dropEntity(entity);
+            originalEngine.dropEntity(otherEntity);
+
+            checkEntity("* Asserting test1 table is not present in any schema...",
+                entity, originalEngine, otherEngine, false, false);
+
+            originalEngine.addEntity(entity);
+            checkEntity("* Created test1 table in original schema - asserting it is there and not in the other schema...",
+                entity, originalEngine, otherEngine, true, false);
+
+            otherEngine.addEntity(entity);
+            checkEntity("* Created test1 table in other schema - asserting it is there and still is in the original schema...",
+                entity, originalEngine, otherEngine, true, true);
+
+            otherEngine.addEntity(otherEntity);
+            checkEntity("* Created test2 table in other schema - asserting it is there and not in the original schema...",
+                otherEntity, originalEngine, otherEngine, false, true);
+
+            otherEngine.dropEntity(entity);
+            checkEntity("* Dropped test1 table in other schema - asserting it is not there, but is still in the original schema...",
+                entity, originalEngine, otherEngine, true, false);
+
+            originalEngine.dropEntity(entity);
+            checkEntity("* Dropped test1 table in original schema - asserting it is not present in any schema...",
+                entity, originalEngine, otherEngine, false, false);
+        }
+    }
+
+    private static void checkEntity(final String reasonMessage, final DbEntity entity,
+                                    final DatabaseEngine originalEngine,
+                                    final DatabaseEngine otherEngine,
+                                    final boolean isPresentOriginal,
+                                    final boolean isPresentOther) throws DatabaseEngineException {
+        final String name = entity.getName();
+
+        assertEquals(
+            String.format("%s\n--> Metadata for table '%s' should%s be present in original schema.",
+                reasonMessage, name, isPresentOriginal ? "" : " not"),
+            isPresentOriginal ? 1 : 0,
+            originalEngine.getMetadata(name).size()
+        );
+
+        assertEquals(
+            String.format("%s\n--> Table '%s' should%s be present in original schema.",
+                reasonMessage, name, isPresentOriginal ? "" : " not"),
+            isPresentOriginal,
+            originalEngine.getEntities().containsKey(name)
+        );
+
+        assertEquals(
+            String.format("%s\n--> Metadata for table '%s' should%s be present in other schema.",
+                reasonMessage, name, isPresentOther ? "" : " not"),
+            isPresentOther ? 1 : 0,
+            otherEngine.getMetadata(name).size()
+        );
+
+        assertEquals(
+            String.format("%s\n--> Table '%s' should%s be present in other schema.",
+                reasonMessage, name, isPresentOther ? "" : " not"),
+            isPresentOther,
+            otherEngine.getEntities().containsKey(name)
+        );
+    }
+
+    /**
      * Auxiliary method that checks that the inserted value is indeed the provided column value.
      *
      * @param engine      The database engine.
@@ -639,9 +741,60 @@ public abstract class AbstractEngineSchemaTest {
                 .build();
     }
 
-    protected void defineUDFGetOne(DatabaseEngine engine) throws DatabaseEngineException {
+    /**
+     * Defines the UDF "GetOne" in the database engine.
+     *
+     * @param engine The database engine.
+     * @throws DatabaseEngineException If anything goes wrong creating the UDF.
+     */
+    protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
     }
 
-    protected void defineUDFTimesTwo(DatabaseEngine engine) throws DatabaseEngineException {
+    /**
+     * Defines the UDF "TimesTwo" in the database engine.
+     *
+     * This UDF is supposed to be created in the {@link #getTestSchema() test schema} (if the database supports it).
+     *
+     * @param engine The database engine.
+     * @throws DatabaseEngineException If anything goes wrong creating the UDF.
+     */
+    protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
     }
+
+    /**
+     * Creates the {@link #getTestSchema() test schema} in the database, dropping it first if necessary.
+     *
+     * @throws DatabaseEngineException  If anything goes wrong creating the schema.
+     * @throws DatabaseFactoryException If anything goes wrong connecting to the database.
+     * @since 2.1.13
+     */
+    public void dropCreateTestSchema() throws DatabaseEngineException, DatabaseFactoryException {
+        try (final DatabaseEngine engine = DatabaseFactory.getConnection(properties)) {
+            dropSchema(engine, getTestSchema());
+            createSchema(engine, getTestSchema());
+        }
+    }
+
+    /**
+     * Creates a schema in the database.
+     *
+     * This method is expected to create the necessary permissions for the current user and/or the user associated
+     * with the schema to login and create tables in it.
+     *
+     * @param engine The database engine.
+     * @param schema The schema to create.
+     * @throws DatabaseEngineException If anything goes wrong creating the schema.
+     * @since 2.1.13
+     */
+    protected abstract void createSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException;
+
+    /**
+     * Drops a schema from the database (won't fail if schema doesn't exist or if it isn't empty).
+     *
+     * @param engine The database engine.
+     * @param schema The schema to drop.
+     * @throws DatabaseEngineException If anything goes wrong dropping the schema.
+     * @since 2.1.13
+     */
+    protected abstract void dropSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException;
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -105,7 +105,7 @@ public class BatchUpdateTest {
     }
 
     @Before
-    public void init() throws DatabaseEngineException, DatabaseFactoryException {
+    public void init() throws DatabaseFactoryException {
         properties = new Properties() {
 
             {

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineIsolationTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineIsolationTest.java
@@ -15,7 +15,6 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
@@ -52,7 +51,7 @@ public class EngineIsolationTest {
     public DatabaseConfiguration config;
 
     @Before
-    public void init() throws DatabaseEngineException {
+    public void init() {
         this.properties = new Properties() {
             {
                 setProperty(JDBC, config.jdbc);
@@ -65,25 +64,25 @@ public class EngineIsolationTest {
     }
 
     @Test
-    public void readCommittedTest() throws DatabaseEngineException, InterruptedException, DatabaseFactoryException {
+    public void readCommittedTest() throws DatabaseFactoryException {
         properties.setProperty(ISOLATION_LEVEL, "read_committed");
         DatabaseFactory.getConnection(properties);
     }
 
     @Test
-    public void readUncommittedTest() throws DatabaseEngineException, InterruptedException, DatabaseFactoryException {
+    public void readUncommittedTest() throws DatabaseFactoryException {
         this.properties.setProperty(ISOLATION_LEVEL, "read_uncommitted");
         DatabaseFactory.getConnection(properties);
     }
 
     @Test
-    public void repeatableReadTest() throws DatabaseEngineException, InterruptedException, DatabaseFactoryException {
+    public void repeatableReadTest() throws DatabaseFactoryException {
         this.properties.setProperty(ISOLATION_LEVEL, "read_uncommitted");
         DatabaseFactory.getConnection(properties);
     }
 
     @Test
-    public void serializableTest() throws DatabaseEngineException, InterruptedException, DatabaseFactoryException {
+    public void serializableTest() throws DatabaseFactoryException {
         this.properties.setProperty(ISOLATION_LEVEL, "read_uncommitted");
         DatabaseFactory.getConnection(properties);
     }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/LongOverflowTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/LongOverflowTest.java
@@ -22,7 +22,6 @@ import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
@@ -64,7 +63,7 @@ public class LongOverflowTest {
     /*
      * Test table name and columns.
      */
-    private static String TEST_TABLE = "TEST_OVFL_TBL";
+    private static final String TEST_TABLE = "TEST_OVFL_TBL";
     private static final String PK_COL = "PK_COL";
     private static final String LONG_COL = "LONG_COL";
     private static final String DBL_COL_1 = "DBL_COL_1";
@@ -140,7 +139,7 @@ public class LongOverflowTest {
      * Scenario for an insert using persist().
      */
     @Test
-    public void testLongOverflowNormal() throws DatabaseFactoryException, DatabaseEngineException {
+    public void testLongOverflowNormal() throws DatabaseEngineException {
         dbEngine.persist(TEST_TABLE, getTestEntry());
         dbEngine.commit();
         checkInsertedValue();
@@ -191,7 +190,7 @@ public class LongOverflowTest {
      * Scenario for an insert using batch updates.
      */
     @Test
-    public void testLongOverflowBatch() throws DatabaseFactoryException, DatabaseEngineException {
+    public void testLongOverflowBatch() throws DatabaseEngineException {
         dbEngine.addBatch(TEST_TABLE, getTestEntry());
         dbEngine.flush();
         dbEngine.commit();
@@ -227,7 +226,7 @@ public class LongOverflowTest {
     }
 
     @After
-    public void cleanup() throws DatabaseEngineException {
+    public void cleanup() {
         dbEngine.close();
     }
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/UnderflowTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/UnderflowTest.java
@@ -22,7 +22,6 @@ import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
@@ -65,7 +64,7 @@ public class UnderflowTest {
     /*
      * Test table properties, a table with a PK and two double columns.
      */
-    private static String TEST_TABLE = "TEST_TBL";
+    private static final String TEST_TABLE = "TEST_TBL";
     private static final String PK_COL = "PK_COL";
     private static final String ERROR_COL = "ERROR_COL";
     private static final String NORMAL_COL = "VALUE_COL";
@@ -123,7 +122,7 @@ public class UnderflowTest {
      * Scenario for an insert using persist().
      */
     @Test
-    public void testUnderflowNormal() throws DatabaseFactoryException, DatabaseEngineException {
+    public void testUnderflowNormal() throws DatabaseEngineException {
         dbEngine.beginTransaction();
         dbEngine.persist(TEST_TABLE, getTestEntry());
         dbEngine.commit();
@@ -174,7 +173,7 @@ public class UnderflowTest {
      * Scenario for an insert using batch updates.
      */
     @Test
-    public void testUnderflowBatch() throws DatabaseFactoryException, DatabaseEngineException {
+    public void testUnderflowBatch() throws DatabaseEngineException {
         dbEngine.beginTransaction();
         dbEngine.addBatch(TEST_TABLE, getTestEntry());
         dbEngine.flush();
@@ -209,7 +208,7 @@ public class UnderflowTest {
     }
 
     @After
-    public void cleanup() throws DatabaseEngineException {
+    public void cleanup() {
         dbEngine.close();
     }
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/db2/DB2EngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/db2/DB2EngineSchemaTest.java
@@ -16,15 +16,18 @@
 package com.feedzai.commons.sql.abstraction.engine.impl.db2;
 
 
+import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Joao Silva (joao.silva@feedzai.com)
@@ -33,33 +36,63 @@ import java.util.Collection;
 @RunWith(Parameterized.class)
 public class DB2EngineSchemaTest extends AbstractEngineSchemaTest {
 
-
     @Parameterized.Parameters
     public static Collection<DatabaseConfiguration> data() throws Exception {
         return DatabaseTestUtil.loadConfigurations("db2");
     }
 
-    protected String getDefaultSchema() {
-        return config.username;
+    @Override
+    protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
+        engine.executeUpdate(
+            "CREATE OR REPLACE FUNCTION GETONE () " +
+            "    RETURNS INTEGER " +
+            "    NO EXTERNAL ACTION " +
+            "F1: BEGIN ATOMIC " +
+                "RETURN 1; " +
+            "END"
+        );
     }
 
-    /*
-     * TODO: remove after creating UDFs for DB2
-     * http://newpush.com/2009/08/creating-a-user-defined-function-udf-in-java-for-ibm-db2-9-7/
-     */
     @Override
-    @Test
-    @Ignore("Test suite doesn't have UDFs for DB2")
-    public void udfGetOneTest() throws Exception {
+    protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
+        engine.executeUpdate(
+            "CREATE OR REPLACE FUNCTION \"" + getTestSchema() + "\".TimesTwo (VARNAME VARCHAR(128)) " +
+            "    RETURNS INTEGER " +
+            "    NO EXTERNAL ACTION " +
+            "F1: BEGIN ATOMIC " +
+            "    RETURN VARNAME * 2; " +
+            "END"
+        );
     }
 
-    /*
-     * TODO: remove after creating UDFs for DB2
-     * http://newpush.com/2009/08/creating-a-user-defined-function-udf-in-java-for-ibm-db2-9-7/
-     */
     @Override
-    @Test
-    @Ignore("Test suite doesn't have UDFs for DB2")
-    public void udfTimesTwoTest() throws Exception {
+    protected void createSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
+        engine.executeUpdate("CREATE SCHEMA \"" + schema + "\"");
+    }
+
+    @Override
+    protected void dropSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
+        final List<Map<String, ResultColumn>> tableResults = engine.query(
+            "SELECT tabname FROM syscat.tables WHERE tabschema='" + schema + "'"
+        );
+
+        for (final Map<String, ResultColumn> table : tableResults) {
+            engine.executeUpdate("DROP TABLE \"" + schema + "\".\"" + table.get("TABNAME") + "\"");
+        }
+
+        final List<Map<String, ResultColumn>> funcResults = engine.query(
+            "SELECT funcname FROM syscat.functions WHERE funcschema='" + schema + "'"
+        );
+
+        for (final Map<String, ResultColumn> result : funcResults) {
+            engine.executeUpdate("DROP FUNCTION \"" + schema + "\".\"" + result.get("FUNCNAME") + "\"");
+        }
+
+        engine.executeUpdate(
+                "BEGIN\n" +
+                "   DECLARE CONTINUE HANDLER FOR SQLSTATE '42704' BEGIN END;\n" +
+                "   EXECUTE IMMEDIATE 'DROP SCHEMA \"" + schema + "\" RESTRICT';\n" +
+                "END"
+        );
     }
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/BatchConnectionRetryTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/BatchConnectionRetryTest.java
@@ -82,7 +82,7 @@ public class BatchConnectionRetryTest {
     private BatchEntry[] failureResults = null;
 
     @Before
-    public void init() throws DatabaseEngineException, DatabaseFactoryException {
+    public void init() throws DatabaseFactoryException {
         Properties properties = new Properties() {
 
             {
@@ -165,7 +165,7 @@ public class BatchConnectionRetryTest {
         // 2. force an error disallowing the connection to be fetched
         try {
             engineCapsule.get().getConnection().close();
-        } catch (Exception e) {
+        } catch (final Exception e) {
         }
         // disallow new connections to force to exhaust the retry mechanism
         allowConnection.set(false);

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/H2EngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/H2EngineSchemaTest.java
@@ -40,24 +40,32 @@ public class H2EngineSchemaTest extends AbstractEngineSchemaTest {
     }
 
     @Override
-    protected String getSchema() {
-        return "myschema";
-    }
-
-    @Override
     protected Ieee754Support getIeee754Support() {
         return SUPPORTED_STRINGS;
     }
 
     @Override
-    protected void defineUDFGetOne(DatabaseEngine engine) throws DatabaseEngineException {
-        engine.executeUpdate("CREATE ALIAS IF NOT EXISTS GetOne FOR \"com.feedzai.commons.sql.abstraction.engine.impl.h2.H2EngineSchemaTest.GetOne\";");
+    protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
+        engine.executeUpdate(
+            "CREATE ALIAS IF NOT EXISTS GetOne FOR \"com.feedzai.commons.sql.abstraction.engine.impl.h2.H2EngineSchemaTest.GetOne\";"
+        );
     }
 
     @Override
-    protected void defineUDFTimesTwo(DatabaseEngine engine) throws DatabaseEngineException {
-        engine.executeUpdate("CREATE SCHEMA IF NOT EXISTS " + getSchema());
-        engine.executeUpdate("CREATE ALIAS IF NOT EXISTS " + getSchema() + ".TimesTwo FOR \"com.feedzai.commons.sql.abstraction.engine.impl.h2.H2EngineSchemaTest.TimesTwo\";");
+    protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
+        engine.executeUpdate(
+            "CREATE ALIAS IF NOT EXISTS \"" + getTestSchema() + "\".TimesTwo FOR \"com.feedzai.commons.sql.abstraction.engine.impl.h2.H2EngineSchemaTest.TimesTwo\";"
+        );
+    }
+
+    @Override
+    protected void createSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
+        engine.executeUpdate("CREATE SCHEMA IF NOT EXISTS \"" + schema + "\"");
+    }
+
+    @Override
+    protected void dropSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
+        engine.executeUpdate("DROP SCHEMA IF EXISTS \"" + schema + "\" CASCADE");
     }
 
     public static int GetOne() {

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/NotifyOnFailureTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/NotifyOnFailureTest.java
@@ -75,7 +75,7 @@ public class NotifyOnFailureTest {
     private BatchEntry[] failureResults = null;
 
     @Before
-    public void init() throws DatabaseEngineException, DatabaseFactoryException {
+    public void init() throws DatabaseFactoryException {
         properties = new Properties() {
 
             {

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/mysql/MySqlEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/mysql/MySqlEngineSchemaTest.java
@@ -38,30 +38,32 @@ public class MySqlEngineSchemaTest extends AbstractEngineSchemaTest {
     }
 
     @Override
-    protected String getSchema() {
-        return "myschema";
-    }
-
-    @Override
-    protected void defineUDFGetOne(DatabaseEngine engine) throws DatabaseEngineException {
+    protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate("DROP FUNCTION IF EXISTS GetOne");
         engine.executeUpdate(
-            "CREATE FUNCTION GetOne()\n" +
-                "   RETURNS INTEGER\n" +
-                "   RETURN 1;"
+            "CREATE FUNCTION GetOne() " +
+            "RETURNS INTEGER " +
+            "RETURN 1;"
         );
     }
 
     @Override
-    protected void defineUDFTimesTwo(DatabaseEngine engine) throws DatabaseEngineException {
-        engine.executeUpdate("DROP SCHEMA IF EXISTS myschema");
-        engine.executeUpdate("CREATE SCHEMA myschema");
-
-        engine.executeUpdate("DROP FUNCTION IF EXISTS myschema.TimesTwo");
+    protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
+        engine.executeUpdate("DROP FUNCTION IF EXISTS " + getTestSchema() + ".TimesTwo");
         engine.executeUpdate(
-            "CREATE FUNCTION myschema.TimesTwo(number INT)\n" +
-                "   RETURNS INTEGER\n" +
-                "   RETURN number * 2;"
+            "CREATE FUNCTION " + getTestSchema() + ".TimesTwo(number INT) " +
+            "RETURNS INTEGER " +
+            "RETURN number * 2;"
         );
+    }
+
+    @Override
+    protected void createSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
+        engine.executeUpdate("CREATE SCHEMA IF NOT EXISTS " + schema);
+    }
+
+    @Override
+    protected void dropSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
+        engine.executeUpdate("DROP SCHEMA IF EXISTS " + schema);
     }
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/postgresql/PostgreSqlEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/postgresql/PostgreSqlEngineSchemaTest.java
@@ -15,7 +15,6 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.postgresql;
 
-
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest;
@@ -35,15 +34,9 @@ import static com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngine
 @RunWith(Parameterized.class)
 public class PostgreSqlEngineSchemaTest extends AbstractEngineSchemaTest {
 
-
     @Parameterized.Parameters
     public static Collection<DatabaseConfiguration> data() throws Exception {
         return DatabaseTestUtil.loadConfigurations("postgresql");
-    }
-
-    @Override
-    protected String getSchema() {
-        return "myschema";
     }
 
     @Override
@@ -52,25 +45,33 @@ public class PostgreSqlEngineSchemaTest extends AbstractEngineSchemaTest {
     }
 
     @Override
-    protected void defineUDFGetOne(DatabaseEngine engine) throws DatabaseEngineException {
+    protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate(
-            "CREATE OR REPLACE FUNCTION GetOne()\n" +
-                "    RETURNS INTEGER\n" +
-                "    AS 'SELECT 1;'\n" +
-                "    LANGUAGE SQL;"
+            "CREATE OR REPLACE FUNCTION GetOne() " +
+            "RETURNS INTEGER " +
+            "AS 'SELECT 1;' " +
+            "LANGUAGE SQL;"
         );
     }
 
     @Override
-    protected void defineUDFTimesTwo(DatabaseEngine engine) throws DatabaseEngineException {
-        engine.executeUpdate("DROP SCHEMA IF EXISTS myschema CASCADE");
-        engine.executeUpdate("CREATE SCHEMA myschema");
-
+    protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate(
-            "    CREATE OR REPLACE FUNCTION myschema.TimesTwo(INTEGER)\n" +
-                "    RETURNS INTEGER\n" +
-                "    AS 'SELECT $1 * 2;'\n" +
-                "    LANGUAGE SQL;\n"
+            "CREATE OR REPLACE FUNCTION \"" + getTestSchema() + "\".TimesTwo(INTEGER) " +
+            "RETURNS INTEGER " +
+            "AS 'SELECT $1 * 2;' " +
+            "LANGUAGE SQL;"
         );
+    }
+
+    @Override
+    protected void createSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
+        engine.executeUpdate("CREATE SCHEMA IF NOT EXISTS \"" + schema + "\"");
+
+    }
+
+    @Override
+    protected void dropSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
+        engine.executeUpdate("DROP SCHEMA IF EXISTS \"" + schema + "\" CASCADE");
     }
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineGeneralTest.java
@@ -85,7 +85,7 @@ public class SqlServerEngineGeneralTest {
     public DatabaseConfiguration config;
 
     @Before
-    public void init() throws DatabaseEngineException, DatabaseFactoryException {
+    public void init() throws DatabaseFactoryException {
         properties = new Properties() {
 
             {

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineSchemaTest.java
@@ -20,6 +20,8 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -39,48 +41,60 @@ public class SqlServerEngineSchemaTest extends AbstractEngineSchemaTest {
     }
 
     @Override
-    protected String getDefaultSchema() {
-        return "dbo";
+    @Test
+    @Ignore("Microsoft Sql Server doesn't support setting schema per session")
+    public void udfTimesTwoTest() {
     }
 
     @Override
-    protected String getSchema() {
-        return "myschema";
+    @Test
+    @Ignore("Microsoft Sql Server doesn't support setting schema per session")
+    public void testCreateSameEntityDifferentSchemas() {
     }
 
     @Override
     protected void defineUDFGetOne(DatabaseEngine engine) throws DatabaseEngineException {
-        engine.executeUpdate("IF OBJECT_ID (N'dbo.GetOne', N'FN') IS NOT NULL\n" +
-            "    DROP FUNCTION dbo.GetOne");
         engine.executeUpdate(
-            "CREATE FUNCTION dbo.GetOne()\n" +
-                "RETURNS INTEGER\n" +
-                "AS\n" +
-                "BEGIN\n" +
-                "  RETURN(1)\n" +
-                "END"
+            "IF OBJECT_ID (N'GetOne', N'FN') IS NOT NULL " +
+            "    DROP FUNCTION GetOne"
+        );
+
+        engine.executeUpdate(
+            "CREATE FUNCTION GetOne() " +
+            "RETURNS INTEGER " +
+            "AS " +
+            "BEGIN " +
+            "    RETURN(1) " +
+            "END"
         );
     }
 
     @Override
     protected void defineUDFTimesTwo(DatabaseEngine engine) throws DatabaseEngineException {
-        engine.executeUpdate("IF EXISTS (SELECT * FROM sys.schemas WHERE name = N'myschema')\n" +
-            "BEGIN\n" +
-            "   IF OBJECT_ID (N'myschema.TimesTwo', N'FN') IS NOT NULL\n" +
-            "   BEGIN\n" +
-            "       DROP FUNCTION myschema.TimesTwo;\n" +
-            "   END\n" +
-            "   DROP SCHEMA myschema;\n" +
-            "END");
-        engine.executeUpdate("CREATE SCHEMA myschema");
+        engine.executeUpdate(
+            "IF OBJECT_ID (N'" + getTestSchema() + ".TimesTwo', N'FN') IS NOT NULL " +
+            "BEGIN " +
+            "    DROP FUNCTION " + getTestSchema() + ".TimesTwo;" +
+            "END"
+        );
 
         engine.executeUpdate(
-            "CREATE FUNCTION myschema.TimesTwo(@number INTEGER)\n" +
-                "RETURNS INTEGER\n" +
-                "AS\n" +
-                "BEGIN\n" +
-                "  RETURN(@number * 2)\n" +
-                "END\n"
+            "CREATE FUNCTION " + getTestSchema() + ".TimesTwo(@number INTEGER) " +
+            "RETURNS INTEGER " +
+            "AS " +
+            "BEGIN " +
+            "    RETURN(@number * 2) " +
+            "END"
         );
+    }
+
+    @Override
+    protected void createSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
+        engine.executeUpdate("CREATE SCHEMA " + schema);
+    }
+
+    @Override
+    protected void dropSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
+        engine.executeUpdate("DROP SCHEMA " + schema);
     }
 }

--- a/src/test/resources/connections.properties
+++ b/src/test/resources/connections.properties
@@ -8,13 +8,12 @@ h2.password=pdb
 
 mysql.engine=com.feedzai.commons.sql.abstraction.engine.impl.MySqlEngine
 mysql.jdbc=jdbc:mysql://localhost:3306/mysql?useSSL=false
-# appended "useSSL=false" to jdbc url to avoid a warning about not using SSL
+# appended "useSSL=false" to jdbc url to avoid a warning about not using SSL;
 # for mysql, schema and database is the same thing
 # default database/schema: none, it must be specified either in jdbc url or in schema property
-## currently must always be specified in jdbc, because PDB ignores schema property for mysql
-# used in jdbc url: jdbc:mysql://localhost:3306/mysql
+# example when used in jdbc url: jdbc:mysql://localhost:3306/mysql
 mysql.username=root
-mysql.password=my-secret-pw
+mysql.password=AaBb12.#
 #mysql.schema=mysql
 
 
@@ -23,7 +22,7 @@ sqlserver.jdbc=jdbc:sqlserver://localhost:1433
 # default database: master
 # used in jdbc url: jdbc:sqlserver://localhost:1433;databaseName=master
 sqlserver.username=sa
-sqlserver.password=AAaa11!!
+sqlserver.password=AaBb12.#
 #sqlserver.schema=dbo
 
 
@@ -31,22 +30,24 @@ postgresql.engine=com.feedzai.commons.sql.abstraction.engine.impl.PostgreSqlEngi
 postgresql.jdbc=jdbc:postgresql://localhost:5432/postgres
 # default database: postgres is used because it's mandatory in jdbc url and it's the only one in the test server
 postgresql.username=postgres
-postgresql.password=pgpassword
+postgresql.password=AaBb12.#
 #postgresql.schema=public
 
 
 oracle.engine=com.feedzai.commons.sql.abstraction.engine.impl.OracleEngine
 oracle.jdbc=jdbc:oracle:thin:@(DESCRIPTION=(ENABLE=broken)(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521)))(CONNECT_DATA=(SID=orcl)))
+# alternate short jdbc URL = jdbc:oracle:thin:@localhost:1521:orcl
 # default database: orcl is used because it's mandatory in jdbc url and it's the only one in the test server
 oracle.username=system
 oracle.password=admin
 # for oracle, default schema is the same as user name
-#oracle.schema=oracle
+#oracle.schema=system
 
 
 db2.engine=com.feedzai.commons.sql.abstraction.engine.impl.DB2Engine
 db2.jdbc=jdbc:db2://localhost:50000/testdb
 # default database: testdb is used because it's mandatory in jdbc url and it's the only one in the test server
 db2.username=db2inst1
-db2.password=db2inst1-pwd
-db2.schema=testschema
+db2.password=AaBb12.#
+# for DB2, default schema is the same as user name
+#db2.schema=db2inst1

--- a/src/test/resources/udfs/oracle.sql
+++ b/src/test/resources/udfs/oracle.sql
@@ -1,5 +1,5 @@
 --
--- the following statements must be run separetely
+-- the following statements must be run separately
 --
 
 CREATE OR REPLACE FUNCTION GetOne
@@ -17,7 +17,7 @@ END GetOne;
 -- 1
 --
 
-CREATE OR REPLACE FUNCTION TimesTwo (n IN INTEGER)
+CREATE OR REPLACE FUNCTION myschema.TimesTwo (n IN INTEGER)
 RETURN INTEGER
 AS
 BEGIN
@@ -26,7 +26,7 @@ END TimesTwo;
 
 --
 -- Query:
--- SELECT TimesTwo(10) FROM dual;
+-- SELECT myschema.TimesTwo(10) FROM dual;
 --
 -- Output:
 -- 20

--- a/src/test/resources/udfs/sqlserver.sql
+++ b/src/test/resources/udfs/sqlserver.sql
@@ -1,12 +1,11 @@
 USE [pdb]
 GO
 
-IF OBJECT_ID (N'dbo.GetOne', N'FN') IS NOT NULL
-    DROP FUNCTION dbo.GetOne;
+IF OBJECT_ID (N'GetOne', N'FN') IS NOT NULL
+    DROP FUNCTION GetOne;
 GO
 
--- sqlserver always requires a schema
-CREATE FUNCTION dbo.GetOne()
+CREATE FUNCTION GetOne()
 RETURNS INTEGER
 AS
 BEGIN
@@ -15,7 +14,7 @@ END
 GO
 
 --
--- Query:
+-- Query (sqlserver always requires a schema when calling functions):
 -- SELECT dbo.GetOne();
 --
 -- Output:
@@ -44,7 +43,7 @@ END
 GO
 
 --
--- Query:
+-- Query (sqlserver always requires a schema when calling functions):
 -- SELECT myschema.TimesTwo(10);
 --
 -- Output:


### PR DESCRIPTION
This addresses PULSEDEV-23140, where Oracle engine had some problems when schema property was defined and was different from the user, and all other engines weren't respecting the schema property at all.

The tests were updated accordingly.