### PR TITLE
[Oracle] Batch inserts/updates with LOBs don't free temporary LOB (fixes #114)

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -1035,13 +1035,30 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
             }
 
             PreparedStatement ps = me.getInsert();
-            entityToPreparedStatement(me.getEntity(), ps, entry, true);
+            entityToPreparedStatementForBatch(me.getEntity(), ps, entry, true);
 
             ps.addBatch();
         } catch (final Exception ex) {
             throw new DatabaseEngineException("Error adding to batch", ex);
         }
 
+    }
+
+    /**
+     * Translates the given entry entity to the prepared statement when used in the context of
+     * batch updates. This is to be overriden on engines where a distinct treatment is required
+     * for these situations.
+     *
+     * @param entity The entity.
+     * @param ps     The prepared statement.
+     * @param entry  The entry.
+     * @return The prepared statement filled in.
+     * @throws DatabaseEngineException if something occurs during the translation.
+     *
+     * @since 2.4.2
+     */
+    protected int entityToPreparedStatementForBatch(final DbEntity entity, final PreparedStatement ps, final EntityEntry entry, final boolean useAutoIncs) throws DatabaseEngineException {
+        return entityToPreparedStatement(entity, ps, entry, useAutoIncs);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -233,7 +233,7 @@ public class OracleEngine extends AbstractDatabaseEngine {
                             // it when the PreparedStatement is closed. This will be closed
                             // explicitly when the batch is flushed.
                             final Blob blob = ps.getConnection().createBlob();
-                            blob.setBytes(1, objectToArray(val));
+                            blob.setBytes(1, valArray);
                             ps.setBlob(i, blob);
                             postFlushActions.add(blob::free);
                         } else {
@@ -254,7 +254,7 @@ public class OracleEngine extends AbstractDatabaseEngine {
                                 // it when the PreparedStatement is closed. This will be closed
                                 // explicitly when the batch is flushed.
                                 final Clob clob = ps.getConnection().createClob();
-                                clob.setString(1, (String) val);
+                                clob.setString(1, valString);
                                 ps.setClob(i, clob);
                                 postFlushActions.add(clob::free);
                             } else {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -38,6 +38,8 @@ import com.google.common.collect.ImmutableList;
 import oracle.jdbc.OraclePreparedStatement;
 import oracle.jdbc.OracleTypes;
 
+import java.sql.Blob;
+import java.sql.Clob;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -45,9 +47,11 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -117,6 +121,27 @@ public class OracleEngine extends AbstractDatabaseEngine {
     private static final Double ZERO = 0.0;
 
     /**
+     * The size (in bytes) of a column after which {@link Blob blobs} are used for batch inserts.
+     *
+     * @since 2.4.2
+     */
+    private static final int MIN_SIZE_FOR_BLOB = 3900;
+
+    /**
+     * The size (in characters) of a column after which {@link Clob clobs} are used for batch inserts.
+     *
+     * @since 2.4.2
+     */
+    private static final int MIN_SIZE_FOR_CLOB = 35000;
+
+    /**
+     * The actions that need to be performed after the current batch is flushed.
+     *
+     * @since 2.4.2
+     */
+    private Deque<Action0> postFlushActions = new ConcurrentLinkedDeque<>();
+
+    /**
      * Creates a new Oracle connection.
      *
      * @param properties The properties for the database connection.
@@ -145,7 +170,46 @@ public class OracleEngine extends AbstractDatabaseEngine {
     }
 
     @Override
+    public synchronized void flush() throws DatabaseEngineException {
+        super.flush();
+        while (!postFlushActions.isEmpty()) {
+            try {
+                postFlushActions.pop().apply();
+            } catch (Exception e) {
+                logger.error("Error on post flush action", e);
+            }
+        }
+    }
+
+    @Override
+    protected int entityToPreparedStatementForBatch(final DbEntity entity, final PreparedStatement originalPs, final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
+        return entityToPreparedStatement(entity, originalPs, entry, useAutoInc, true);
+    }
+
+    @Override
     protected int entityToPreparedStatement(final DbEntity entity, final PreparedStatement originalPs, final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
+        return entityToPreparedStatement(entity, originalPs, entry, useAutoInc, false);
+    }
+
+    /**
+     * Translates the given entry entity to the prepared statement.
+     *
+     * @param entity        The entity.
+     * @param originalPs    The prepared statement.
+     * @param entry         The entry.
+     * @param fromBatch     Indicates if this is being requested in the context of a
+     *                      batch update or not.
+     *
+     * @return The prepared statement filled in.
+     * @throws DatabaseEngineException if something occurs during the translation.
+     *
+     * @since 2.4.2
+     */
+    private int entityToPreparedStatement(final DbEntity entity,
+                                          final PreparedStatement originalPs,
+                                          final EntityEntry entry,
+                                          final boolean useAutoInc,
+                                          final boolean fromBatch) throws DatabaseEngineException {
         final OraclePreparedStatement ps = (OraclePreparedStatement) originalPs;
         int i = 1;
         for (final DbColumn column : entity.getColumns()) {
@@ -162,7 +226,19 @@ public class OracleEngine extends AbstractDatabaseEngine {
                 }
                 switch (column.getDbColumnType()) {
                     case BLOB:
-                        ps.setBytesForBlob(i, objectToArray(val));
+                        final byte[] valArray = objectToArray(val);
+                        if (fromBatch && valArray.length > MIN_SIZE_FOR_BLOB) {
+                            // Use a blob for columns greater than 4K when inside a batch
+                            // update because the Oracle driver creates one and only releases
+                            // it when the PreparedStatement is closed. This will be closed
+                            // explicitly when the batch is flushed.
+                            final Blob blob = ps.getConnection().createBlob();
+                            blob.setBytes(1, objectToArray(val));
+                            ps.setBlob(i, blob);
+                            postFlushActions.add(blob::free);
+                        } else {
+                            ps.setBytesForBlob(i, valArray);
+                        }
                         break;
                     case JSON:
                     case CLOB:
@@ -170,9 +246,20 @@ public class OracleEngine extends AbstractDatabaseEngine {
                             ps.setNull(i, Types.CLOB);
                             break;
                         }
-
                         if (val instanceof String) {
-                            ps.setStringForClob(i, (String) val);
+                            final String valString = (String) val;
+                            if (fromBatch && valString.length() > MIN_SIZE_FOR_CLOB) {
+                                // Use a clob for columns greater than 35K when inside a batch
+                                // update because the Oracle driver creates one and only releases
+                                // it when the PreparedStatement is closed. This will be closed
+                                // explicitly when the batch is flushed.
+                                final Clob clob = ps.getConnection().createClob();
+                                clob.setString(1, (String) val);
+                                ps.setClob(i, clob);
+                                postFlushActions.add(clob::free);
+                            } else {
+                                ps.setStringForClob(i, valString);
+                            }
                         } else {
                             throw new DatabaseEngineException("Cannot convert " + val.getClass().getSimpleName() + " to String. CLOB columns only accept Strings.");
                         }
@@ -1046,4 +1133,17 @@ public class OracleEngine extends AbstractDatabaseEngine {
     protected ResultIterator createResultIterator(PreparedStatement ps) throws DatabaseEngineException {
         return new OracleResultIterator(ps);
     }
+
+    /**
+     * Represents an action that can throw any exception.
+     * Has no parameters and returns void.
+     */
+    @FunctionalInterface
+    public interface Action0 {
+        /**
+         * Executes the action.
+         */
+        void apply() throws Exception;
+    }
+
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
@@ -266,45 +266,19 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
 
     /**
      * This is a regression test for https://github.com/feedzai/pdb/issues/114. It inserts
-     * 10 rows containing a BLOB column using the batch update interface and ensures that
-     * no temp lOBs are left.
+     * 10 rows using the batch update interface and ensures that no temp LOBs are left.
      *
      * @throws Exception Should not be thrown.
      * @since 2.4.2
      */
     @Test
-    public void testBlobBatchInsertClearsResources() throws Exception {
-        testLobBatchInsertClearsResources(BLOB);
-    }
-
-    /**
-     * This is a regression test for https://github.com/feedzai/pdb/issues/114. It inserts
-     * 10 rows containing a CLOB column using the batch update interface and ensures that
-     * no temp lOBs are left.
-     *
-     * @throws Exception Should not be thrown.
-     * @since 2.4.2
-     */
-    @Test
-    public void testClobBatchInsertClearsResources() throws Exception {
-        testLobBatchInsertClearsResources(CLOB);
-    }
-
-    /**
-     * This is a regression test for https://github.com/feedzai/pdb/issues/114. It inserts
-     * 10 rows using the batch update interface and ensures that no temp lOBs are left.
-     *
-     * @param testedColType  The type of LOB being tested, either
-     *                      {@link DbColumnType#CLOB} or {@link DbColumnType#BLOB}.
-     *
-     * @throws Exception Should not be thrown.
-     * @since 2.4.2
-     */
-    private void testLobBatchInsertClearsResources(final DbColumnType testedColType) throws Exception {
+    public void testLobBatchInsertClearsLobResources() throws Exception {
+        final String tableName = "TEST";
         final DbEntity entity = dbEntity()
-                .name("TEST")
+                .name(tableName)
                 .addColumn("COL1", STRING)
-                .addColumn("COL2", testedColType)
+                .addColumn("COL2", CLOB)
+                .addColumn("COL3", BLOB)
                 .build();
 
         try (DatabaseEngine engine = DatabaseFactory.getConnection(properties)) {
@@ -313,16 +287,21 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
             // Bach with huge size and timeout, so we control it explicitly
             final AbstractBatch batch = engine.createBatch(1000000, 2000000L, "Testing");
 
-            // Add 10 rows with a large CLOB
-            for (int rowIdx = 0; rowIdx < 10; rowIdx++) {
-                final StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < (testedColType == BLOB ? 4000 : 40000); i++) {
-                    sb.append("a");
-                }
-                final String bigString = sb.toString();
-                final EntityEntry entry = entry().set("COL1", "CENINHAS").set("COL2", bigString)
+            // Add 10 rows with a large LOBs
+            final StringBuilder clobValue = new StringBuilder();
+            for (int i = 0; i < 40000; i++) {
+                clobValue.append("a");
+            }
+            final byte[] blobValue = new byte[4000];
+            Arrays.fill(blobValue, (byte) 'x');
+            final int numRows = 10;
+            for (int rowIdx = 0; rowIdx < numRows; rowIdx++) {
+                final EntityEntry entry = entry()
+                        .set("COL1", "CENINHAS")
+                        .set("COL2", clobValue.toString())
+                        .set("COL3", blobValue)
                         .build();
-                batch.add("TEST", entry);
+                batch.add(tableName, entry);
             }
 
             // Flush the batch
@@ -340,6 +319,17 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
             rs.next();
             final int cachedLobs = rs.getInt(1);
             assertEquals("No cached lobs after batch update", 0, cachedLobs);
+
+            // Check that we read what we stored
+            final Expression query = select(all()).from(table(tableName));
+            final List<Map<String, ResultColumn>> result = engine.query(query);
+            assertEquals(numRows, result.size());
+
+            for (int i = 0; i < numRows; i++) {
+                assertEquals("CENINHAS", result.get(i).get("COL1").toString());
+                assertEquals(clobValue.toString(), result.get(i).get("COL2").toString());
+                assertTrue(Arrays.equals(blobValue, result.get(i).get("COL3").toBlob()));
+            }
         }
     }
 


### PR DESCRIPTION
On batch updates with LOB columns with a size greater than 4000 bytes, the oracle driver uses a temporary LOB that is never freed because PDB uses a single PreparedStatement for the whole session. This commit avoids this resource leak by using explicit LOBs on these circumstances, and releasing them explicitly when the batch is flushed. The OracleEngine was modified by adding an attribute with the actions that must be executed after the flush of the current batch, and ensuring that actions are added on addBatch() and performed on flush(). The state of this attribute reflects what was added to the batch of the current insert PreparedStatement, so it has the same resource release requirements as that PreparedStatement.