### PR TITLE
Support for String Aggregation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ results = engine.query(
 |[sum]|Aggregation operator for numeric values. They are applicable to expression involving columns.|
 |[avg]|Aggregation operator for numeric values. They are applicable to expression involving columns.|
 |[stddev]|Aggregation operator for numeric values. They are applicable to expression involving columns.|
+|[stringAgg]|Aggregation operator that aggregates data of a column into a string.|
 |[udf]|If you have defined your own sql function you may access it with udf.|
 [alias]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/Expression.html#alias(java.lang.String)
 [count]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#count(com.feedzai.commons.sql.abstraction.dml.Expression)
@@ -684,6 +685,7 @@ results = engine.query(
 [sum]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#sum(com.feedzai.commons.sql.abstraction.dml.Expression)
 [avg]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#avg(com.feedzai.commons.sql.abstraction.dml.Expression)
 [stddev]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#stddev(com.feedzai.commons.sql.abstraction.dml.Expression)
+[stringAgg]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#stringAgg(com.feedzai.commons.sql.abstraction.dml.Expression)
 [udf]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#udf(java.lang.String,%20com.feedzai.commons.sql.abstraction.dml.Expression)
 
 Sometimes it is required to merge the content of more than one table.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
@@ -8,10 +8,6 @@
  */
 package com.feedzai.commons.sql.abstraction.dml;
 
-import com.google.inject.Injector;
-
-import javax.inject.Inject;
-
 /**
  * @author Francisco Santos (francisco.santos@feedzai.com)
  * @since 2.2.3
@@ -28,11 +24,10 @@ public class StringAgg extends Expression {
      */
     private char delimiter;
 
-
     /**
      * Is it distinct.
      */
-    private boolean distinct;
+    private String distinct;
 
     /**
      * @param column column to be aggregated.
@@ -40,6 +35,7 @@ public class StringAgg extends Expression {
     private StringAgg(final Expression column) {
         this.column = column;
         this.delimiter = ',';
+        this.distinct = "";
     }
 
     /**
@@ -75,7 +71,7 @@ public class StringAgg extends Expression {
      *
      * @return if it should apply DISTINCT.
      */
-    public boolean isDistinct() {
+    public String getDistinct() {
         return distinct;
     }
 
@@ -89,8 +85,8 @@ public class StringAgg extends Expression {
      *
      * @return this
      */
-    public StringAgg distinct(){
-        this.distinct = true;
+    public StringAgg distinct() {
+        this.distinct = "DISTINCT";
         return this;
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
@@ -103,7 +103,7 @@ public class StringAgg extends Expression {
      * @param delimiter char that splits records aggregated.
      * @return this
      */
-    public StringAgg delimiter(final char delimiter){
+    public StringAgg delimiter(final char delimiter) {
         this.delimiter = delimiter;
         return this;
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.feedzai.commons.sql.abstraction.dml;
 
@@ -25,9 +32,9 @@ public class StringAgg extends Expression {
     private char delimiter;
 
     /**
-     * DISTINCT clause.
+     * Is it distinct.
      */
-    private String distinct;
+    private boolean distinct;
 
     /**
      * @param column column to be aggregated.
@@ -35,7 +42,7 @@ public class StringAgg extends Expression {
     private StringAgg(final Expression column) {
         this.column = column;
         this.delimiter = ',';
-        this.distinct = "";
+        this.distinct = false;
     }
 
     /**
@@ -67,11 +74,11 @@ public class StringAgg extends Expression {
     }
 
     /**
-     * Returns DISTINCT clause.
+     * Returns if it should apply DISTINCT.
      *
-     * @return DISTINCT clause.
+     * @return if it should apply DISTINCT.
      */
-    public String getDistinct() {
+    public boolean isDistinct() {
         return distinct;
     }
 
@@ -86,7 +93,7 @@ public class StringAgg extends Expression {
      * @return this
      */
     public StringAgg distinct() {
-        this.distinct = "DISTINCT";
+        this.distinct = true;
         return this;
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
@@ -1,0 +1,80 @@
+/*
+ * The copyright of this file belongs to Feedzai. The file cannot be
+ * reproduced in whole or in part, stored in a retrieval system,
+ * transmitted in any form, or by any means electronic, mechanical,
+ * photocopying, or otherwise, without the prior permission of the owner.
+ *
+ * (c) 2018 Feedzai, Strictly Confidential
+ */
+package com.feedzai.commons.sql.abstraction.dml;
+
+import com.google.inject.Injector;
+
+import javax.inject.Inject;
+
+/**
+ * @author Francisco Santos (francisco.santos@feedzai.com)
+ * @since 2.2.3
+ */
+public final class StringAgg extends Expression {
+
+    /**
+     *
+     */
+    public final Expression column;
+
+    /**
+     *
+     */
+    private char delimiter;
+
+
+    private boolean distinct;
+
+    /**
+     * @param column column to be aggregated.
+     */
+    private StringAgg(final Expression column) {
+        this.column = column;
+        this.delimiter = ',';
+    }
+
+    /**
+     * @param column column to be aggregated.
+     * @return a new stringagg.
+     */
+    public static StringAgg stringAgg(final Expression column) {
+        return new StringAgg(column);
+    }
+
+    public Expression getColumn() {
+        return column;
+    }
+
+    public char getDelimiter() {
+        return delimiter;
+    }
+
+    public boolean isDistinct() {
+        return distinct;
+    }
+
+    @Override
+    public String translate() {
+        return translator.translate(this);
+    }
+
+    public StringAgg distinct(){
+        this.distinct = true;
+        return this;
+    }
+
+    /**
+     * @param delimiter char that splits records aggregated.
+     * @return
+     */
+    public StringAgg delimiter(final char delimiter){
+        this.delimiter = delimiter;
+        return this;
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
@@ -25,7 +25,7 @@ public class StringAgg extends Expression {
     private char delimiter;
 
     /**
-     * Is it distinct.
+     * DISTINCT clause.
      */
     private String distinct;
 
@@ -67,9 +67,9 @@ public class StringAgg extends Expression {
     }
 
     /**
-     * Returns if it should apply DISTINCT.
+     * Returns DISTINCT clause.
      *
-     * @return if it should apply DISTINCT.
+     * @return DISTINCT clause.
      */
     public String getDistinct() {
         return distinct;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/StringAgg.java
@@ -16,19 +16,22 @@ import javax.inject.Inject;
  * @author Francisco Santos (francisco.santos@feedzai.com)
  * @since 2.2.3
  */
-public final class StringAgg extends Expression {
+public class StringAgg extends Expression {
 
     /**
-     *
+     * The column to aggregate.
      */
     public final Expression column;
 
     /**
-     *
+     * The delimiter.
      */
     private char delimiter;
 
 
+    /**
+     * Is it distinct.
+     */
     private boolean distinct;
 
     /**
@@ -40,21 +43,38 @@ public final class StringAgg extends Expression {
     }
 
     /**
+     * Returns a new StringAgg.
+     *
      * @param column column to be aggregated.
-     * @return a new stringagg.
+     * @return a new StringAgg.
      */
     public static StringAgg stringAgg(final Expression column) {
         return new StringAgg(column);
     }
 
+    /**
+     * Returns the column to be aggregated.
+     *
+     * @return column to be aggregated.
+     */
     public Expression getColumn() {
         return column;
     }
 
+    /**
+     * Returns the delimiter.
+     *
+     * @return the delimiter.
+     */
     public char getDelimiter() {
         return delimiter;
     }
 
+    /**
+     * Returns if it should apply DISTINCT.
+     *
+     * @return if it should apply DISTINCT.
+     */
     public boolean isDistinct() {
         return distinct;
     }
@@ -64,14 +84,21 @@ public final class StringAgg extends Expression {
         return translator.translate(this);
     }
 
+    /**
+     * Apply distinct.
+     *
+     * @return this
+     */
     public StringAgg distinct(){
         this.distinct = true;
         return this;
     }
 
     /**
+     * Sets the delimiter.
+     *
      * @param delimiter char that splits records aggregated.
-     * @return
+     * @return this
      */
     public StringAgg delimiter(final char delimiter){
         this.delimiter = delimiter;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
@@ -468,6 +468,16 @@ public final class SqlBuilder {
     }
 
     /**
+     * The StringAgg function.
+     *
+     * @param column The expression inside the operator.
+     * @return The StringAgg function.
+     */
+    public static Expression stringAgg(final Expression column) {
+        return StringAgg.stringAgg(column);
+    }
+
+    /**
      * The LOWER operator.
      *
      * @param exp The expression inside the operator.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
@@ -473,7 +473,7 @@ public final class SqlBuilder {
      * @param column The expression inside the operator.
      * @return The StringAgg function.
      */
-    public static Expression stringAgg(final Expression column) {
+    public static StringAgg stringAgg(final Expression column) {
         return StringAgg.stringAgg(column);
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
@@ -425,6 +425,11 @@ public abstract class AbstractTranslator {
      */
     public abstract String translate(DbColumn dc);
 
-
+    /**
+     * Translates {@link StringAgg}.
+     *
+     * @param stringAgg The object to translate.
+     * @return The string representation of the given object.
+     */
     public abstract String translate(final StringAgg stringAgg);
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
@@ -31,6 +31,7 @@ import com.feedzai.commons.sql.abstraction.dml.Modulo;
 import com.feedzai.commons.sql.abstraction.dml.Name;
 import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
+import com.feedzai.commons.sql.abstraction.dml.StringAgg;
 import com.feedzai.commons.sql.abstraction.dml.Truncate;
 import com.feedzai.commons.sql.abstraction.dml.Update;
 import com.feedzai.commons.sql.abstraction.dml.View;
@@ -423,4 +424,7 @@ public abstract class AbstractTranslator {
      * @return The string representation of the given object.
      */
     public abstract String translate(DbColumn dc);
+
+
+    public abstract String translate(final StringAgg stringAgg);
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
@@ -431,5 +431,5 @@ public abstract class AbstractTranslator {
      * @param stringAgg The object to translate.
      * @return The string representation of the given object.
      */
-    public abstract String translate(final StringAgg stringAgg);
+    public abstract String translate(StringAgg stringAgg);
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -607,4 +607,11 @@ public interface DatabaseEngine extends AutoCloseable {
      * @param eh The reference for exception callbacks.
      */
     void setExceptionHandler(ExceptionHandler eh);
+
+    /**
+     * Checks if the engine supports using DISTINCT inside a string aggregation.
+     *
+     * @return true if the engine supports using DISTINCT inside a string aggregation, false otherwise.
+     */
+    boolean isAbleToStringAggDistinct();
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -613,5 +613,5 @@ public interface DatabaseEngine extends AutoCloseable {
      *
      * @return true if the engine supports using DISTINCT inside a string aggregation, false otherwise.
      */
-    boolean isAbleToStringAggDistinct();
+    boolean isStringAggDistinctCapable();
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/OperationNotSupportedRuntimeException.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/OperationNotSupportedRuntimeException.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.feedzai.commons.sql.abstraction.engine;
+
+/**
+ * @author Francisco Santos (francisco.santos@feedzai.com)
+ * @since 2.2.3
+ */
+public class OperationNotSupportedRuntimeException extends DatabaseEngineRuntimeException {
+    /**
+     * Constructs a new runtime exception with {@code null} as its detail message.  The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause}.
+     */
+    public OperationNotSupportedRuntimeException() {
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for later retrieval by the {@link #getMessage()}
+     *                method.
+     */
+    public OperationNotSupportedRuntimeException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message and cause.  <p>Note that the detail message
+     * associated with {@code cause} is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause   the cause (which is saved for later retrieval by the {@link #getCause()} method).  (A <tt>null</tt>
+     *                value is permitted, and indicates that the cause is nonexistent or
+     */
+    public OperationNotSupportedRuntimeException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified cause and a detail message of <tt>(cause==null ? null :
+     * cause.toString())</tt> (which typically contains the class and detail message of
+     * <tt>cause</tt>).  This constructor is useful for runtime exceptions
+     * that are little more than wrappers for other throwables.
+     *
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).  (A <tt>null</tt>
+     *              value is permitted, and indicates that the cause is nonexistent or unknown.)
+     */
+    public OperationNotSupportedRuntimeException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message, cause, suppression enabled or disabled, and
+     * writable stack trace enabled or disabled.
+     *
+     * @param message            the detail message.
+     * @param cause              the cause.  (A {@code null} value is permitted, and indicates that the cause is nonexistent
+     *                           or unknown.)
+     * @param enableSuppression  whether or not suppression is enabled or disabled
+     * @param writableStackTrace whether or not the stack trace should
+     */
+    public OperationNotSupportedRuntimeException(final String message,
+                                                 final Throwable cause,
+                                                 final boolean enableSuppression,
+                                                 final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -1045,6 +1045,11 @@ public class DB2Engine extends AbstractDatabaseEngine {
         }
     }
 
+    @Override
+    public boolean isAbleToStringAggDistinct() {
+        return true;
+    }
+
     /**
      * DB2 does not support CLOB. The strategy here is to try and write the object. If the object is a {@link String} DB2 will not allow
      * and then we encapsulate the String in a {@link byte[]}. If it fails and the value is not a string then throw the error since it is

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -1046,7 +1046,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    public boolean isAbleToStringAggDistinct() {
+    public boolean isStringAggDistinctCapable() {
         return true;
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -1047,7 +1047,8 @@ public class DB2Engine extends AbstractDatabaseEngine {
 
     @Override
     public boolean isStringAggDistinctCapable() {
-        return true;
+        // The current version of DB2 supported by PDB, does not allow for the use of distinct.
+        return false;
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -353,7 +353,7 @@ public class DB2Translator extends AbstractTranslator {
         String column = stringAgg.getColumn().translate();
 
         return String.format(
-                "LISTAGG(%s %s, '%c') WITHIN GROUP (ORDER BY %s)",
+                "LISTAGG(%s %s, '%c') WITHIN GROUP(ORDER BY %s)",
                 stringAgg.isDistinct() ? "DISTINCT" : "",
                 column,
                 stringAgg.getDelimiter(),

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -350,19 +350,15 @@ public class DB2Translator extends AbstractTranslator {
     @Override
     public String translate(final StringAgg stringAgg) {
         inject(stringAgg.column);
-        if (stringAgg.isDistinct()) {
-            return String.format(
-                    "LISTAGG(DISTINCT CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
-        } else {
-            return String.format(
-                    "LISTAGG(CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
-        }
+        String column = stringAgg.getColumn().translate();
+
+        return String.format(
+                "LISTAGG(%s %s, '%c') WITHIN GROUP ( ORDER BY %s)",
+                stringAgg.getDistinct(),
+                column,
+                stringAgg.getDelimiter(),
+                column
+        );
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -354,7 +354,7 @@ public class DB2Translator extends AbstractTranslator {
 
         return String.format(
                 "LISTAGG(%s %s, '%c') WITHIN GROUP (ORDER BY %s)",
-                stringAgg.getDistinct(),
+                stringAgg.isDistinct() ? "DISTINCT" : "",
                 column,
                 stringAgg.getDelimiter(),
                 column

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -353,7 +353,7 @@ public class DB2Translator extends AbstractTranslator {
         String column = stringAgg.getColumn().translate();
 
         return String.format(
-                "LISTAGG(%s %s, '%c') WITHIN GROUP ( ORDER BY %s)",
+                "LISTAGG(%s %s, '%c') WITHIN GROUP (ORDER BY %s)",
                 stringAgg.getDistinct(),
                 column,
                 stringAgg.getDelimiter(),

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -27,6 +27,7 @@ import com.feedzai.commons.sql.abstraction.dml.Modulo;
 import com.feedzai.commons.sql.abstraction.dml.Name;
 import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
+import com.feedzai.commons.sql.abstraction.dml.StringAgg;
 import com.feedzai.commons.sql.abstraction.dml.Truncate;
 import com.feedzai.commons.sql.abstraction.dml.View;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
@@ -343,6 +344,24 @@ public class DB2Translator extends AbstractTranslator {
 
             default:
                 throw new DatabaseEngineRuntimeException(format("Mapping not found for '%s'. Please report this error.", c.getDbColumnType()));
+        }
+    }
+
+    @Override
+    public String translate(final StringAgg stringAgg) {
+        inject(stringAgg.column);
+        if (stringAgg.isDistinct()) {
+            return String.format(
+                    "LISTAGG(DISTINCT CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                    stringAgg.getColumn().translate(),
+                    stringAgg.getDelimiter()
+            );
+        } else {
+            return String.format(
+                    "LISTAGG(CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                    stringAgg.getColumn().translate(),
+                    stringAgg.getDelimiter()
+            );
         }
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -32,6 +32,7 @@ import com.feedzai.commons.sql.abstraction.dml.Truncate;
 import com.feedzai.commons.sql.abstraction.dml.View;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
+import com.feedzai.commons.sql.abstraction.engine.OperationNotSupportedRuntimeException;
 import com.feedzai.commons.sql.abstraction.util.Constants;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -349,12 +350,16 @@ public class DB2Translator extends AbstractTranslator {
 
     @Override
     public String translate(final StringAgg stringAgg) {
+        if (stringAgg.isDistinct()) {
+            throw new OperationNotSupportedRuntimeException("LISTAGG does not support distinct in this DB2 version. " +
+                                                                    "If you really need it, " +
+                                                                    "you may do it using regex or a subquery.");
+        }
+
         inject(stringAgg.column);
         String column = stringAgg.getColumn().translate();
-
         return String.format(
-                "LISTAGG(%s %s, '%c') WITHIN GROUP(ORDER BY %s)",
-                stringAgg.isDistinct() ? "DISTINCT" : "",
+                "LISTAGG(%s, '%c') WITHIN GROUP(ORDER BY %s)",
                 column,
                 stringAgg.getDelimiter(),
                 column

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -573,7 +573,7 @@ public class H2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    public boolean isAbleToStringAggDistinct() {
+    public boolean isStringAggDistinctCapable() {
         return true;
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -573,6 +573,11 @@ public class H2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
+    public boolean isAbleToStringAggDistinct() {
+        return true;
+    }
+
+    @Override
     protected void addFks(DbEntity entity) throws DatabaseEngineException {
         for (DbFk fk : entity.getFks()) {
             final List<String> quotizedLocalColumns = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
@@ -295,19 +295,12 @@ public class H2Translator extends AbstractTranslator {
     @Override
     public String translate(final StringAgg stringAgg) {
         inject(stringAgg.column);
-        if (stringAgg.isDistinct()) {
-            return String.format(
-                    "string_agg(DISTINCT CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
-        } else {
-            return String.format(
-                    "string_agg(CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
-        }
+        return String.format(
+                "STRING_AGG(%s CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                stringAgg.getDistinct(),
+                stringAgg.getColumn().translate(),
+                stringAgg.getDelimiter()
+        );
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
@@ -297,7 +297,7 @@ public class H2Translator extends AbstractTranslator {
         inject(stringAgg.column);
         return String.format(
                 "STRING_AGG(%s CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                stringAgg.getDistinct(),
+                stringAgg.isDistinct() ? "DISTINCT" : "",
                 stringAgg.getColumn().translate(),
                 stringAgg.getDelimiter()
         );

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
@@ -296,7 +296,7 @@ public class H2Translator extends AbstractTranslator {
     public String translate(final StringAgg stringAgg) {
         inject(stringAgg.column);
         return String.format(
-                "STRING_AGG(%s CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                "STRING_AGG(%s %s, '%c')",
                 stringAgg.isDistinct() ? "DISTINCT" : "",
                 stringAgg.getColumn().translate(),
                 stringAgg.getDelimiter()

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
@@ -293,6 +293,24 @@ public class H2Translator extends AbstractTranslator {
     }
 
     @Override
+    public String translate(final StringAgg stringAgg) {
+        inject(stringAgg.column);
+        if (stringAgg.isDistinct()) {
+            return String.format(
+                    "string_agg(DISTINCT CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                    stringAgg.getColumn().translate(),
+                    stringAgg.getDelimiter()
+            );
+        } else {
+            return String.format(
+                    "string_agg(CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                    stringAgg.getColumn().translate(),
+                    stringAgg.getDelimiter()
+            );
+        }
+    }
+
+    @Override
     public String translateEscape() {
         return "\"";
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -875,7 +875,7 @@ public class MySqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    public boolean isAbleToStringAggDistinct() {
+    public boolean isStringAggDistinctCapable() {
         return true;
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -875,6 +875,11 @@ public class MySqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
+    public boolean isAbleToStringAggDistinct() {
+        return true;
+    }
+
+    @Override
     public String commentCharacter() {
         return "#";
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
@@ -280,7 +280,7 @@ public class MySqlTranslator extends AbstractTranslator {
         inject(stringAgg.column);
         return String.format(
                 "GROUP_CONCAT(%s %s SEPARATOR '%c')",
-                stringAgg.getDistinct(),
+                stringAgg.isDistinct() ? "DISTINCT" : "",
                 stringAgg.getColumn().translate(),
                 stringAgg.getDelimiter()
         );

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
@@ -276,6 +276,24 @@ public class MySqlTranslator extends AbstractTranslator {
     }
 
     @Override
+    public String translate(final StringAgg stringAgg) {
+        inject(stringAgg.column);
+        if (stringAgg.isDistinct()) {
+            return String.format(
+                    "GROUP_CONCAT(DISTINCT CAST (%s AS TEXT) SEPARATOR CAST ('%c' AS TEXT))",
+                    stringAgg.getColumn().translate(),
+                    stringAgg.getDelimiter()
+            );
+        } else {
+            return String.format(
+                    "GROUP_CONCAT(CAST (%s AS TEXT) SEPARATOR CAST ('%c' AS TEXT))",
+                    stringAgg.getColumn().translate(),
+                    stringAgg.getDelimiter()
+            );
+        }
+    }
+
+    @Override
     public String translateEscape() {
         return "`";
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
@@ -278,19 +278,12 @@ public class MySqlTranslator extends AbstractTranslator {
     @Override
     public String translate(final StringAgg stringAgg) {
         inject(stringAgg.column);
-        if (stringAgg.isDistinct()) {
-            return String.format(
-                    "GROUP_CONCAT(DISTINCT CAST (%s AS TEXT) SEPARATOR CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
-        } else {
-            return String.format(
-                    "GROUP_CONCAT(CAST (%s AS TEXT) SEPARATOR CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
-        }
+        return String.format(
+                "GROUP_CONCAT(%s %s SEPARATOR '%c')",
+                stringAgg.getDistinct(),
+                stringAgg.getColumn().translate(),
+                stringAgg.getDelimiter()
+        );
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -140,6 +140,11 @@ public class OracleEngine extends AbstractDatabaseEngine {
     }
 
     @Override
+    public boolean isAbleToStringAggDistinct() {
+        return false;
+    }
+
+    @Override
     protected int entityToPreparedStatement(final DbEntity entity, final PreparedStatement originalPs, final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
         final OraclePreparedStatement ps = (OraclePreparedStatement) originalPs;
         int i = 1;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -140,7 +140,7 @@ public class OracleEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    public boolean isAbleToStringAggDistinct() {
+    public boolean isStringAggDistinctCapable() {
         return false;
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
@@ -15,10 +15,23 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl;
 
-import com.feedzai.commons.sql.abstraction.ddl.*;
-import com.feedzai.commons.sql.abstraction.dml.*;
+import com.feedzai.commons.sql.abstraction.ddl.AlterColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
+import com.feedzai.commons.sql.abstraction.ddl.DropPrimaryKey;
+import com.feedzai.commons.sql.abstraction.ddl.Rename;
+import com.feedzai.commons.sql.abstraction.dml.Expression;
+import com.feedzai.commons.sql.abstraction.dml.Function;
+import com.feedzai.commons.sql.abstraction.dml.Join;
+import com.feedzai.commons.sql.abstraction.dml.Modulo;
+import com.feedzai.commons.sql.abstraction.dml.Name;
+import com.feedzai.commons.sql.abstraction.dml.Query;
+import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
+import com.feedzai.commons.sql.abstraction.dml.StringAgg;
+import com.feedzai.commons.sql.abstraction.dml.View;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
+import com.feedzai.commons.sql.abstraction.engine.OperationNotSupportedRuntimeException;
 import com.feedzai.commons.sql.abstraction.util.StringUtils;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -283,8 +296,8 @@ public class OracleTranslator extends AbstractTranslator {
 
     @Override
     public String translate(final StringAgg stringAgg) {
-        if (!stringAgg.getDistinct().isEmpty()) {
-            throw new DatabaseEngineRuntimeException("LISTAGG does not support distinct. If you really need it, " +
+        if (stringAgg.isDistinct()) {
+            throw new OperationNotSupportedRuntimeException("LISTAGG does not support distinct. If you really need it, " +
                                                              "you may do it using regex or a subquery. " +
                                                              "Check this: https://dba.stackexchange.com/a/8478 or this:" +
                                                              "https://stackoverflow.com/a/50589222");

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
@@ -282,6 +282,24 @@ public class OracleTranslator extends AbstractTranslator {
     }
 
     @Override
+    public String translate(final StringAgg stringAgg) {
+        inject(stringAgg.column);
+        if (stringAgg.isDistinct()) {
+            return String.format(
+                    "LISTAGG(DISTINCT CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                    stringAgg.getColumn().translate(),
+                    stringAgg.getDelimiter()
+            );
+        } else {
+            return String.format(
+                    "LISTAGG(CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                    stringAgg.getColumn().translate(),
+                    stringAgg.getDelimiter()
+            );
+        }
+    }
+
+    @Override
     public String translateEscape() {
         return "\"";
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
@@ -305,7 +305,7 @@ public class OracleTranslator extends AbstractTranslator {
         inject(stringAgg.column);
         String column = stringAgg.getColumn().translate();
         return String.format(
-                "LISTAGG(%s, '%c') WITHIN GROUP ( ORDER BY %s)",
+                "LISTAGG(%s, '%c') WITHIN GROUP (ORDER BY %s)",
                 column,
                 stringAgg.getDelimiter(),
                 column

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
@@ -283,20 +283,20 @@ public class OracleTranslator extends AbstractTranslator {
 
     @Override
     public String translate(final StringAgg stringAgg) {
-        inject(stringAgg.column);
-        if (stringAgg.isDistinct()) {
-            return String.format(
-                    "LISTAGG(DISTINCT CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
-        } else {
-            return String.format(
-                    "LISTAGG(CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
+        if (!stringAgg.getDistinct().isEmpty()) {
+            throw new DatabaseEngineRuntimeException("LISTAGG does not support distinct. If you really need it, " +
+                                                             "you may do it using regex or a subquery. " +
+                                                             "Check this: https://dba.stackexchange.com/a/8478 or this:" +
+                                                             "https://stackoverflow.com/a/50589222");
         }
+        inject(stringAgg.column);
+        String column = stringAgg.getColumn().translate();
+        return String.format(
+                "LISTAGG(%s, '%c') WITHIN GROUP ( ORDER BY %s)",
+                column,
+                stringAgg.getDelimiter(),
+                column
+        );
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -153,6 +153,11 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         super.setParameter(name, index, param);
     }
 
+    @Override
+    public boolean isAbleToStringAggDistinct() {
+        return true;
+    }
+
     /**
      * Converts a String value into a PG JSON value ready to be assigned to bind variables in Prepared Statements.
      *

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -154,7 +154,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    public boolean isAbleToStringAggDistinct() {
+    public boolean isStringAggDistinctCapable() {
         return true;
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
@@ -325,7 +325,7 @@ public class PostgreSqlTranslator extends AbstractTranslator {
         inject(stringAgg.column);
         return String.format(
                 "STRING_AGG(%s CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                stringAgg.getDistinct(),
+                stringAgg.isDistinct() ? "DISTINCT" : "",
                 stringAgg.getColumn().translate(),
                 stringAgg.getDelimiter()
         );

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
@@ -301,10 +301,7 @@ public class PostgreSqlTranslator extends AbstractTranslator {
                 }
 
             case STRING:
-                return format(
-                        "VARCHAR(%s)",
-                        c.isSizeSet() ? c.getSize().toString() : properties.getProperty(VARCHAR_SIZE)
-                );
+                return format("VARCHAR(%s)", c.isSizeSet() ? c.getSize().toString() : properties.getProperty(VARCHAR_SIZE));
 
             case CLOB:
                 return "TEXT";
@@ -326,19 +323,12 @@ public class PostgreSqlTranslator extends AbstractTranslator {
     @Override
     public String translate(final StringAgg stringAgg) {
         inject(stringAgg.column);
-        if (stringAgg.isDistinct()) {
-            return String.format(
-                    "string_agg(DISTINCT CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
-        } else {
-            return String.format(
-                    "string_agg(CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
-        }
+        return String.format(
+                "STRING_AGG(%s CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                stringAgg.getDistinct(),
+                stringAgg.getColumn().translate(),
+                stringAgg.getDelimiter()
+        );
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
@@ -324,7 +324,7 @@ public class PostgreSqlTranslator extends AbstractTranslator {
     public String translate(final StringAgg stringAgg) {
         inject(stringAgg.column);
         return String.format(
-                "STRING_AGG(%s CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                "STRING_AGG(%s %s, '%c')",
                 stringAgg.isDistinct() ? "DISTINCT" : "",
                 stringAgg.getColumn().translate(),
                 stringAgg.getDelimiter()

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
@@ -324,7 +324,7 @@ public class PostgreSqlTranslator extends AbstractTranslator {
     public String translate(final StringAgg stringAgg) {
         inject(stringAgg.column);
         return String.format(
-                "STRING_AGG(%s %s, '%c')",
+                "STRING_AGG(%s CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
                 stringAgg.isDistinct() ? "DISTINCT" : "",
                 stringAgg.getColumn().translate(),
                 stringAgg.getDelimiter()

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -751,6 +751,11 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
     }
 
     @Override
+    public boolean isAbleToStringAggDistinct() {
+        return false;
+    }
+
+    @Override
     protected boolean checkConnection(final Connection conn) {
         Statement s = null;
         try {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -751,7 +751,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    public boolean isAbleToStringAggDistinct() {
+    public boolean isStringAggDistinctCapable() {
         return false;
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -32,6 +32,7 @@ import com.feedzai.commons.sql.abstraction.dml.Update;
 import com.feedzai.commons.sql.abstraction.dml.View;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
+import com.feedzai.commons.sql.abstraction.engine.OperationNotSupportedRuntimeException;
 import com.feedzai.commons.sql.abstraction.util.StringUtils;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -350,8 +351,8 @@ public class SqlServerTranslator extends AbstractTranslator {
 
     @Override
     public String translate(final StringAgg stringAgg) {
-        if (!stringAgg.getDistinct().isEmpty()) {
-            throw new DatabaseEngineRuntimeException("STRING_AGG does not support distinct. If you really need it, " +
+        if (stringAgg.isDistinct()) {
+            throw new OperationNotSupportedRuntimeException("STRING_AGG does not support distinct. If you really need it, " +
                                                              "you may do it using a subquery. " +
                                                              "Check this: https://stackoverflow.com/a/50589222");
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -27,6 +27,7 @@ import com.feedzai.commons.sql.abstraction.dml.Modulo;
 import com.feedzai.commons.sql.abstraction.dml.Name;
 import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
+import com.feedzai.commons.sql.abstraction.dml.StringAgg;
 import com.feedzai.commons.sql.abstraction.dml.Update;
 import com.feedzai.commons.sql.abstraction.dml.View;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
@@ -344,6 +345,24 @@ public class SqlServerTranslator extends AbstractTranslator {
 
             default:
                 throw new DatabaseEngineRuntimeException(format("Mapping not found for '%s'. Please report this error.", c.getDbColumnType()));
+        }
+    }
+
+    @Override
+    public String translate(final StringAgg stringAgg) {
+        inject(stringAgg.column);
+        if (stringAgg.isDistinct()) {
+            return String.format(
+                    "STRING_AGG(DISTINCT CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                    stringAgg.getColumn().translate(),
+                    stringAgg.getDelimiter()
+            );
+        } else {
+            return String.format(
+                    "STRING_AGG(CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
+                    stringAgg.getColumn().translate(),
+                    stringAgg.getDelimiter()
+            );
         }
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -358,7 +358,7 @@ public class SqlServerTranslator extends AbstractTranslator {
         }
         inject(stringAgg.column);
         return String.format(
-                "STRING_AGG (%s, '%c')",
+                "STRING_AGG(%s, '%c')",
                 stringAgg.getColumn().translate(),
                 stringAgg.getDelimiter()
         );

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -350,20 +350,17 @@ public class SqlServerTranslator extends AbstractTranslator {
 
     @Override
     public String translate(final StringAgg stringAgg) {
-        inject(stringAgg.column);
-        if (stringAgg.isDistinct()) {
-            return String.format(
-                    "STRING_AGG(DISTINCT CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
-        } else {
-            return String.format(
-                    "STRING_AGG(CAST (%s AS TEXT), CAST ('%c' AS TEXT))",
-                    stringAgg.getColumn().translate(),
-                    stringAgg.getDelimiter()
-            );
+        if (!stringAgg.getDistinct().isEmpty()) {
+            throw new DatabaseEngineRuntimeException("STRING_AGG does not support distinct. If you really need it, " +
+                                                             "you may do it using a subquery. " +
+                                                             "Check this: https://stackoverflow.com/a/50589222");
         }
+        inject(stringAgg.column);
+        return String.format(
+                "STRING_AGG (%s, '%c')",
+                stringAgg.getColumn().translate(),
+                stringAgg.getDelimiter()
+        );
     }
 
     @Override

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -37,6 +37,7 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
 import com.feedzai.commons.sql.abstraction.engine.NameAlreadyExistsException;
+import com.feedzai.commons.sql.abstraction.engine.OperationNotSupportedRuntimeException;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.BlobTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
@@ -3366,7 +3367,7 @@ public class EngineGeneralTest {
             assertEquals("COL1 must be 2", 2, query.get(1).get("COL1").toInt().intValue());
             assertEquals("COL5 must be TeStE,tesTte", "TeStE,tesTte", query.get(1).get("agg").toString());
 
-        } catch (DatabaseEngineRuntimeException e) {
+        } catch (OperationNotSupportedRuntimeException e) {
             // Ignore for SQL Server and ORACLE since they do not support it.
             if (!this.engine.getDialect().equals(SQLSERVER) && !this.engine.getDialect().equals(ORACLE)) {
                 throw e;

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -3376,6 +3376,32 @@ public class EngineGeneralTest {
     }
 
     @Test
+    public void testStringAggNotStrings() throws DatabaseEngineException {
+        test5Columns();
+        engine.persist("TEST", entry().set("COL1", 1).set("COL5", "TESTE")
+                .build());
+        engine.persist("TEST", entry().set("COL1", 1).set("COL5", "teste")
+                .build());
+        engine.persist("TEST", entry().set("COL1", 2).set("COL5", "TeStE")
+                .build());
+        engine.persist("TEST", entry().set("COL1", 2).set("COL5", "tesTte")
+                .build());
+
+        final List<Map<String, ResultColumn>> query = engine.query(
+                select(column("COL1"), stringAgg(column("COL1")).alias("agg"))
+                        .from(table("TEST"))
+                        .groupby(column("COL1"))
+                        .orderby(column("COL1").asc())
+        );
+
+        assertEquals("Resultset must have only 2 results", 2, query.size());
+        assertEquals("COL1 must be 1", 1, query.get(0).get("COL1").toInt().intValue());
+        assertEquals("COL5 must be 1,1", "1,1", query.get(0).get("agg").toString());
+        assertEquals("COL1 must be 2", 2, query.get(1).get("COL1").toInt().intValue());
+        assertEquals("COL5 must be 2,2", "2,2", query.get(1).get("agg").toString());
+    }
+
+    @Test
     public void dropPrimaryKeyWithOneColumnTest() throws Exception {
         DbEntity entity =
                 dbEntity()

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -32,6 +32,7 @@ import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.ConnectionResetException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
@@ -72,6 +73,8 @@ import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.DOUBLE;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.INT;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.LONG;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.STRING;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.Dialect.ORACLE;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.Dialect.SQLSERVER;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.L;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.all;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.avg;
@@ -3288,9 +3291,9 @@ public class EngineGeneralTest {
     @Test
     public void testStringAgg() throws DatabaseEngineException {
         test5Columns();
-        engine.persist("TEST", entry().set("COL1", 1).set("COL5", "teste")
-                .build());
         engine.persist("TEST", entry().set("COL1", 1).set("COL5", "TESTE")
+                .build());
+        engine.persist("TEST", entry().set("COL1", 1).set("COL5", "teste")
                 .build());
         engine.persist("TEST", entry().set("COL1", 2).set("COL5", "TeStE")
                 .build());
@@ -3301,11 +3304,12 @@ public class EngineGeneralTest {
                 select(column("COL1"), stringAgg(column("COL5")).alias("agg"))
                         .from(table("TEST"))
                         .groupby(column("COL1"))
+                        .orderby(column("COL1").asc())
         );
 
         assertEquals("Resultset must have only 2 results", 2, query.size());
         assertEquals("COL1 must be 1", 1, query.get(0).get("COL1").toInt().intValue());
-        assertEquals("COL5 must be teste,TESTE", "teste,TESTE", query.get(0).get("agg").toString());
+        assertEquals("COL5 must be TESTE,teste", "TESTE,teste", query.get(0).get("agg").toString());
         assertEquals("COL1 must be 2", 2, query.get(1).get("COL1").toInt().intValue());
         assertEquals("COL5 must be TeStE,tesTte", "TeStE,tesTte", query.get(1).get("agg").toString());
     }
@@ -3313,9 +3317,9 @@ public class EngineGeneralTest {
     @Test
     public void testStringAggDelimiter() throws DatabaseEngineException {
         test5Columns();
-        engine.persist("TEST", entry().set("COL1", 1).set("COL5", "teste")
-                .build());
         engine.persist("TEST", entry().set("COL1", 1).set("COL5", "TESTE")
+                .build());
+        engine.persist("TEST", entry().set("COL1", 1).set("COL5", "teste")
                 .build());
         engine.persist("TEST", entry().set("COL1", 2).set("COL5", "TeStE")
                 .build());
@@ -3326,11 +3330,12 @@ public class EngineGeneralTest {
                 select(column("COL1"), stringAgg(column("COL5")).delimiter(';').alias("agg"))
                         .from(table("TEST"))
                         .groupby(column("COL1"))
+                        .orderby(column("COL1").asc())
         );
 
         assertEquals("Resultset must have only 2 results", 2, query.size());
         assertEquals("COL1 must be 1", 1, query.get(0).get("COL1").toInt().intValue());
-        assertEquals("COL5 must be teste;TESTE", "teste;TESTE", query.get(0).get("agg").toString());
+        assertEquals("COL5 must be TESTE;teste", "TESTE;teste", query.get(0).get("agg").toString());
         assertEquals("COL1 must be 2", 2, query.get(1).get("COL1").toInt().intValue());
         assertEquals("COL5 must be TeStE;tesTte", "TeStE;tesTte", query.get(1).get("agg").toString());
     }
@@ -3347,17 +3352,29 @@ public class EngineGeneralTest {
         engine.persist("TEST", entry().set("COL1", 2).set("COL5", "tesTte")
                 .build());
 
-        final List<Map<String, ResultColumn>> query = engine.query(
-                select(column("COL1"), stringAgg(column("COL5")).distinct().alias("agg"))
-                        .from(table("TEST"))
-                        .groupby(column("COL1"))
-        );
+        try {
+            final List<Map<String, ResultColumn>> query = engine.query(
+                    select(column("COL1"), stringAgg(column("COL5")).distinct().alias("agg"))
+                            .from(table("TEST"))
+                            .groupby(column("COL1"))
+                            .orderby(column("COL1").asc())
+            );
 
-        assertEquals("Resultset must have only 2 results", 2, query.size());
-        assertEquals("COL1 must be 1", 1, query.get(0).get("COL1").toInt().intValue());
-        assertEquals("COL5 must be teste", "teste", query.get(0).get("agg").toString());
-        assertEquals("COL1 must be 2", 2, query.get(1).get("COL1").toInt().intValue());
-        assertEquals("COL5 must be TeStE,tesTte", "TeStE,tesTte", query.get(1).get("agg").toString());
+            System.out.println(query.get(0));
+            System.out.println(query.get(1));
+
+            assertEquals("Resultset must have only 2 results", 2, query.size());
+            assertEquals("COL1 must be 1", 1, query.get(0).get("COL1").toInt().intValue());
+            assertEquals("COL5 must be teste", "teste", query.get(0).get("agg").toString());
+            assertEquals("COL1 must be 2", 2, query.get(1).get("COL1").toInt().intValue());
+            assertEquals("COL5 must be TeStE,tesTte", "TeStE,tesTte", query.get(1).get("agg").toString());
+
+        } catch (DatabaseEngineRuntimeException e){
+            // Ignore for SQL Server and ORACLE since they do not support it.
+            if (!this.engine.getDialect().equals(SQLSERVER) && !this.engine.getDialect().equals(ORACLE)) {
+                throw e;
+            }
+        }
     }
 
     @Test

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -3366,7 +3366,7 @@ public class EngineGeneralTest {
             assertEquals("COL1 must be 2", 2, query.get(1).get("COL1").toInt().intValue());
             assertEquals("COL5 must be TeStE,tesTte", "TeStE,tesTte", query.get(1).get("agg").toString());
 
-        } catch (DatabaseEngineRuntimeException e){
+        } catch (DatabaseEngineRuntimeException e) {
             // Ignore for SQL Server and ORACLE since they do not support it.
             if (!this.engine.getDialect().equals(SQLSERVER) && !this.engine.getDialect().equals(ORACLE)) {
                 throw e;

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -3343,6 +3343,9 @@ public class EngineGeneralTest {
 
     @Test
     public void testStringAggDistinct() throws DatabaseEngineException {
+        if (!this.engine.isStringAggDistinctCapable()) {
+            return;
+        }
         test5Columns();
         engine.persist("TEST", entry().set("COL1", 1).set("COL5", "teste")
                 .build());
@@ -3353,26 +3356,18 @@ public class EngineGeneralTest {
         engine.persist("TEST", entry().set("COL1", 2).set("COL5", "tesTte")
                 .build());
 
-        try {
-            final List<Map<String, ResultColumn>> query = engine.query(
-                    select(column("COL1"), stringAgg(column("COL5")).distinct().alias("agg"))
-                            .from(table("TEST"))
-                            .groupby(column("COL1"))
-                            .orderby(column("COL1").asc())
-            );
+        final List<Map<String, ResultColumn>> query = engine.query(
+                select(column("COL1"), stringAgg(column("COL5")).distinct().alias("agg"))
+                        .from(table("TEST"))
+                        .groupby(column("COL1"))
+                        .orderby(column("COL1").asc())
+        );
 
-            assertEquals("Resultset must have only 2 results", 2, query.size());
-            assertEquals("COL1 must be 1", 1, query.get(0).get("COL1").toInt().intValue());
-            assertEquals("COL5 must be teste", "teste", query.get(0).get("agg").toString());
-            assertEquals("COL1 must be 2", 2, query.get(1).get("COL1").toInt().intValue());
-            assertEquals("COL5 must be TeStE,tesTte", "TeStE,tesTte", query.get(1).get("agg").toString());
-
-        } catch (OperationNotSupportedRuntimeException e) {
-            // Ignore for SQL Server and ORACLE since they do not support it.
-            if (!this.engine.getDialect().equals(SQLSERVER) && !this.engine.getDialect().equals(ORACLE)) {
-                throw e;
-            }
-        }
+        assertEquals("Resultset must have only 2 results", 2, query.size());
+        assertEquals("COL1 must be 1", 1, query.get(0).get("COL1").toInt().intValue());
+        assertEquals("COL5 must be teste", "teste", query.get(0).get("agg").toString());
+        assertEquals("COL1 must be 2", 2, query.get(1).get("COL1").toInt().intValue());
+        assertEquals("COL5 must be TeStE,tesTte", "TeStE,tesTte", query.get(1).get("agg").toString());
     }
 
     @Test

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -3360,9 +3360,6 @@ public class EngineGeneralTest {
                             .orderby(column("COL1").asc())
             );
 
-            System.out.println(query.get(0));
-            System.out.println(query.get(1));
-
             assertEquals("Resultset must have only 2 results", 2, query.size());
             assertEquals("COL1 must be 1", 1, query.get(0).get("COL1").toInt().intValue());
             assertEquals("COL5 must be teste", "teste", query.get(0).get("agg").toString());

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/testconfig/CustomTranslator.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/testconfig/CustomTranslator.java
@@ -87,4 +87,9 @@ public class CustomTranslator extends AbstractTranslator {
     public String translate(DbColumn dc) {
         return null;
     }
+
+    @Override
+    public String translate(final StringAgg stringAgg) {
+        return null;
+    }
 }


### PR DESCRIPTION
Implementation of String Aggregation. This is useful, for instance, when an aggregation is done and we still need to know the IDs of such rows.

This closes #92.