### PR TITLE
Add socket connection timeout.

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
@@ -30,6 +30,7 @@ import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_BLOB_BU
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_DISABLE_LOB_CACHING;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_FETCH_SIZE;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_ISOLATION_LEVEL;
+import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_LOGIN_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_MAXIMUM_TIME_BATCH_SHUTDOWN;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_MAX_IDENTIFIER_SIZE;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_RECONNECT_ON_LOST;
@@ -37,6 +38,7 @@ import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_RETRY_I
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SCHEMA_POLICY;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SECRET_LOCATION;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_COMPRESS_LOBS;
+import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SOCKET_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_VARCHAR_SIZE;
 
 /**
@@ -152,6 +154,16 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
     public static final String DISABLE_LOB_CACHING = "pdb.disable_lob_caching";
 
     /**
+     * Property that indicates the waiting time for the database connection to be established (in seconds)
+     */
+    public static final String LOGIN_TIMEOUT = "pdb.login_timeout";
+
+    /**
+     * Property that indicates the time, in seconds, of socket timeout.
+     */
+    public static final String SOCKET_TIMEOUT = "pdb.socket_timeout";
+
+    /**
      * Creates a new instance of an empty {@link PdbProperties}.
      */
     public PdbProperties() {
@@ -182,6 +194,8 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
             setProperty(MAXIMUM_TIME_BATCH_SHUTDOWN, DEFAULT_MAXIMUM_TIME_BATCH_SHUTDOWN);
             setProperty(COMPRESS_LOBS, DEFAULT_COMPRESS_LOBS);
             setProperty(DISABLE_LOB_CACHING, DEFAULT_DISABLE_LOB_CACHING);
+            setProperty(LOGIN_TIMEOUT, DEFAULT_LOGIN_TIMEOUT);
+            setProperty(SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
         }
     }
 
@@ -458,6 +472,24 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
      */
     public String getSchema() {
         return getProperty(SCHEMA);
+    }
+
+    /**
+     * Gets the socket login timeout (in seconds).
+     *
+     * @return The socket login timeout.
+     */
+    public String getLoginTimeout() {
+        return getProperty(LOGIN_TIMEOUT);
+    }
+
+    /**
+     * Gets the socket connection timeout (in seconds).
+     *
+     * @return The socket connection timeout.
+     */
+    public String getSocketTimeout() {
+        return getProperty(SOCKET_TIMEOUT);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -50,6 +50,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -156,6 +157,18 @@ public class DB2Engine extends AbstractDatabaseEngine {
         }
 
         return i - 1;
+    }
+
+    @Override
+    protected Properties getDBProperties() {
+        final Properties props = new Properties();
+        // in seconds
+        final String loginTimeout = this.properties.getLoginTimeout();
+        final String socketTimeout = this.properties.getSocketTimeout();
+        // in seconds
+        props.setProperty("loginTimeout", loginTimeout);
+        props.setProperty("socketTimeout", socketTimeout);
+        return props;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -41,6 +41,7 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -113,6 +114,19 @@ public class H2Engine extends AbstractDatabaseEngine {
         }
 
         return jdbc;
+    }
+
+    @Override
+    protected Properties getDBProperties() {
+        final Properties props = new Properties();
+        // in seconds
+        final String loginTimeout = this.properties.getLoginTimeout();
+        final String socketTimeout = this.properties.getSocketTimeout();
+        // in seconds
+        // Note: these settings don't work with H2
+        props.setProperty("loginTimeout", loginTimeout);
+        props.setProperty("socketTimeout", socketTimeout);
+        return props;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -48,6 +48,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
@@ -858,6 +859,18 @@ public class MySqlEngine extends AbstractDatabaseEngine {
                 logger.trace("Error closing result set.", a);
             }
         }
+    }
+
+    @Override
+    protected Properties getDBProperties() {
+        final Properties props = new Properties();
+        // in seconds
+        final String loginTimeout = this.properties.getLoginTimeout();
+        final String socketTimeout = this.properties.getSocketTimeout();
+        // in milliseconds
+        props.setProperty("loginTimeout", loginTimeout + "000");
+        props.setProperty("socketTimeout", socketTimeout + "000");
+        return props;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -37,6 +37,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import oracle.jdbc.OraclePreparedStatement;
 import oracle.jdbc.OracleTypes;
+import oracle.jdbc.driver.OracleConnection;
 
 import java.sql.Blob;
 import java.sql.Clob;
@@ -51,6 +52,7 @@ import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
@@ -149,6 +151,18 @@ public class OracleEngine extends AbstractDatabaseEngine {
      */
     public OracleEngine(PdbProperties properties) throws DatabaseEngineException {
         super(ORACLE_DRIVER, properties, Dialect.ORACLE);
+    }
+
+    @Override
+    protected Properties getDBProperties() {
+        final Properties props = new Properties();
+        // in seconds
+        final String loginTimeout = this.properties.getLoginTimeout();
+        final String socketTimeout = this.properties.getSocketTimeout();
+        // in milliseconds
+        props.setProperty(OracleConnection.CONNECTION_PROPERTY_THIN_NET_CONNECT_TIMEOUT, loginTimeout + "000");
+        props.setProperty(OracleConnection.CONNECTION_PROPERTY_THIN_READ_TIMEOUT, socketTimeout + "000");
+        return props;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -34,6 +34,7 @@ import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import oracle.jdbc.driver.OracleConnection;
 import org.postgresql.Driver;
 import org.postgresql.PGProperty;
 import org.postgresql.util.PGobject;
@@ -662,6 +663,18 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
             }
 
         }
+    }
+
+    @Override
+    protected Properties getDBProperties() {
+        final Properties props = new Properties();
+        // in seconds
+        final String loginTimeout = this.properties.getLoginTimeout();
+        final String socketTimeout = this.properties.getSocketTimeout();
+        // in seconds
+        props.setProperty("loginTimeout", loginTimeout);
+        props.setProperty("socketTimeout", socketTimeout);
+        return props;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -33,6 +33,7 @@ import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import oracle.jdbc.driver.OracleConnection;
 
 import java.io.StringReader;
 import java.sql.Connection;
@@ -43,6 +44,7 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -95,6 +97,18 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
      */
     public SqlServerEngine(PdbProperties properties) throws DatabaseEngineException {
         super(SQLSERVER_DRIVER, properties, Dialect.SQLSERVER);
+    }
+
+    @Override
+    protected Properties getDBProperties() {
+        final Properties props = new Properties();
+        // in seconds
+        final String loginTimeout = this.properties.getLoginTimeout();
+        final String socketTimeout = this.properties.getSocketTimeout();
+        // in milliseconds
+        props.setProperty("loginTimeout", loginTimeout + "000");
+        props.setProperty("socketTimeout", socketTimeout + "000");
+        return props;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -84,4 +84,16 @@ public final class Constants {
      * server. This is only possible on implementations that support this behavior. The default value is {@code false}.
      */
     public static final boolean DEFAULT_DISABLE_LOB_CACHING = false;
+
+    /**
+     * Default duration (in seconds) to wait for the database connection to be established.
+     * By default, there is no timeout at establishing the connection, so pdb will wait indefinitely for the database.
+     */
+    public static final String DEFAULT_LOGIN_TIMEOUT = "0";
+
+    /**
+     * The default socket connection timeout (in seconds).
+     * By default, there is no timeout at the socket level, so pdb will wait indefinitely for the database to respond the queries.
+     */
+    public static final String DEFAULT_SOCKET_TIMEOUT = "0";
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
@@ -25,6 +25,8 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.NameAlreadyExistsException;
+import com.feedzai.commons.sql.abstraction.engine.RecoveryException;
+import com.feedzai.commons.sql.abstraction.engine.RetryLimitExceededException;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
@@ -36,6 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -52,9 +55,11 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.table;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.udf;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.LOGIN_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SOCKET_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
 import static com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest.Ieee754Support.SUPPORTED_STRINGS;
 import static com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest.Ieee754Support.UNSUPPORTED;
@@ -418,6 +423,38 @@ public abstract class AbstractEngineSchemaTest {
     @Test(expected = Exception.class)
     public void testInsertBatchRandomValuesDoNoWorkInBinaryDoubleColumn() throws Exception {
         testInsertSpecialValuesByBatch("randomString");
+    }
+
+    /**
+     * Tests if the timeout setting is properly set in the connection socket to the database.
+     * Note: the DB2 and H2 databases don't support setting the connection socket timeout
+     *
+     * @throws DatabaseFactoryException
+     * @throws ClassNotFoundException
+     * @throws InterruptedException
+     * @throws RecoveryException
+     * @throws RetryLimitExceededException
+     * @throws SQLException
+     */
+    @Test
+    public void testTimeout() throws DatabaseFactoryException, ClassNotFoundException, InterruptedException, RecoveryException, RetryLimitExceededException, SQLException {
+        final int socketTimeout = 60;// in seconds
+        final int loginTimeout = 30;// in seconds
+        final Properties properties = new Properties() {
+            {
+                setProperty(JDBC, config.jdbc);
+                setProperty(USERNAME, config.username);
+                setProperty(PASSWORD, config.password);
+                setProperty(ENGINE, config.engine);
+                setProperty(SCHEMA_POLICY, "create");
+                setProperty(SOCKET_TIMEOUT, Integer.toString(socketTimeout));
+                setProperty(LOGIN_TIMEOUT, Integer.toString(loginTimeout));
+            }
+        };
+
+        final DatabaseEngine de = DatabaseFactory.getConnection(properties);
+        final int connectionTimeoutInMs = de.getConnection().getNetworkTimeout();
+        assertEquals("Is the timeout of the DB connection the expected?", socketTimeout * 1000, connectionTimeoutInMs);
     }
 
     /**

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/db2/DB2EngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/db2/DB2EngineSchemaTest.java
@@ -19,15 +19,31 @@ package com.feedzai.commons.sql.abstraction.engine.impl.db2;
 import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
+import com.feedzai.commons.sql.abstraction.engine.RecoveryException;
+import com.feedzai.commons.sql.abstraction.engine.RetryLimitExceededException;
 import com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.LOGIN_TIMEOUT;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SOCKET_TIMEOUT;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Joao Silva (joao.silva@feedzai.com)
@@ -94,5 +110,38 @@ public class DB2EngineSchemaTest extends AbstractEngineSchemaTest {
                 "   EXECUTE IMMEDIATE 'DROP SCHEMA \"" + schema + "\" RESTRICT';\n" +
                 "END"
         );
+    }
+
+    /**
+     * Tests if the timeout setting is properly set in the connection socket to the database.
+     * Note: the DB2 and H2 databases don't support setting the connection socket timeout
+     *
+     * @throws DatabaseFactoryException
+     * @throws ClassNotFoundException
+     * @throws InterruptedException
+     * @throws RecoveryException
+     * @throws RetryLimitExceededException
+     * @throws SQLException
+     */
+    @Test
+    public void testTimeout() throws DatabaseFactoryException, InterruptedException, RecoveryException, RetryLimitExceededException, SQLException {
+        final int socketTimeout = 60;// in seconds
+        final int loginTimeout = 30;// in seconds
+        final Properties properties = new Properties() {
+            {
+                setProperty(JDBC, config.jdbc);
+                setProperty(USERNAME, config.username);
+                setProperty(PASSWORD, config.password);
+                setProperty(ENGINE, config.engine);
+                setProperty(SCHEMA_POLICY, "create");
+                setProperty(SOCKET_TIMEOUT, Integer.toString(socketTimeout));
+                setProperty(LOGIN_TIMEOUT, Integer.toString(loginTimeout));
+            }
+        };
+
+        final DatabaseEngine de = DatabaseFactory.getConnection(properties);
+        final int connectionTimeoutInMs = de.getConnection().getNetworkTimeout();
+        // Not supported
+        assertEquals("Is the timeout of the DB connection disabled as expected?", 0, connectionTimeoutInMs);
     }
 }


### PR DESCRIPTION
The pdb doesn't have a connection timeout, so when the connection to the database fails abruptly, the threads block waiting for a response of a submitted query.
This new branch adds a connection and a login connection timeout (defined by the user) so it doesn't block the system.