### PR TITLE
Fix interrupted exceptions being treated as errors

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -362,8 +362,12 @@ public abstract class AbstractBatch implements Runnable {
                     processBatch(temp);
 
                     success = true;
-                } catch (final Exception exc) {
-                    logger.warn(dev, "[{}] Error occurred while flushing (retry attempt {}).", name, retryCount + 1, exc);
+                } catch (final InterruptedException ex) {
+                    logger.debug("Interrupted while trying to flush batch. Stopping retries.");
+                    Thread.currentThread().interrupt();
+                    break;
+                } catch (final Exception ex) {
+                    logger.warn(dev, "[{}] Error occurred while flushing (retry attempt {}).", name, retryCount + 1, ex);
                 }
             }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -355,8 +355,10 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
 
                 // return it.
                 return conn;
+            } catch (final InterruptedException ex) {
+                logger.debug("Thread interrupted.");
+                throw new InterruptedException();
             } catch (final SQLException ex) {
-
                 logger.debug("Connection failed.");
 
                 if (maximumNumberOfTries > 0 && retries > maximumNumberOfTries) {


### PR DESCRIPTION
Some `InterruptedException`s were being treated as error exceptions. This means that even when the thread executing a query was interrupted, it would continue to retry the query.