### PR TITLE
Support for Values clause.

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Values.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Values.java
@@ -24,7 +24,7 @@ import java.util.List;
  * The Values clause.
  *
  * @author Francisco Santos (francisco.santos@feedzai.com)
- * @since 2.3.1
+ * @since 2.4.0
  */
 public class Values extends Expression {
 
@@ -105,6 +105,9 @@ public class Values extends Expression {
 
     /**
      * A Row belonging to a Values clause.
+     *
+     * @author Francisco Santos (francisco.santos@feedzai.com)
+     * @since 2.4.0
      */
     public static class Row extends Expression {
         

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Values.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Values.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.feedzai.commons.sql.abstraction.dml;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.union;
+
+/**
+ * The union clause.
+ *
+ * @author Francisco Santos (francisco.santos@feedzai.com)
+ * @since 2.3.1
+ */
+public class Values extends Expression {
+
+    private final List<Row> rows;
+
+    private final String[] names;
+
+    public Values(String... names) {
+        this.names = names;
+        this.rows = new ArrayList<>();
+    }
+
+    public List<Row> getRows() {
+        return rows;
+    }
+
+    public String[] getNames() {
+        return names;
+    }
+
+    @Override
+    public String translate() {
+        return translator.translate(this);
+        /*if (this.translator instanceof PostgreSqlTranslator) {
+            // Engines that support VALUES.
+            this.rows.forEach(expression -> injector.injectMembers(expression));
+            final String translation = "VALUES " + this.rows.stream()
+                    .map(row -> {
+                        row.enclose();
+                        return row.translate();
+                    })
+                    .collect(Collectors.joining(", "));
+
+            if (this.names != null && this.names.length > 0) {
+                final String namesTranslation = Arrays.stream(this.names)
+                        .map(StringUtils::quotize)
+                        .collect(Collectors.joining(", "));
+                return "SELECT * FROM (" + translation + ") as \"temp\"(" + namesTranslation + ")";
+            } else {
+                return translation;
+            }
+
+        } else {
+
+            if (this.names != null && this.names.length > 0) {
+                this.rows.forEach(row -> row.names(this.names));
+            }
+            final Set<Expression> literals = this.rows.stream()
+                    .map(SqlBuilder::select)
+                    .collect(Collectors.toSet());
+
+            final Union union = union(literals).all();
+
+            injector.injectMembers(union);
+            return "SELECT * FROM (" + union.translate() + ") as \"temp\"";
+        }*/
+    }
+
+    public Values rows(final Row... newRows) {
+        this.rows.addAll(Arrays.asList(newRows));
+        return this;
+    }
+
+    public Values rows(final Collection<Row> newRows) {
+        this.rows.addAll(newRows);
+        return this;
+    }
+
+
+    public static class Row extends Expression {
+        private final List<Expression> expressions;
+
+        public Row(final Collection<Expression> expressions) {
+            this.expressions = new ArrayList<>(expressions);
+        }
+
+        public Row(final Expression... expressions) {
+            this.expressions = Arrays.asList(expressions);
+        }
+
+        public List<Expression> getExpressions() {
+            return expressions;
+        }
+
+        @Override
+        public String translate() {
+            return translator.translate(this);
+            /*if (names != null) {
+                for (int i = 0; i < this.names.length && i < expressions.size(); i++) {
+                    expressions.get(i).alias(this.names[i]);
+                }
+            }
+            expressions.forEach(expression -> injector.injectMembers(expression));
+            final String translation = expressions.stream()
+                    .map(Expression::translate)
+                    .collect(Collectors.joining(", "));
+            if (isEnclosed()) {
+                return "(" + translation + ")";
+            } else {
+                return translation;
+            }*/
+        }
+
+
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Values.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Values.java
@@ -76,31 +76,20 @@ public class Values extends Expression {
         return rows;
     }
 
+    /**
+     * Add a row to values.
+     *
+     * @param expressions row expressions.
+     * @return this values.
+     */
+    public Values row(final Expression... expressions) {
+        this.rows.add(new Row(expressions));
+        return this;
+    }
+
     @Override
     public String translate() {
         return translator.translate(this);
-    }
-
-    /**
-     * Adds rows to values.
-     *
-     * @param newRows new rows to be added.
-     * @return this values.
-     */
-    public Values rows(final Row... newRows) {
-        this.rows.addAll(Arrays.asList(newRows));
-        return this;
-    }
-
-    /**
-     * Adds rows to values.
-     *
-     * @param newRows new rows to be added.
-     * @return this values.
-     */
-    public Values rows(final Collection<Row> newRows) {
-        this.rows.addAll(newRows);
-        return this;
     }
 
     /**
@@ -118,19 +107,10 @@ public class Values extends Expression {
 
         /**
          * Creates a new row.
-         * 
-         * @param expressions the expressions on the row.
-         */
-        public Row(final Collection<Expression> expressions) {
-            this.expressions = new ArrayList<>(expressions);
-        }
-
-        /**
-         * Creates a new row.
          *
          * @param expressions the expressions on the row.
          */
-        public Row(final Expression... expressions) {
+        private Row(final Expression... expressions) {
             this.expressions = Arrays.asList(expressions);
         }
 
@@ -147,6 +127,5 @@ public class Values extends Expression {
         public String translate() {
             return translator.translate(this);
         }
-
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Values.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Values.java
@@ -20,31 +20,60 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.union;
-
 /**
- * The union clause.
+ * The Values clause.
  *
  * @author Francisco Santos (francisco.santos@feedzai.com)
  * @since 2.3.1
  */
 public class Values extends Expression {
 
+    /**
+     * The columns' aliases.
+     */
+    private final String[] aliases;
+
+    /**
+     * The rows.
+     */
     private final List<Row> rows;
 
-    private final String[] names;
-
-    public Values(String... names) {
-        this.names = names;
+    /**
+     * Creates a new Values.
+     * 
+     * @param aliases the columns' aliases.
+     */
+    public Values(final String... aliases) {
+        this.aliases = aliases;
         this.rows = new ArrayList<>();
     }
 
-    public List<Row> getRows() {
-        return rows;
+    /**
+     * Creates a new Values.
+     *
+     * @param aliases the columns' aliases.
+     */
+    public Values(final Collection<String> aliases) {
+        this.aliases = aliases.toArray(new String[0]);
+        this.rows = new ArrayList<>();
     }
 
-    public String[] getNames() {
-        return names;
+    /**
+     * Gets the columns' aliases.
+     *
+     * @return the columns' aliases.
+     */
+    public String[] getAliases() {
+        return aliases;
+    }
+
+    /**
+     * Gets the rows.
+     *
+     * @return the rows.
+     */
+    public List<Row> getRows() {
+        return rows;
     }
 
     @Override
@@ -85,28 +114,62 @@ public class Values extends Expression {
         }*/
     }
 
+    /**
+     * Adds rows to values.
+     *
+     * @param newRows new rows to be added.
+     * @return this values.
+     */
     public Values rows(final Row... newRows) {
         this.rows.addAll(Arrays.asList(newRows));
         return this;
     }
 
+    /**
+     * Adds rows to values.
+     *
+     * @param newRows new rows to be added.
+     * @return this values.
+     */
     public Values rows(final Collection<Row> newRows) {
         this.rows.addAll(newRows);
         return this;
     }
 
 
+    /**
+     * The internal Values expression Row
+     */
     public static class Row extends Expression {
+        
+        /**
+         * The list of expressions on the row.
+         */
         private final List<Expression> expressions;
 
+        /**
+         * Creates a new row.
+         * 
+         * @param expressions the expressions on the row.
+         */
         public Row(final Collection<Expression> expressions) {
             this.expressions = new ArrayList<>(expressions);
         }
 
+        /**
+         * Creates a new row.
+         *
+         * @param expressions the expressions on the row.
+         */
         public Row(final Expression... expressions) {
             this.expressions = Arrays.asList(expressions);
         }
 
+        /**
+         * Gets the list of expressions.
+         * 
+         * @return the list of expressions.
+         */
         public List<Expression> getExpressions() {
             return expressions;
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
@@ -20,7 +20,6 @@ import com.feedzai.commons.sql.abstraction.dml.*;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 
 import java.util.Collection;
-import java.util.stream.Collectors;
 
 import static com.feedzai.commons.sql.abstraction.dml.Function.*;
 import static com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter.*;
@@ -612,6 +611,18 @@ public final class SqlBuilder {
      */
     public static Union union(final Collection<Expression> expressions) {
         return new Union(expressions);
+    }
+
+    public static Values values(final String... alias) {
+        return new Values(alias);
+    }
+
+    public static Values.Row row(final Expression... expressions) {
+        return new Values.Row(expressions);
+    }
+
+    public static Values.Row row(final Collection<Expression> expressions) {
+        return new Values.Row(expressions);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
@@ -613,14 +613,42 @@ public final class SqlBuilder {
         return new Union(expressions);
     }
 
-    public static Values values(final String... alias) {
-        return new Values(alias);
+    /**
+     * Creates a values expression.
+     *
+     * @param aliases the columns' aliases.
+     * @return The values representation.
+     */
+    public static Values values(final String... aliases) {
+        return new Values(aliases);
     }
 
+    /**
+     * Creates a values expression.
+     *
+     * @param aliases the columns' aliases.
+     * @return The values representation.
+     */
+    public static Values values(final Collection<String> aliases) {
+        return new Values(aliases);
+    }
+
+    /**
+     * Creates a row expression.
+     *
+     * @param expressions the row's expressions.
+     * @return The row representation.
+     */
     public static Values.Row row(final Expression... expressions) {
         return new Values.Row(expressions);
     }
 
+    /**
+     * Creates a row expression.
+     *
+     * @param expressions the row's expressions.
+     * @return The row representation.
+     */
     public static Values.Row row(final Collection<Expression> expressions) {
         return new Values.Row(expressions);
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
@@ -634,26 +634,6 @@ public final class SqlBuilder {
     }
 
     /**
-     * Creates a row expression.
-     *
-     * @param expressions the row's expressions.
-     * @return The row representation.
-     */
-    public static Values.Row row(final Expression... expressions) {
-        return new Values.Row(expressions);
-    }
-
-    /**
-     * Creates a row expression.
-     *
-     * @param expressions the row's expressions.
-     * @return The row representation.
-     */
-    public static Values.Row row(final Collection<Expression> expressions) {
-        return new Values.Row(expressions);
-    }
-
-    /**
      * The not equal expression.
      *
      * @param exps The expressions.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
@@ -445,6 +445,7 @@ public abstract class AbstractTranslator {
             rows.forEach(row -> {
                 final List<Expression> expressions = row.getExpressions();
                 for (int i = 0; i < expressions.size() && i < aliases.length; i++) {
+                    // DISCLAIMER : May have side-effects because will change the state of the row's expressions.
                     expressions.get(i).alias(aliases[i]);
                 }
             });

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
@@ -452,6 +452,7 @@ public abstract class AbstractTranslator {
 
         return row.getExpressions().stream()
                 .map(expression -> {
+                    // Enforce aliases to be translated.
                     final String alias = expression.isAliased() ? " AS " + quotize(expression.getAlias()) : "";
                     return expression.translate() + alias;
                 })

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
@@ -437,8 +437,11 @@ public abstract class AbstractTranslator {
         final ArrayList<Values.Row> rows = new ArrayList<>(values.getRows());
         final String[] aliases = values.getAliases();
 
-        // Given a list of rows and if aliases exist, apply them.
-        if (aliases != null) {
+        // If aliases does not exist, throw an exception.
+        // Otherwise, apply them to the columns.
+        if (aliases == null || aliases.length == 0) {
+            throw new DatabaseEngineRuntimeException("Values requires aliases to avoid ambiguous columns names.");
+        } else {
             rows.forEach(row -> {
                 final List<Expression> expressions = row.getExpressions();
                 for (int i = 0; i < expressions.size() && i < aliases.length; i++) {
@@ -476,7 +479,7 @@ public abstract class AbstractTranslator {
                 })
                 .collect(Collectors.joining(", "));
 
-        return row.isEnclosed() ? "(" + translation + ")": translation;
+        return row.isEnclosed() ? "(" + translation + ")" : translation;
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
@@ -371,14 +371,15 @@ public class PostgreSqlTranslator extends AbstractTranslator {
                 })
                 .collect(Collectors.joining(", "));
 
-        // If aliases exist, apply them to the columns.
-        if (aliases != null) {
+        // If aliases does not exist, throw an exception.
+        // Otherwise, apply them to the columns.
+        if (aliases == null || aliases.length == 0) {
+            throw new DatabaseEngineRuntimeException("Values requires aliases to avoid ambiguous columns names.");
+        } else {
             final String namesTranslation = Arrays.stream(aliases)
                     .map(StringUtils::quotize)
                     .collect(Collectors.joining(", "));
             return "SELECT * FROM (" + translation + ") as \"temp\"(" + namesTranslation + ")";
-        } else {
-            return translation;
         }
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
@@ -29,6 +29,7 @@ import com.feedzai.commons.sql.abstraction.dml.Name;
 import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
 import com.feedzai.commons.sql.abstraction.dml.StringAgg;
+import com.feedzai.commons.sql.abstraction.dml.Values;
 import com.feedzai.commons.sql.abstraction.dml.View;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
@@ -38,7 +39,9 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.VARCHAR_SIZE;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -351,6 +354,32 @@ public class PostgreSqlTranslator extends AbstractTranslator {
         return String.format("CAST(%s AS %s)",
                 cast.getExpression().translate(),
                 type);
+    }
+
+    @Override
+    public String translate(final Values values) {
+        final String[] aliases = values.getAliases();
+        final List<Values.Row> rows = values.getRows();
+
+        inject(rows);
+
+        // Enclose all rows and join them using a comma.
+        final String translation = "VALUES " + rows.stream()
+                .map(row -> {
+                    row.enclose();
+                    return row.translate();
+                })
+                .collect(Collectors.joining(", "));
+
+        // If aliases exist, apply them to the columns.
+        if (aliases != null) {
+            final String namesTranslation = Arrays.stream(aliases)
+                    .map(StringUtils::quotize)
+                    .collect(Collectors.joining(", "));
+            return "SELECT * FROM (" + translation + ") as \"temp\"(" + namesTranslation + ")";
+        } else {
+            return translation;
+        }
     }
 
     @Override

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -118,7 +118,6 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.mod;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.neq;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.notBetween;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.or;
-import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.row;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.select;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.stddev;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.stringAgg;
@@ -2340,11 +2339,12 @@ public class EngineGeneralTest {
 
     @Test
     public void testValues() throws DatabaseEngineException {
-        final Values values = values("id", "name")
-                .rows(row(k(1), k("ana")),
-                        row(k(2), k("fred")),
-                        row(k(3), k("manuel")),
-                        row(k(4), k("rita")));
+        final Values values =
+                values("id", "name")
+                    .row(k(1), k("ana"))
+                    .row(k(2), k("fred"))
+                    .row(k(3), k("manuel"))
+                    .row(k(4), k("rita"));
 
         final List<Map<String, ResultColumn>> result = engine.query(values);
 
@@ -2367,6 +2367,22 @@ public class EngineGeneralTest {
         assertEquals("name must be 'fred'", "fred", names.get(1));
         assertEquals("name must be 'manuel'", "manuel", names.get(2));
         assertEquals("name must be 'rita'", "rita", names.get(3));
+    }
+
+    @Test(expected = DatabaseEngineRuntimeException.class)
+    public void testValuesNoAliases() throws DatabaseEngineException {
+        final Values values =
+                values()
+                    .row(k(1), k("ana"))
+                    .row(k(2), k("fred"))
+                    .row(k(3), k("manuel"))
+                    .row(k(4), k("rita"));
+        try {
+            engine.query(values);
+        } catch (DatabaseEngineRuntimeException e) {
+            assertEquals("Values requires aliases to avoid ambiguous columns names.", e.getMessage());
+            throw e;
+        }
     }
 
     @Test

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -29,6 +29,7 @@ import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.Truncate;
 import com.feedzai.commons.sql.abstraction.dml.Union;
 import com.feedzai.commons.sql.abstraction.dml.Update;
+import com.feedzai.commons.sql.abstraction.dml.Values;
 import com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder;
 import com.feedzai.commons.sql.abstraction.dml.With;
 import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
@@ -117,6 +118,7 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.mod;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.neq;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.notBetween;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.or;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.row;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.select;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.stddev;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.stringAgg;
@@ -127,6 +129,7 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.union;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.update;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.upper;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.with;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.values;
 import static com.feedzai.commons.sql.abstraction.engine.EngineTestUtils.buildEntity;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
@@ -2333,6 +2336,34 @@ public class EngineGeneralTest {
         assertEquals("COL5 must be c", "c", resultSorted.get(2));
         assertEquals("COL5 must be d", "d", resultSorted.get(3));
         assertEquals("COL5 must be d", "d", resultSorted.get(4));
+    }
+
+    @Test
+    public void testValues() throws DatabaseEngineException {
+        test5Columns();
+        engine.persist("TEST", entry().set("COL1", 1).set("COL5", "teste")
+                .build());
+        engine.persist("TEST", entry().set("COL1", 2).set("COL5", "xpto")
+                .build());
+        engine.persist("TEST", entry().set("COL1", 3).set("COL5", "xpto")
+                .build());
+        engine.persist("TEST", entry().set("COL1", 4).set("COL5", "teste")
+                .build());
+
+        final Values values = values("id", "name")
+                .rows(row(k(1), k("ana")));
+                //        row(k(2), k("fred")),
+                //        row(k(3), k("manuel")),
+                //        row(k(4), k("rita")));
+        System.out.println("LALA");
+        final List<Map<String, ResultColumn>> result = engine.query(values);
+        System.out.println("lol " + result.get(0).get("name").toString());
+
+
+        // assertEquals("COL5 must be LOL", "LOL", result.get(0).get("case").toString());
+        // assertEquals("COL5 must be ROFL", "ROFL", result.get(1).get("case").toString());
+        // assertEquals("COL5 must be ROFL", "ROFL", result.get(2).get("case").toString());
+        // assertEquals("COL5 must be LOL", "LOL", result.get(3).get("case").toString());
     }
 
     @Test

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -2350,6 +2350,7 @@ public class EngineGeneralTest {
         engine.persist("TEST", entry().set("COL1", 4).set("COL5", "teste")
                 .build());
 
+        System.out.println("ola");
         final Values values = values("id", "name")
                 .rows(row(k(1), k("ana")),
                         row(k(2), k("fred")),
@@ -2358,15 +2359,25 @@ public class EngineGeneralTest {
 
         final List<Map<String, ResultColumn>> result = engine.query(values);
 
-        assertEquals("id must be 1", new Integer(1), result.get(0).get("id").toInt());
-        assertEquals("id must be 2", new Integer(2), result.get(1).get("id").toInt());
-        assertEquals("id must be 3", new Integer(3), result.get(2).get("id").toInt());
-        assertEquals("id must be 4", new Integer(4), result.get(3).get("id").toInt());
+        final List<Integer> ids = result.stream()
+                .map(row -> row.get("id").toInt())
+                .sorted()
+                .collect(Collectors.toList());
 
-        assertEquals("name must be 'ana'", "ana", result.get(0).get("name").toString());
-        assertEquals("name must be 'fred'", "fred", result.get(1).get("name").toString());
-        assertEquals("name must be 'manuel'", "manuel", result.get(2).get("name").toString());
-        assertEquals("name must be 'rita'", "rita", result.get(3).get("name").toString());
+        final List<String> names = result.stream()
+                .map(row -> row.get("name").toString())
+                .sorted()
+                .collect(Collectors.toList());
+
+        assertEquals("id must be 1", new Integer(1), ids.get(0));
+        assertEquals("id must be 2", new Integer(2), ids.get(1));
+        assertEquals("id must be 3", new Integer(3), ids.get(2));
+        assertEquals("id must be 4", new Integer(4), ids.get(3));
+
+        assertEquals("name must be 'ana'", "ana", names.get(0));
+        assertEquals("name must be 'fred'", "fred", names.get(1));
+        assertEquals("name must be 'manuel'", "manuel", names.get(2));
+        assertEquals("name must be 'rita'", "rita", names.get(3));
     }
 
     @Test

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -38,6 +38,7 @@ import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.ConnectionResetException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -2351,19 +2351,22 @@ public class EngineGeneralTest {
                 .build());
 
         final Values values = values("id", "name")
-                .rows(row(k(1), k("ana")));
-                //        row(k(2), k("fred")),
-                //        row(k(3), k("manuel")),
-                //        row(k(4), k("rita")));
-        System.out.println("LALA");
+                .rows(row(k(1), k("ana")),
+                        row(k(2), k("fred")),
+                        row(k(3), k("manuel")),
+                        row(k(4), k("rita")));
+
         final List<Map<String, ResultColumn>> result = engine.query(values);
-        System.out.println("lol " + result.get(0).get("name").toString());
 
+        assertEquals("id must be 1", new Integer(1), result.get(0).get("id").toInt());
+        assertEquals("id must be 2", new Integer(2), result.get(1).get("id").toInt());
+        assertEquals("id must be 3", new Integer(3), result.get(2).get("id").toInt());
+        assertEquals("id must be 4", new Integer(4), result.get(3).get("id").toInt());
 
-        // assertEquals("COL5 must be LOL", "LOL", result.get(0).get("case").toString());
-        // assertEquals("COL5 must be ROFL", "ROFL", result.get(1).get("case").toString());
-        // assertEquals("COL5 must be ROFL", "ROFL", result.get(2).get("case").toString());
-        // assertEquals("COL5 must be LOL", "LOL", result.get(3).get("case").toString());
+        assertEquals("name must be 'ana'", "ana", result.get(0).get("name").toString());
+        assertEquals("name must be 'fred'", "fred", result.get(1).get("name").toString());
+        assertEquals("name must be 'manuel'", "manuel", result.get(2).get("name").toString());
+        assertEquals("name must be 'rita'", "rita", result.get(3).get("name").toString());
     }
 
     @Test

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -2340,17 +2340,6 @@ public class EngineGeneralTest {
 
     @Test
     public void testValues() throws DatabaseEngineException {
-        test5Columns();
-        engine.persist("TEST", entry().set("COL1", 1).set("COL5", "teste")
-                .build());
-        engine.persist("TEST", entry().set("COL1", 2).set("COL5", "xpto")
-                .build());
-        engine.persist("TEST", entry().set("COL1", 3).set("COL5", "xpto")
-                .build());
-        engine.persist("TEST", entry().set("COL1", 4).set("COL5", "teste")
-                .build());
-
-        System.out.println("ola");
         final Values values = values("id", "name")
                 .rows(row(k(1), k("ana")),
                         row(k(2), k("fred")),


### PR DESCRIPTION
PostgreSQL supports the VALUES clause. 
As alternative UNION ALL was used to support the other engines.
Closes #104