### PR TITLE
[PostgreSQL] Keep old behavior for default SSL mode

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -119,6 +119,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         final boolean sslEnabled = PGProperty.SSL.getBoolean(parsedProps) || "".equals(PGProperty.SSL.get(parsedProps));
         final String sslmode = PGProperty.SSL_MODE.get(parsedProps);
         if (sslEnabled && sslmode == null) {
+            logger.trace("SSL enabled without SSL mode specified: \"require\" will be used by default, appended to JDBC URL");
             return jdbc.concat(LEGACY_DEFAULT_SSL_MODE);
         }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -34,6 +34,8 @@ import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import org.postgresql.Driver;
+import org.postgresql.PGProperty;
 import org.postgresql.util.PGobject;
 
 import java.sql.Connection;
@@ -45,6 +47,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -79,6 +82,19 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
      * Table or view does not exist.
      */
     public static final String CONSTRAINT_NAME_ALREADY_EXISTS = "42710";
+    /**
+     * The default SSL mode for the connection, when that PostgreSQL property is not set in the JDBC URL but SSL is
+     * enabled.
+     *
+     * This is required to avoid requiring configuration changes, by keeping the old behavior where if SSL was enabled
+     * ("ssl" option present in JDBC URL, without arguments or with argument "true") but SSL mode was not set, then SSL
+     * mode would work as "require".
+     * The new behavior since driver v42.2.5 when SSL is enabled but SSL mode is not set is "verify-full".
+     *
+     * When using SSL it is recommended to perform the certificate verifications, but that should be explicitly set
+     * (either setting SSL mode as "verify-full", or using an SSL connection factory that already does that).
+     */
+    private static final String LEGACY_DEFAULT_SSL_MODE = "&" + PGProperty.SSL_MODE.getName() + "=require";
 
     /**
      * Creates a new PostgreSql connection.
@@ -88,6 +104,25 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
      */
     public PostgreSqlEngine(PdbProperties properties) throws DatabaseEngineException {
         super(POSTGRESQL_DRIVER, properties, Dialect.POSTGRESQL);
+    }
+
+    @Override
+    protected String getFinalJdbcConnection(final String jdbc) {
+        final Properties parsedProps = Driver.parseURL(jdbc, null);
+        if (parsedProps == null) {
+            return jdbc;
+        }
+
+        // If SSL is enabled ("ssl" option is present in JDBC URL, with argument "true" or without arguments)
+        // but SSL mode ("sslmode" option) is not set, use legacy behavior - consider "sslmode" = "require"
+        // NOTE: the properties should be explicitly set, this code may be reverted in the future
+        final boolean sslEnabled = PGProperty.SSL.getBoolean(parsedProps) || "".equals(PGProperty.SSL.get(parsedProps));
+        final String sslmode = PGProperty.SSL_MODE.get(parsedProps);
+        if (sslEnabled && sslmode == null) {
+            return jdbc.concat(LEGACY_DEFAULT_SSL_MODE);
+        }
+
+        return jdbc;
     }
 
     @Override


### PR DESCRIPTION
Summary:
The PostgreSQL driver was updated to the latest version 42.2.6 in commit
 3dc357883b819c7c6bab27e122e1598ed17450f6; since 42.2.5, when SSL is
 enabled but SSL mode is not set, it is assumed to be "verify-full" by
 default.

 SSL is considered enabled if the "ssl" option present in JDBC URL,
  either without arguments or with argument "true".

In the previous driver versions, if SSL was enabled and SSL mode was not
 set, then "require" would be the default.

To keep compatibility with the old behavior and avoid requiring
 configuration changes, this commit now changes the JDBC URL internally
 before connecting by setting "sslmode" to "require" if it is not set
 but SSL is enabled.

The SSL mode configuration should be explicitly set, and this code may
 be reverted in the future.