### PR TITLE
[Oracle] Also clean temporary segment for LOB data when LOBs are freed (fixes #114)

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_ALLOW_COLUMN_DROP;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_BLOB_BUFFER_SIZE;
+import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_DISABLE_LOB_CACHING;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_FETCH_SIZE;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_ISOLATION_LEVEL;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_MAXIMUM_TIME_BATCH_SHUTDOWN;
@@ -144,6 +145,11 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
      * Property that indicates the lobs should be compressed. This depends on the database implementation.
      */
     public static final String COMPRESS_LOBS = "pdb.compress_lobs";
+    /**
+     * Property that indicates if LOB data caching should be disabled, to avoid consuming too much memory and/or disk
+     * space in the DB server. This depends on the database implementation.
+     */
+    public static final String DISABLE_LOB_CACHING = "pdb.disable_lob_caching";
 
     /**
      * Creates a new instance of an empty {@link PdbProperties}.
@@ -175,6 +181,7 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
             setProperty(FETCH_SIZE, DEFAULT_FETCH_SIZE);
             setProperty(MAXIMUM_TIME_BATCH_SHUTDOWN, DEFAULT_MAXIMUM_TIME_BATCH_SHUTDOWN);
             setProperty(COMPRESS_LOBS, DEFAULT_COMPRESS_LOBS);
+            setProperty(DISABLE_LOB_CACHING, DEFAULT_DISABLE_LOB_CACHING);
         }
     }
 
@@ -361,6 +368,15 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
      */
     public boolean shouldCompressLobs() {
         return Boolean.parseBoolean(getProperty(COMPRESS_LOBS));
+    }
+
+    /**
+     * Checks if LOB data caching should be disabled.
+     *
+     * @return {@code true} if LOB caching should be disabled, {@code false} otherwise.
+     */
+    public boolean isLobCachingDisabled() {
+        return Boolean.parseBoolean(getProperty(DISABLE_LOB_CACHING));
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -152,6 +152,14 @@ public class OracleEngine extends AbstractDatabaseEngine {
     }
 
     @Override
+    protected void connect() throws Exception {
+        super.connect();
+        // need to enable this for the session in order to clean temporary segment usage when cached LOBs are freed
+        // (followup on https://github.com/feedzai/pdb/issues/114)
+        query("alter session set events '60025 trace name context forever'");
+    }
+
+    @Override
     public synchronized void setParameters(final String name, final Object... params) throws DatabaseEngineException, ConnectionResetException {
         for(int i = 0 ; i < params.length ; i++) {
             params[i] = ensureNoUnderflow(params[i]);

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -154,9 +154,16 @@ public class OracleEngine extends AbstractDatabaseEngine {
     @Override
     protected void connect() throws Exception {
         super.connect();
-        // need to enable this for the session in order to clean temporary segment usage when cached LOBs are freed
-        // (followup on https://github.com/feedzai/pdb/issues/114)
-        query("alter session set events '60025 trace name context forever'");
+
+        if (this.properties.isLobCachingDisabled()) {
+            // need to enable this for the session in order to clean temporary segment usage when cached LOBs are freed
+            // (followup for https://github.com/feedzai/pdb/issues/114)
+            try {
+                query("alter session set events '60025 trace name context forever'");
+            } catch (final Exception ex) {
+                logger.debug("LOB caching is set to be disabled in properties, but it was not possible to disable for this DB session");
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -79,4 +79,9 @@ public final class Constants {
      * this behavior. The default value is {@code false}.
      */
     public static final boolean DEFAULT_COMPRESS_LOBS = false;
+    /**
+     * Indicates if LOB data caching should be disabled, to avoid consuming too much memory and/or disk space in the DB
+     * server. This is only possible on implementations that support this behavior. The default value is {@code false}.
+     */
+    public static final boolean DEFAULT_DISABLE_LOB_CACHING = false;
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
@@ -50,6 +50,7 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.k;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.select;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.table;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.COMPRESS_LOBS;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.DISABLE_LOB_CACHING;
 import static com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest.Ieee754Support.SUPPORTED_STRINGS;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static org.junit.Assert.assertArrayEquals;
@@ -277,6 +278,8 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
                 .addColumn("COL2", CLOB)
                 .addColumn("COL3", BLOB)
                 .build();
+
+        properties.setProperty(DISABLE_LOB_CACHING, Boolean.toString(true));
 
         try (DatabaseEngine engine = DatabaseFactory.getConnection(properties)) {
             engine.addEntity(entity);


### PR DESCRIPTION
Summary:
The changes in #115 made sure that the LOBs were freed after use, which
 cleared them from LOB cache.
However, this cache is merely a locator for temporary LOB data; to
 really remove that data after usage, the session needs to enable the
 Oracle 60025 Event for temp segment cleanup used for temp lobs.

For more information on the subject see
http://ksun-oracle.blogspot.com/2015/06/temporary-lob-memory-allocation-and.html