### PR TITLE
fixes #82 - Fix connection bug and add test profile for H2 remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Run the following to run the tests for the chosen vendor **specified in lowercas
 ```bash
 mvn test -P<vendor>
 ```
+_NOTE_: there is also a "special" profile for H2 to test that engine in server mode (instead of the default H2 embedded);
+ for that case the profile `h2remote` is used in the `<vendor>` placeholder.    
+
 This will start a docker container running the chosen vendor's database server, and run the tests.
 The container will be stopped at the end if all tests pass, otherwise will be kept running.
 

--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,61 @@
 
     <profiles>
         <profile>
+            <id>h2remote</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <instances>h2remote</instances>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
+                        <executions>
+                            <execution>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <!-- automatically creates the classpath using all project dependencies,
+                                     also adding the project build directory -->
+                                <classpath/>
+                                <argument>org.h2.tools.Server</argument>
+                                <!-- make db available via tcp -->
+                                <argument>-tcp</argument>
+                                <!-- set local file inside test output directory -->
+                                <argument>-baseDir</argument>
+                                <argument>${project.build.testOutputDirectory}/pdb-h2-remote</argument>
+                            </arguments>
+                            <async>true</async>
+                            <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>mysql</id>
             <build>
                 <plugins>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -678,9 +678,8 @@ public class H2Engine extends AbstractDatabaseEngine {
         } catch (final Exception ex) {
             if (ex instanceof SQLException && OPTIONAL_FEATURE_NOT_SUPPORTED.equals(((SQLException) ex).getSQLState())) {
                 // if connection is remote, getSchema() may not be supported; try again
-                try (final PreparedStatement ps = conn.prepareStatement("SET SCHEMA ?")) {
-                    ps.setString(1, schema);
-                    ps.execute();
+                try (final Statement stmt = conn.createStatement()) {
+                    stmt.execute("SET SCHEMA " + quotize(schema));
                     return;
 
                 } catch (final Exception queryEx) {

--- a/src/test/resources/connections.properties
+++ b/src/test/resources/connections.properties
@@ -5,6 +5,11 @@ h2.jdbc=jdbc:h2:./target/pdb
 h2.username=pdb
 h2.password=pdb
 
+h2remote.engine=com.feedzai.commons.sql.abstraction.engine.impl.H2Engine
+h2remote.jdbc=jdbc:h2:tcp://localhost:9092/public
+h2remote.username=sa
+h2remote.password=sa
+
 
 mysql.engine=com.feedzai.commons.sql.abstraction.engine.impl.MySqlEngine
 mysql.jdbc=jdbc:mysql://localhost:3306/mysql?useSSL=false


### PR DESCRIPTION
Summary:
H2 remote, for some reason, doesn't support the JDBC methods getSchema()
 and setSchema(String).

This was known in the last commit to make PDB use schmema property, so
 getSchema() got replaced with a query when the connection is H2 remote.
The same was done for setSchema, but the query used a PreparedStatement
 to replace the schema identifier, which is not allowed (PreparedStatements
 replace values only).
This commit replaces the PreparedStatement with a normal Statement.

DB2 is also using a PreparedStatement to set schema, but it works with
 that engine, so nothing was changed there.

This commit fixes the problem in H2 remote and adds a new 'h2remote' profile.