### PR TITLE
Support Ceiling/Floor expressions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,8 @@ results = engine.query(
 |[sum]|Aggregation operator for numeric values. They are applicable to expression involving columns.|
 |[avg]|Aggregation operator for numeric values. They are applicable to expression involving columns.|
 |[stddev]|Aggregation operator for numeric values. They are applicable to expression involving columns.|
+|[floor]|Operator that returns the largest integer value that is smaller than or equal to a number. They are applicable to expression involving columns.|
+|[ceil]|Operator that returns the smallest integer value that is larger than or equal to a number. They are applicable to expression involving columns.|
 |[udf]|If you have defined your own sql function you may access it with udf.|
 [alias]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/Expression.html#alias(java.lang.String)
 [count]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#count(com.feedzai.commons.sql.abstraction.dml.Expression)
@@ -684,6 +686,8 @@ results = engine.query(
 [sum]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#sum(com.feedzai.commons.sql.abstraction.dml.Expression)
 [avg]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#avg(com.feedzai.commons.sql.abstraction.dml.Expression)
 [stddev]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#stddev(com.feedzai.commons.sql.abstraction.dml.Expression)
+[floor]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#floor(com.feedzai.commons.sql.abstraction.dml.Expression)
+[ceil]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#ceil(com.feedzai.commons.sql.abstraction.dml.Expression)
 [udf]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#udf(java.lang.String,%20com.feedzai.commons.sql.abstraction.dml.Expression)
 
 Sometimes it is required to merge the content of more than one table.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
@@ -66,7 +66,7 @@ public class Function extends Expression {
     /**
      * The CEILING function.
      */
-    public static final String CEILING = "CEILING";
+    public static final String CEILING = "CEIL";
     /**
      * The list of functions.
      */

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
@@ -60,6 +60,14 @@ public class Function extends Expression {
      */
     public static final String LOWER = "lower";
     /**
+     * The FLOOR function.
+     */
+    public static final String FLOOR = "FLOOR";
+    /**
+     * The FLOOR function.
+     */
+    public static final String CEILING = "CEILING";
+    /**
      * The list of functions.
      */
     public static final Set<String> FUNCTIONS;
@@ -74,6 +82,8 @@ public class Function extends Expression {
                 .add(SUM)
                 .add(UPPER)
                 .add(LOWER)
+                .add(FLOOR)
+                .add(CEILING)
                 .build();
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
@@ -64,7 +64,7 @@ public class Function extends Expression {
      */
     public static final String FLOOR = "FLOOR";
     /**
-     * The FLOOR function.
+     * The CEILING function.
      */
     public static final String CEILING = "CEILING";
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
@@ -437,6 +437,26 @@ public final class SqlBuilder {
     }
 
     /**
+     * The FLOOR operator.
+     *
+     * @param exp The expression.
+     * @return The FLOOR representation.
+     */
+    public static Expression floor(final Expression exp) {
+        return new Function(FLOOR, exp);
+    }
+
+    /**
+     * The CEILING operator.
+     *
+     * @param exp The expression.
+     * @return The CEILING representation.
+     */
+    public static Expression ceiling(final Expression exp) {
+        return new Function(CEILING, exp);
+    }
+
+    /**
      * The Used Defined Function operator.
      *
      * @param udf The UDF name.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -103,9 +103,13 @@ public class SqlServerTranslator extends AbstractTranslator {
 
         if (Function.STDDEV.equals(function)) {
             function = "STDEV";
-        } else if (Function.AVG.equals(function)) {
+        }
+
+        if (Function.AVG.equals(function)) {
             expTranslated = String.format("CONVERT(DOUBLE PRECISION, %s)", expTranslated);
-        } else if (Function.CEILING.equals(function)) {
+        }
+
+        if (Function.CEILING.equals(function)) {
             function = "CEILING";
         }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -103,10 +103,10 @@ public class SqlServerTranslator extends AbstractTranslator {
 
         if (Function.STDDEV.equals(function)) {
             function = "STDEV";
-        }
-
-        if (Function.AVG.equals(function)) {
+        } else if (Function.AVG.equals(function)) {
             expTranslated = String.format("CONVERT(DOUBLE PRECISION, %s)", expTranslated);
+        } else if (Function.CEILING.equals(function)) {
+            function = "CEILING";
         }
 
         // if it is a user-defined function

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -76,6 +76,7 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.L;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.all;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.avg;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.between;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.ceiling;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.coalesce;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.column;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.count;
@@ -89,6 +90,7 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.dropPK;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.entry;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.eq;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.f;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.floor;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.in;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.k;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.like;
@@ -1280,6 +1282,50 @@ public class EngineGeneralTest {
         List<Map<String, ResultColumn>> query = engine.query(select(min(column("COL1")).alias("MIN")).from(table("TEST")));
 
         assertEquals("result ok?", 0, (int) query.get(0).get("MIN").toInt());
+    }
+
+    @Test
+    public void floorTest() throws DatabaseEngineException {
+        test5Columns();
+
+        EntityEntry.Builder entry = entry()
+                .set("COL1", 2)
+                .set("COL2", false)
+                .set("COL3", 2.5D)
+                .set("COL4", 3L)
+                .set("COL5", "ADEUS");
+
+        for (int i = 0; i < 10; i++) {
+            entry.set("COL1", i);
+            engine.persist("TEST", entry
+                    .build());
+        }
+
+        List<Map<String, ResultColumn>> query = engine.query(select(floor(column("COL3")).alias("FLOOR")).from(table("TEST")));
+
+        assertEquals("result ok?", 2.0, query.get(0).get("FLOOR").toDouble(), 0.1);
+    }
+
+    @Test
+    public void ceilingTest() throws DatabaseEngineException {
+        test5Columns();
+
+        EntityEntry.Builder entry = entry()
+                .set("COL1", 2)
+                .set("COL2", false)
+                .set("COL3", 2.5D)
+                .set("COL4", 3L)
+                .set("COL5", "ADEUS");
+
+        for (int i = 0; i < 10; i++) {
+            entry.set("COL1", i);
+            engine.persist("TEST", entry
+                    .build());
+        }
+
+        List<Map<String, ResultColumn>> query = engine.query(select(ceiling(column("COL3")).alias("CEILING")).from(table("TEST")));
+
+        assertEquals("result ok?", 3.0, query.get(0).get("CEILING").toDouble(), 0.1);
     }
 
     @Test

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -132,6 +132,8 @@ import static org.junit.Assert.fail;
 public class EngineGeneralTest {
 
 
+    private static final double DELTA = 1e-7;
+
     protected DatabaseEngine engine;
     protected Properties properties;
 
@@ -1303,7 +1305,7 @@ public class EngineGeneralTest {
 
         List<Map<String, ResultColumn>> query = engine.query(select(floor(column("COL3")).alias("FLOOR")).from(table("TEST")));
 
-        assertEquals("result ok?", 2.0, query.get(0).get("FLOOR").toDouble(), 0.1);
+        assertEquals("result ok?", 2.0, query.get(0).get("FLOOR").toDouble(), DELTA);
     }
 
     @Test
@@ -1325,7 +1327,7 @@ public class EngineGeneralTest {
 
         List<Map<String, ResultColumn>> query = engine.query(select(ceiling(column("COL3")).alias("CEILING")).from(table("TEST")));
 
-        assertEquals("result ok?", 3.0, query.get(0).get("CEILING").toDouble(), 0.1);
+        assertEquals("result ok?", 3.0, query.get(0).get("CEILING").toDouble(), DELTA);
     }
 
     @Test


### PR DESCRIPTION
Implementation of Ceiling/Floor expressions, which are Engine agnostic and useful when working with doubles.

This closes #91.