### PR TITLE
Disable auto server on the H2 connection in order to improve test performance

### DIFF
--- a/src/test/resources/connections.properties
+++ b/src/test/resources/connections.properties
@@ -1,7 +1,7 @@
 # default databases/schemas commented
 
 h2.engine=com.feedzai.commons.sql.abstraction.engine.impl.H2Engine
-h2.jdbc=jdbc:h2:./target/pdb
+h2.jdbc=jdbc:h2:./target/pdb;AUTO_SERVER=FALSE
 h2.username=pdb
 h2.password=pdb
 


### PR DESCRIPTION
This change reduces the time it takes to run the tests on a Mac from over 30 minutes to just around 1 minute.