### PR TITLE
fixes #86 - Fix Oracle and MySql engines to return correct results in getMetadata and getEntities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
                 <version>4.12</version>
             </dependency>
             <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.10.0</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>18.0</version>
@@ -159,10 +164,15 @@
             <artifactId>jmockit</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Junit -->
+        <!-- Junit + AssertJ -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Guava -->

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -1288,13 +1288,13 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
             getConnection();
 
             // get the entities
-            rs = conn.getMetaData().getTables(null, schemaPattern, "%", null);
+            rs = this.conn.getMetaData().getTables(null, schemaPattern, "%", null);
 
             while (rs.next()) {
-                String entityName = rs.getString("table_name");
-                String entityType = rs.getString("table_type");
+                final String entityName = rs.getString("table_name");
+                final String entityType = rs.getString("table_type");
 
-                DbEntityType type;
+                final DbEntityType type;
 
                 // tag the entities
                 if ("TABLE".equals(entityType)) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -944,7 +944,8 @@ public class OracleEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    public synchronized Map<String, DbColumnType> getMetadata(final String name) throws DatabaseEngineException {
+    public synchronized Map<String, DbColumnType> getMetadata(final String schemaPattern,
+                                                              final String tableNamePattern) throws DatabaseEngineException {
 
         final Map<String, DbColumnType> metaMap = new LinkedHashMap<>();
         Statement s = null;
@@ -955,8 +956,8 @@ public class OracleEngine extends AbstractDatabaseEngine {
             s = conn.createStatement();
             rsColumns = s.executeQuery(format(
                 "SELECT COLUMN_NAME, DATA_TYPE, DATA_PRECISION FROM ALL_TAB_COLS WHERE TABLE_NAME = '%s' AND OWNER = '%s'",
-                name,
-                this.currentSchema
+                    tableNamePattern,
+                    schemaPattern
             ));
 
             while (rsColumns.next()) {


### PR DESCRIPTION
Summary:
MySql - just like getMetadata, the getEntities method also has a "schema"
parameter which is ignored since for this DB engine the "catalog" is
considered the schema - this commit puts the schema value in the
  "catalog" parameter.

Oracle - the method getMetadata(String name) was overriding the same
method in AbstractDatabaseEngine, when the method
  getMetadata(String schemaPattern, String tableNamePattern)
should have been overridden instead (otherwise it would only work for
the current schema) - this commit makes that change.

The tests were also changed to verify that these methods are working
as expected.