### PR TITLE
Update test environment (#116)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,11 @@
                 <artifactId>h2</artifactId>
                 <version>1.4.197</version>
             </dependency>
-            <!-- DB2 driver is not (officially) available in public repositories. -->
+            <dependency>
+                <groupId>com.ibm.db2</groupId>
+                <artifactId>jcc</artifactId>
+                <version>11.1.4.4</version>
+            </dependency>
             <dependency>
                 <groupId>com.microsoft.sqlserver</groupId>
                 <artifactId>mssql-jdbc</artifactId>
@@ -156,6 +160,12 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- IBM DB2 -->
+        <dependency>
+            <groupId>com.ibm.db2</groupId>
+            <artifactId>jcc</artifactId>
             <scope>provided</scope>
         </dependency>
         <!-- JMockit -->
@@ -633,7 +643,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>docker.io/filemon/oracle_11g:latest</name>
+                                    <name>iatebes/oracle_11g:latest</name>
                                     <alias>pdb-oracle</alias>
                                     <run>
                                         <namingStrategy>alias</namingStrategy>
@@ -643,7 +653,7 @@
                                         </ports>
                                         <wait>
                                             <time>40000</time>
-                                            <log>Database instance "orcl" warm started</log>
+                                            <log>Disconnected from Oracle Database 11g</log>
                                         </wait>
                                     </run>
                                 </image>
@@ -656,21 +666,6 @@
 
         <profile>
             <id>db2</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.ibm.db2.jcc</groupId>
-                    <artifactId>db2jcc4</artifactId>
-                    <version>10.1</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-            <repositories>
-                <repository>
-                    <id>alfresco-nexus-public</id>
-                    <name>Alfresco Public Repository</name>
-                    <url>https://artifacts.alfresco.com/nexus/content/repositories/public/</url>
-                </repository>
-            </repositories>
             <build>
                 <plugins>
                     <plugin>

--- a/src/test/resources/connections.properties
+++ b/src/test/resources/connections.properties
@@ -44,7 +44,7 @@ oracle.jdbc=jdbc:oracle:thin:@(DESCRIPTION=(ENABLE=broken)(ADDRESS_LIST=(ADDRESS
 # alternate short jdbc URL = jdbc:oracle:thin:@localhost:1521:orcl
 # default database: orcl is used because it's mandatory in jdbc url and it's the only one in the test server
 oracle.username=system
-oracle.password=admin
+oracle.password=oracle
 # for oracle, default schema is the same as user name
 #oracle.schema=system
 


### PR DESCRIPTION
The Oracle 11g image being used was not available anymore, was replaced by another public image.  
The IBM DB2 driver publicly available on Maven central is now used instead of the one from Alfresco Public Repository.
