### PR TITLE
Fix README tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,14 +439,10 @@ In this section we describe queries that make changes to the database, while in 
 
 |Function|Description|
 |:---|:---|
-|[update]|Creates an update query that will affect the table referred by the given expression.|
-|[set]|Expression that defines the values that will be assigned to each given column.|
-|[where]|Expression for filtering/selecting the affected entries.|
-|[table]|Creates a reference to a table of your choice.|
-[update]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#update(com.feedzai.commons.sql.abstraction.dml.Expression)
-[set]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/Update.html#set(com.feedzai.commons.sql.abstraction.dml.Expression...)
-[where]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/Update.html#where(com.feedzai.commons.sql.abstraction.dml.Expression)
-[table]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#table(java.lang.String)
+|[update](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#update(com.feedzai.commons.sql.abstraction.dml.Expression))|Creates an update query that will affect the table referred by the given expression.|
+|[set](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/Update.html#set(com.feedzai.commons.sql.abstraction.dml.Expression...))|Expression that defines the values that will be assigned to each given column.|
+|[where](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/Update.html#where(com.feedzai.commons.sql.abstraction.dml.Expression))|Expression for filtering/selecting the affected entries.|
+|[table](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#table(java.lang.String))|Creates a reference to a table of your choice.|
 
 Maybe you want to delete entries instead. In that case creating a delete query is required.
 
@@ -465,10 +461,8 @@ engine.executeUpdate(
 
 |Function|Description|
 |:---|:---|
-|[delete]|Creates a delete query that will affect the table referred by the given expression.|
-|[where]|Expression for filtering/selecting the affected entries.|
-[delete]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#delete(com.feedzai.commons.sql.abstraction.dml.Expression)
-[where]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/Delete.html#where(com.feedzai.commons.sql.abstraction.dml.Expression)
+|[delete](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#delete(com.feedzai.commons.sql.abstraction.dml.Expression))|Creates a delete query that will affect the table referred by the given expression.|
+|[where](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/Delete.html#where(com.feedzai.commons.sql.abstraction.dml.Expression))|Expression for filtering/selecting the affected entries.|
 
 ### Truncate Queries
 
@@ -484,8 +478,7 @@ engine.executeUpdate(truncate(table("stream")));
 
 |Function|Description|
 |:---|:---|
-|[truncate]|Creates a truncate query that will affect the table referred by the given expression.|
-[truncate]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#truncate(com.feedzai.commons.sql.abstraction.dml.Expression)
+|[truncate](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#truncate(com.feedzai.commons.sql.abstraction.dml.Expression))|Creates a truncate query that will affect the table referred by the given expression.|
 
 ### Selection Queries
 
@@ -524,13 +517,10 @@ The iterator closes automatically when it reaches the end of the result set, but
 
 |Function|Description|
 |:---|:---|
-|[query]|Processes a given query and computes the corresponding result. It returns a List of results if any. For each column a result is a Map that maps
+|[query](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#query(com.feedzai.commons.sql.abstraction.dml.Expression))|Processes a given query and computes the corresponding result. It returns a List of results if any. For each column a result is a Map that maps
 column names to ResultColumn objects.|
-|[iterator]|Returns an iterator to cycle through the result set. Preferable when dealing with large result sets.|
-|[toXXX]|ResultColumn provides methods to convert the data to the type of your preference. It throws an exception if you try to convert the underlying data to some incompatible type.|
-[query]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#query(com.feedzai.commons.sql.abstraction.dml.Expression)
-[iterator]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#iterator(com.feedzai.commons.sql.abstraction.dml.Expression)
-[toXXX]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/result/ResultColumn.html
+|[iterator](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#iterator(com.feedzai.commons.sql.abstraction.dml.Expression))|Returns an iterator to cycle through the result set. Preferable when dealing with large result sets.|
+|[toXXX](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/result/ResultColumn.html)|ResultColumn provides methods to convert the data to the type of your preference. It throws an exception if you try to convert the underlying data to some incompatible type.|
 
 Let's see this simple query in more detail.
 Where we list all entries in table Streams and return all columns.
@@ -876,12 +866,10 @@ engine.executeUpdate(view);
 ```
 |Function|Description|
 |:---|:---|
-|[createView]|Creates a view with the given name.|
-|[as]|Defines the query that provides the data for this view.|
-|[replace]|Whether or not the view creation is authorized to overwrite over existing views.|
-[createView]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#createView(java.lang.String)
-[as]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/View.html#as(com.feedzai.commons.sql.abstraction.dml.Expression)
-[replace]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/View.html#replace()
+|[createView](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#createView(java.lang.String))|Creates a view with the given name.|
+|[as](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/View.html#as(com.feedzai.commons.sql.abstraction.dml.Expression))|Defines the query that provides the data for this view.|
+|[replace](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/View.html#replace())|Whether or not the view creation is authorized to overwrite over existing views.|
+
 
 ## Further Documentation
 

--- a/README.md
+++ b/README.md
@@ -517,8 +517,7 @@ The iterator closes automatically when it reaches the end of the result set, but
 
 |Function|Description|
 |:---|:---|
-|[query](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#query(com.feedzai.commons.sql.abstraction.dml.Expression))|Processes a given query and computes the corresponding result. It returns a List of results if any. For each column a result is a Map that maps
-column names to ResultColumn objects.|
+|[query](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#query(com.feedzai.commons.sql.abstraction.dml.Expression))|Processes a given query and computes the corresponding result. It returns a List of results if any. For each column a result is a Map that maps column names to ResultColumn objects.|
 |[iterator](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#iterator(com.feedzai.commons.sql.abstraction.dml.Expression))|Returns an iterator to cycle through the result set. Preferable when dealing with large result sets.|
 |[toXXX](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/result/ResultColumn.html)|ResultColumn provides methods to convert the data to the type of your preference. It throws an exception if you try to convert the underlying data to some incompatible type.|
 

--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ A table is represented with a DbEntity and its properties can be defined with me
 
 |Function|Description|
 |:---|:---|
-|[name]|Select the name for this table.|
-|[addColumn]|Create a column with a given name and type. Additionally you can had autoincrement behaviour and define some extra constraints. There are two possible constraints available: UNIQUE and NOT_NULL.|
-|[pkFields]|Define which columns are part of the primary key.|
-[name]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#name(java.lang.String)
-[addColumn]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#pkFields(java.util.Collection)
-[pkFields]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#pkFields(java.util.Collection)
+|name|Select the name for this table.|
+|addColumn|Create a column with a given name and type. Additionally you can had autoincrement behaviour and define some extra constraints. There are two possible constraints available: UNIQUE and NOT_NULL.|
+|pkFields|Define which columns are part of the primary key.|
+[name](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#name(java.lang.String))
+[addColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#pkFields(java.util.Collection))
+[pkFields](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#pkFields(java.util.Collection))
 
 To create the data_type_table you call addEntity method on the previously created database engine.
 Depending on the policy you chose existing tables might be dropped before creation.

--- a/README.md
+++ b/README.md
@@ -211,19 +211,15 @@ A foreign key is created with dbFk(), and it is defined using these methods:
 
 |Function|Description|
 |:---|:---|
-|[addColumn]|Define which columns will be part of this constraint.|
-|[foreignTable]|Define the foreign table we are referring to.|
-|[addForeignColumn]|Selects the affected columns in the foreign table.|
-[addColumn]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbFk.Builder.html#addColumn(java.lang.String...)
-[foreignTable]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbFk.Builder.html#foreignTable(java.lang.String)
-[addForeignColumn]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbFk.Builder.html#addColumn(java.lang.String...)
+|[addColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbFk.Builder.html#addColumn(java.lang.String...))|Define which columns will be part of this constraint.|
+|[foreignTable](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbFk.Builder.html#foreignTable(java.lang.String))|Define the foreign table we are referring to.|
+|[addForeignColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbFk.Builder.html#addColumn(java.lang.String...)|Selects the affected columns in the foreign table.|
 
 Wait! Looks like we also created an index in the Stream table.
 
 |Function|Description|
 |:---|:---|
-|[addIndex]|Creates and index for the listed columns. If not specified, an index is not unique.|
-[addIndex]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#addIndex(boolean,%20java.lang.String...)
+|[addIndex](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#addIndex(boolean,%20java.lang.String...))|Creates and index for the listed columns. If not specified, an index is not unique.|
 
 The rest of the example case is created with the following code:
 
@@ -270,8 +266,7 @@ engine.dropEntity("stream_to_module");
 ```
 |Function|Description|
 |:---|:---|
-|[dropEntity]|Drops an entity given the name.|
-[dropEntity]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#dropEntity(java.lang.String)
+|[dropEntity](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#dropEntity(java.lang.String))|Drops an entity given the name.|
 
 ### Alter Table
 
@@ -289,10 +284,8 @@ engine.updateEntity(data_type_table);
 ```
 |Function|Description|
 |:---|:---|
-|[removeColumn]|Removes a column from the local representation of the table.|
-|[updateEntity]|Synchronizes the entity representation with the table in the database. If schema policy is set to drop-create the whole table is dropped and created again.|
-[removeColumn]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#removeColumn(java.lang.String)
-[updateEntity]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#updateEntity(com.feedzai.commons.sql.abstraction.ddl.DbEntity)
+|[removeColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#removeColumn(java.lang.String))|Removes a column from the local representation of the table.|
+|[updateEntity](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#updateEntity(com.feedzai.commons.sql.abstraction.ddl.DbEntity))|Synchronizes the entity representation with the table in the database. If schema policy is set to drop-create the whole table is dropped and created again.|
 
 Another mechanism to alter table is by using the AlterColumn expression creation and the executeUpdate method provided by the database engine.
 In this case changes are made to each column, one at a time.

--- a/README.md
+++ b/README.md
@@ -152,12 +152,9 @@ A table is represented with a DbEntity and its properties can be defined with me
 
 |Function|Description|
 |:---|:---|
-|name|Select the name for this table.|
-|addColumn|Create a column with a given name and type. Additionally you can had autoincrement behaviour and define some extra constraints. There are two possible constraints available: UNIQUE and NOT_NULL.|
-|pkFields|Define which columns are part of the primary key.|
-[name](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#name(java.lang.String))
-[addColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#pkFields(java.util.Collection))
-[pkFields](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#pkFields(java.util.Collection))
+[name](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#name(java.lang.String))|Select the name for this table.|
+[addColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#pkFields(java.util.Collection))|Create a column with a given name and type. Additionally you can had autoincrement behaviour and define some extra constraints. There are two possible constraints available: UNIQUE and NOT_NULL.|
+[pkFields](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbEntity.Builder.html#pkFields(java.util.Collection))|Define which columns are part of the primary key.|
 
 To create the data_type_table you call addEntity method on the previously created database engine.
 Depending on the policy you chose existing tables might be dropped before creation.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ A foreign key is created with dbFk(), and it is defined using these methods:
 |:---|:---|
 |[addColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbFk.Builder.html#addColumn(java.lang.String...))|Define which columns will be part of this constraint.|
 |[foreignTable](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbFk.Builder.html#foreignTable(java.lang.String))|Define the foreign table we are referring to.|
-|[addForeignColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbFk.Builder.html#addColumn(java.lang.String...)|Selects the affected columns in the foreign table.|
+|[addForeignColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbFk.Builder.html#addColumn(java.lang.String...))|Selects the affected columns in the foreign table.|
 
 Wait! Looks like we also created an index in the Stream table.
 
@@ -303,14 +303,10 @@ engine.executeUpdate(alterColumn);
 ```
 |Function|Description|
 |:---|:---|
-|[alterColumn]|Creates a expression of changing a given table schema affecting a column.|
-|[dbColumn]|Column definition. Provide new type and autoincrement behavior.|
-|[addConstraint]|Define the constraints you want the column to oblige to.|
-|[addConstraints]|Define the constraints you want the column to oblige to.|
-[alterColumn]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#alterColumn(com.feedzai.commons.sql.abstraction.dml.Expression,%20com.feedzai.commons.sql.abstraction.ddl.DbColumn)
-[dbColumn]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#dbColumn(java.lang.String,%20com.feedzai.commons.sql.abstraction.ddl.DbColumnType)
-[addConstraint]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbColumn.Builder.html#addConstraint(com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint)
-[addConstraints]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbColumn.Builder.html#addConstraints(java.util.Collection)
+|[alterColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#alterColumn(com.feedzai.commons.sql.abstraction.dml.Expression,%20com.feedzai.commons.sql.abstraction.ddl.DbColumn))|Creates a expression of changing a given table schema affecting a column.|
+|[dbColumn](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#dbColumn(java.lang.String,%20com.feedzai.commons.sql.abstraction.ddl.DbColumnType))|Column definition. Provide new type and autoincrement behavior.|
+|[addConstraint](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbColumn.Builder.html#addConstraint(com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint))|Define the constraints you want the column to oblige to.|
+|[addConstraints](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/ddl/DbColumn.Builder.html#addConstraints(java.util.Collection))|Define the constraints you want the column to oblige to.|
 
 It is also possible to remove the the primary key constraint.
 
@@ -325,8 +321,7 @@ engine.executeUpdate(dropPrimaryKey);
 ```
 |Function|Description|
 |:---|:---|
-|[dropPK]|Drops the primary key constraint on the given table.|
-[dropPK]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#dropPK(com.feedzai.commons.sql.abstraction.dml.Expression)
+|[dropPK](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.html#dropPK(com.feedzai.commons.sql.abstraction.dml.Expression))|Drops the primary key constraint on the given table.|
 
 ### Insertion Queries
 
@@ -347,8 +342,7 @@ EntityEntry data_type_entry =
 ```
 |Function|Description|
 |:---|:---|
-|[set]|Define the value that will be assigned to a given column.|
-[set]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/entry/EntityEntry.Builder.html#set(java.lang.String,%20java.lang.Object)
+|[set](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/entry/EntityEntry.Builder.html#set(java.lang.String,%20java.lang.Object))|Define the value that will be assigned to a given column.|
 
 Notice that the values for each column were defined using the set method.
 A new entry for the database is persisted with engine's method persist.
@@ -358,8 +352,7 @@ engine.persist("data_type", data_type_entry, false);
 ```
 |Function|Description|
 |:---|:---|
-|[persist]|Select the table in which the new entity will be inserted. If the affected table has an autoincrement column you might want to activate this flag. In case that the autoincrement behaviour is active, this method returns the generated key.|
-[persist]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#persist(java.lang.String,%20com.feedzai.commons.sql.abstraction.entry.EntityEntry)
+|[persist](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#persist(java.lang.String,%20com.feedzai.commons.sql.abstraction.entry.EntityEntry))|Select the table in which the new entity will be inserted. If the affected table has an autoincrement column you might want to activate this flag. In case that the autoincrement behaviour is active, this method returns the generated key.|
 
 If you want to use the autoincrement behavior you must activate the autoincrement flag when defining the entity.
 
@@ -415,18 +408,12 @@ try {
 ```
 |Function|Description|
 |:---|:---|
-|[beginTransaction]|Starts a transaction.|
-|[addBatch]|Adds an entry to the current batch.|
-|[flush]|Executes all entries registered in the batch.|
-|[commit]|Commits the current transaction transaction.|
-|[isTransactionActive]|Tests if the transaction is active.|
-|[rollback]|Rolls back the transaction.|
-[beginTransaction]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#beginTransaction()
-[addBatch]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#addBatch(java.lang.String,%20com.feedzai.commons.sql.abstraction.entry.EntityEntry)
-[flush]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#flush()
-[commit]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#commit()
-[isTransactionActive]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#isTransactionActive()
-[rollback]:http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#rollback()
+|[beginTransaction](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#beginTransaction())|Starts a transaction.|
+|[addBatch](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#addBatch(java.lang.String,%20com.feedzai.commons.sql.abstraction.entry.EntityEntry))|Adds an entry to the current batch.|
+|[flush](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#flush())|Executes all entries registered in the batch.|
+|[commit](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#commit())|Commits the current transaction transaction.|
+|[isTransactionActive](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#isTransactionActive())|Tests if the transaction is active.|
+|[rollback](http://feedzai.github.io/pdb/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.html#rollback())|Rolls back the transaction.|
 
 ### Updating and Deleting Queries
 


### PR DESCRIPTION
For some reason (maybe GitHub changed the makdown flavour syntax) the existing tables on the README file were not readable.

This PR fixes a bunch of them. There are still half needing to be fixed. Will try to find time to do it soon, or in case someone else is available to help on this