### PR TITLE
Fix timeouts and use native JDBC timeouts where possible

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -162,7 +162,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * An {@link ExecutorService} to be used by the DB drivers to break a connection if it has been blocked for longer
      * than the specified socket timeout
      */
-    private ExecutorService socketTimeoutExecutor = Executors.newSingleThreadExecutor();
+    private final ExecutorService socketTimeoutExecutor = Executors.newSingleThreadExecutor();
 
     /**
      * Creates a new instance of {@link AbstractDatabaseEngine}.
@@ -238,7 +238,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      */
     protected Properties getDBProperties() {
         return new Properties();
-    };
+    }
 
     /**
      * Connects to the database.
@@ -283,8 +283,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
 
         this.conn = DriverManager.getConnection(jdbc, props);
 
-        // the "network timeout" is specified in milliseconds, needs to be converted from seconds
-        this.conn.setNetworkTimeout(socketTimeoutExecutor, this.properties.getSocketTimeout() * 1000);
+        this.conn.setNetworkTimeout(socketTimeoutExecutor, (int) TimeUnit.SECONDS.toMillis(this.properties.getSocketTimeout()));
 
         if (this.properties.isSchemaSet()) {
             setSchema(this.properties.getSchema());

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
@@ -154,7 +154,10 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
     public static final String DISABLE_LOB_CACHING = "pdb.disable_lob_caching";
 
     /**
-     * Property that indicates the waiting time for the database connection to be established (in seconds)
+     * Property that indicates the waiting time for the database connection to be established (in seconds).
+     *
+     * In some drivers this may refer only to the login timeout, in others it may refer to the total time to wait
+     * for getting a connection in addition to logging in.
      */
     public static final String LOGIN_TIMEOUT = "pdb.login_timeout";
 
@@ -479,8 +482,8 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
      *
      * @return The socket login timeout.
      */
-    public String getLoginTimeout() {
-        return getProperty(LOGIN_TIMEOUT);
+    public int getLoginTimeout() {
+        return Integer.parseInt(getProperty(LOGIN_TIMEOUT));
     }
 
     /**
@@ -488,8 +491,8 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
      *
      * @return The socket connection timeout.
      */
-    public String getSocketTimeout() {
-        return getProperty(SOCKET_TIMEOUT);
+    public int getSocketTimeout() {
+        return Integer.parseInt(getProperty(SOCKET_TIMEOUT));
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -50,7 +50,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -157,18 +156,6 @@ public class DB2Engine extends AbstractDatabaseEngine {
         }
 
         return i - 1;
-    }
-
-    @Override
-    protected Properties getDBProperties() {
-        final Properties props = new Properties();
-        // in seconds
-        final String loginTimeout = this.properties.getLoginTimeout();
-        final String socketTimeout = this.properties.getSocketTimeout();
-        // in seconds
-        props.setProperty("loginTimeout", loginTimeout);
-        props.setProperty("socketTimeout", socketTimeout);
-        return props;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -41,7 +41,6 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -114,19 +113,6 @@ public class H2Engine extends AbstractDatabaseEngine {
         }
 
         return jdbc;
-    }
-
-    @Override
-    protected Properties getDBProperties() {
-        final Properties props = new Properties();
-        // in seconds
-        final String loginTimeout = this.properties.getLoginTimeout();
-        final String socketTimeout = this.properties.getSocketTimeout();
-        // in seconds
-        // Note: these settings don't work with H2
-        props.setProperty("loginTimeout", loginTimeout);
-        props.setProperty("socketTimeout", socketTimeout);
-        return props;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -48,7 +48,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
@@ -859,18 +858,6 @@ public class MySqlEngine extends AbstractDatabaseEngine {
                 logger.trace("Error closing result set.", a);
             }
         }
-    }
-
-    @Override
-    protected Properties getDBProperties() {
-        final Properties props = new Properties();
-        // in seconds
-        final String loginTimeout = this.properties.getLoginTimeout();
-        final String socketTimeout = this.properties.getSocketTimeout();
-        // in milliseconds
-        props.setProperty("loginTimeout", loginTimeout + "000");
-        props.setProperty("socketTimeout", socketTimeout + "000");
-        return props;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -163,9 +164,10 @@ public class OracleEngine extends AbstractDatabaseEngine {
          long time, so an "initial" socket timeout is set here for the connection/login, and after the connection it is
          set to the value specified by the SOCKET_TIMEOUT Pdb property
          */
-        final int loginTimeoutSeconds = this.properties.getLoginTimeout();
-        // property requires milliseconds
-        props.setProperty(OracleConnection.CONNECTION_PROPERTY_THIN_READ_TIMEOUT, Integer.toString(loginTimeoutSeconds * 1000));
+        props.setProperty(
+                OracleConnection.CONNECTION_PROPERTY_THIN_READ_TIMEOUT,
+                Long.toString(TimeUnit.SECONDS.toMillis(this.properties.getLoginTimeout()))
+        );
 
         return props;
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -33,7 +33,6 @@ import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-import oracle.jdbc.driver.OracleConnection;
 
 import java.io.StringReader;
 import java.sql.Connection;
@@ -101,13 +100,18 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
 
     @Override
     protected Properties getDBProperties() {
-        final Properties props = new Properties();
-        // in seconds
-        final String loginTimeout = this.properties.getLoginTimeout();
-        final String socketTimeout = this.properties.getSocketTimeout();
-        // in milliseconds
-        props.setProperty("loginTimeout", loginTimeout + "000");
-        props.setProperty("socketTimeout", socketTimeout + "000");
+        final Properties props = super.getDBProperties();
+
+        /*
+         Driver supports DriverManager.setLoginTimeout but this login timeout only applies after the socket connection;
+         if there is a problem connecting (e.g. if the DB server is down) the connection process may be blocked for a
+         long time, so an "initial" socket timeout is set here for the connection/login, and after the connection it is
+         set to the value specified by the SOCKET_TIMEOUT Pdb property
+         */
+        final int loginTimeoutSeconds = this.properties.getLoginTimeout();
+        // property requires milliseconds
+        props.setProperty("socketTimeout", Integer.toString(loginTimeoutSeconds * 1000));
+
         return props;
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -44,6 +44,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -108,9 +109,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
          long time, so an "initial" socket timeout is set here for the connection/login, and after the connection it is
          set to the value specified by the SOCKET_TIMEOUT Pdb property
          */
-        final int loginTimeoutSeconds = this.properties.getLoginTimeout();
-        // property requires milliseconds
-        props.setProperty("socketTimeout", Integer.toString(loginTimeoutSeconds * 1000));
+        props.setProperty("socketTimeout", Long.toString(TimeUnit.SECONDS.toMillis(this.properties.getLoginTimeout())));
 
         return props;
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -89,11 +89,11 @@ public final class Constants {
      * Default duration (in seconds) to wait for the database connection to be established.
      * By default, there is no timeout at establishing the connection, so pdb will wait indefinitely for the database.
      */
-    public static final String DEFAULT_LOGIN_TIMEOUT = "0";
+    public static final int DEFAULT_LOGIN_TIMEOUT = 0;
 
     /**
      * The default socket connection timeout (in seconds).
      * By default, there is no timeout at the socket level, so pdb will wait indefinitely for the database to respond the queries.
      */
-    public static final String DEFAULT_SOCKET_TIMEOUT = "0";
+    public static final int DEFAULT_SOCKET_TIMEOUT = 0;
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
@@ -25,8 +25,6 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.NameAlreadyExistsException;
-import com.feedzai.commons.sql.abstraction.engine.RecoveryException;
-import com.feedzai.commons.sql.abstraction.engine.RetryLimitExceededException;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
@@ -38,7 +36,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
-import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -55,11 +52,9 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.table;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.udf;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.LOGIN_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SOCKET_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
 import static com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest.Ieee754Support.SUPPORTED_STRINGS;
 import static com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest.Ieee754Support.UNSUPPORTED;
@@ -423,38 +418,6 @@ public abstract class AbstractEngineSchemaTest {
     @Test(expected = Exception.class)
     public void testInsertBatchRandomValuesDoNoWorkInBinaryDoubleColumn() throws Exception {
         testInsertSpecialValuesByBatch("randomString");
-    }
-
-    /**
-     * Tests if the timeout setting is properly set in the connection socket to the database.
-     * Note: the DB2 and H2 databases don't support setting the connection socket timeout
-     *
-     * @throws DatabaseFactoryException
-     * @throws ClassNotFoundException
-     * @throws InterruptedException
-     * @throws RecoveryException
-     * @throws RetryLimitExceededException
-     * @throws SQLException
-     */
-    @Test
-    public void testTimeout() throws DatabaseFactoryException, ClassNotFoundException, InterruptedException, RecoveryException, RetryLimitExceededException, SQLException {
-        final int socketTimeout = 60;// in seconds
-        final int loginTimeout = 30;// in seconds
-        final Properties properties = new Properties() {
-            {
-                setProperty(JDBC, config.jdbc);
-                setProperty(USERNAME, config.username);
-                setProperty(PASSWORD, config.password);
-                setProperty(ENGINE, config.engine);
-                setProperty(SCHEMA_POLICY, "create");
-                setProperty(SOCKET_TIMEOUT, Integer.toString(socketTimeout));
-                setProperty(LOGIN_TIMEOUT, Integer.toString(loginTimeout));
-            }
-        };
-
-        final DatabaseEngine de = DatabaseFactory.getConnection(properties);
-        final int connectionTimeoutInMs = de.getConnection().getNetworkTimeout();
-        assertEquals("Is the timeout of the DB connection the expected?", socketTimeout * 1000, connectionTimeoutInMs);
     }
 
     /**

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/TimeoutsTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/TimeoutsTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl.abs;
+
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.LOGIN_TIMEOUT;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SOCKET_TIMEOUT;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Test the correct behavior of the PDB properties for timeouts.
+ *
+ * @author José Fidalgo
+ */
+@RunWith(Parameterized.class)
+public class TimeoutsTest {
+
+    /**
+     * The logger for this class.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(TimeoutsTest.class);
+
+    /**
+     * An executor to run actions asynchronously.
+     */
+    private ExecutorService executor = Executors.newCachedThreadPool();
+
+    /**
+     * The database properties to use in the tests.
+     */
+    private Properties dbProps;
+
+    /**
+     * The test value for the login timeout.
+     */
+    private static final int LOGIN_TIMEOUT_SECONDS = 2;
+
+    /**
+     * The test value for the socket timeout (this must be greater than the sum of {@link #LOGIN_TIMEOUT_SECONDS}
+     * and {@link #TIMEOUT_TOLERANCE_SECONDS}).
+     */
+    private static final int SOCKET_TIMEOUT_SECONDS = 6;
+
+    /**
+     * The tolerance to use when checking timeouts.
+     *
+     * This is needed because the drivers may take a few milliseconds after the set timeout value to effectively return;
+     * some other databases may take double the amount of time configured, because they consider login timeout
+     * separately from connection timeout when first establishing a connection to the DB.
+     */
+    private static final int TIMEOUT_TOLERANCE_SECONDS = 3;
+
+    /**
+     * A test "router" that simply forwards the data sent between a {@link DatabaseEngine} in this test and the DB.
+     * The connections can be interrupted without being closed, to test the correct functioning of the network timeouts.
+     */
+    private TestRouter testRouter;
+
+    @Parameterized.Parameters
+    public static Collection<DatabaseConfiguration> data() throws Exception {
+        return DatabaseTestUtil.loadConfigurations();
+    }
+
+    @Parameterized.Parameter
+    public DatabaseConfiguration config;
+
+    @Before
+    public void setupTest() throws IOException {
+        assertThat(SOCKET_TIMEOUT_SECONDS)
+                .as("This test should be configured with a socket timeout greater than login timeout (plus timeout tolerance)")
+                .isGreaterThan(LOGIN_TIMEOUT_SECONDS+ TIMEOUT_TOLERANCE_SECONDS);
+
+        dbProps = new Properties() {
+            {
+                setProperty(JDBC, config.jdbc);
+                setProperty(USERNAME, config.username);
+                setProperty(PASSWORD, config.password);
+                setProperty(ENGINE, config.engine);
+                setProperty(SCHEMA_POLICY, "create-drop");
+                put(LOGIN_TIMEOUT, LOGIN_TIMEOUT_SECONDS);
+                put(SOCKET_TIMEOUT, SOCKET_TIMEOUT_SECONDS);
+            }
+        };
+
+        final DatabaseEngineDriver engine = DatabaseEngineDriver.fromEngine(dbProps.getProperty(ENGINE));
+
+        // For H2 there is a socket timeout property but it must be defined as a system property, before the driver
+        // is loaded: see org.h2.engine.SysProperties
+        assumeTrue("H2 engine doesn't support setting timeouts, tests will be skipped", engine != DatabaseEngineDriver.H2);
+
+        final int defaultPort = engine.defaultPort();
+
+        testRouter = new TestRouter(executor, defaultPort);
+
+        dbProps.setProperty(JDBC, config.jdbc.replace("localhost:" + defaultPort, "localhost:" + testRouter.getLocalPort()));
+    }
+
+    @After
+    public void cleanResources() {
+        try {
+            testRouter.close();
+        } catch (final Exception ex) {
+            // ignore
+        }
+
+        executor.shutdownNow();
+    }
+
+    /**
+     * Tests that when the DB server is down, the login timeout forces a return from {@link DatabaseFactory#getConnection}
+     * in a timely fashion (with an Exception).
+     */
+    @Test
+    public void testLoginTimeout() {
+        final Future<DatabaseEngine> dbEngineFuture = executor.submit(() -> DatabaseFactory.getConnection(dbProps));
+
+        assertThatCode(() -> dbEngineFuture.get(LOGIN_TIMEOUT_SECONDS + TIMEOUT_TOLERANCE_SECONDS, TimeUnit.SECONDS))
+                .as("When the DB server is down, the DB engine creation should fail by timeout in the connection")
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(DatabaseFactoryException.class);
+    }
+
+    /**
+     * Tests that after a connection with the DB server has been successfully established, if that connection is broken
+     * a given action returns in a timely fashion (with an Exception), according to the configured socket timeout.
+     *
+     * In this test the action performed is {@link DatabaseEngine#checkConnection()}.
+     * The connection between the test DB engine and the DB server is broken <strong>without being closed</strong>
+     * (this may happen for example when a load balancer changes the connections to a DB server without closing the old
+     * ones to the client).
+     */
+    @Test
+    public void testNetworkTimeout() throws Exception {
+        testRouter.init();
+
+        final DatabaseEngine dbEngine = executor.submit(() -> DatabaseFactory.getConnection(dbProps))
+                .get(LOGIN_TIMEOUT_SECONDS + TIMEOUT_TOLERANCE_SECONDS, TimeUnit.SECONDS);
+
+        Future<Boolean> connCheckFuture = executor.submit(() -> dbEngine.checkConnection());
+        assertTrue("PDB should be connected to the DB server", connCheckFuture.get(LOGIN_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+        testRouter.breakConnections();
+
+        connCheckFuture = executor.submit(() -> dbEngine.checkConnection());
+
+        /*
+         we want to make sure that the login timeout (which is usually lower than socket timeout)
+          is not being used for timing out already established connections
+         */
+        TimeUnit.SECONDS.sleep(LOGIN_TIMEOUT_SECONDS + TIMEOUT_TOLERANCE_SECONDS);
+        assertThat(connCheckFuture)
+                .as("Connection check should only timeout after at least %d seconds", SOCKET_TIMEOUT_SECONDS)
+                .isNotDone();
+
+        assertFalse("After breaking connection, PDB should detect that it is not connected to the DB server",
+                connCheckFuture.get(SOCKET_TIMEOUT_SECONDS - LOGIN_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
+
+    /**
+     * A class that acts as a router, to forwards data sent between a {@link DatabaseEngine} in this test and the DB.
+     * This offers the possibility of interrupting the connections without closing them.
+     */
+    private static class TestRouter implements Closeable {
+
+        private final ServerSocket serverSocket = new ServerSocket(0);
+        private final Socket socketRouterToDb = new Socket();
+        private ExecutorService executor;
+        private final int dbPort;
+        private volatile boolean isRunning = true;
+
+        /**
+         * Constructor for this class.
+         *
+         * @param executor An {@link ExecutorService} to run tasks asynchronously.
+         * @param dbPort   The real DB server port.
+         * @throws IOException if some problem occurs creating a new {@link ServerSocket}.
+         */
+        private TestRouter(final ExecutorService executor, final int dbPort) throws IOException {
+            this.executor = executor;
+            this.dbPort = dbPort;
+        }
+
+        /**
+         * Gets the local port (that will act as the DB server port for the DB engine).
+         *
+         * @return the local port.
+         */
+        public int getLocalPort() {
+            return serverSocket.getLocalPort();
+        }
+
+        /**
+         * Initializes connections to/from the DB server.
+         *
+         * @throws IOException if there is a problem establishing connections.
+         */
+        public void init() throws IOException {
+            socketRouterToDb.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), dbPort));
+
+            final Future<Socket> socketFuture = executor.submit(serverSocket::accept);
+
+            executor.submit(() -> {
+                        final Socket socketTestToRouter = socketFuture.get();
+                        logger.info("Test-to-DB established");
+                        while (isRunning) {
+                            int read = socketTestToRouter.getInputStream().read();
+                            socketRouterToDb.getOutputStream().write(read);
+                        }
+                        return null;
+                    }
+            );
+
+            executor.submit(() -> {
+                        final Socket socketTestToDb = socketFuture.get();
+                        logger.info("DB-to-Test established");
+                        while (isRunning) {
+                            int read = socketRouterToDb.getInputStream().read();
+                            socketTestToDb.getOutputStream().write(read);
+                        }
+                        return null;
+                    }
+            );
+        }
+
+        /**
+         * Terminates the forwarding of data to/from the DB server, thus breaking the connections (without closing them).
+         */
+        public void breakConnections() {
+            isRunning = false;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                socketRouterToDb.close();
+            } finally {
+                serverSocket.close();
+            }
+        }
+    }
+}

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/db2/DB2EngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/db2/DB2EngineSchemaTest.java
@@ -19,31 +19,15 @@ package com.feedzai.commons.sql.abstraction.engine.impl.db2;
 import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
-import com.feedzai.commons.sql.abstraction.engine.RecoveryException;
-import com.feedzai.commons.sql.abstraction.engine.RetryLimitExceededException;
 import com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.LOGIN_TIMEOUT;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SOCKET_TIMEOUT;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Joao Silva (joao.silva@feedzai.com)
@@ -110,38 +94,5 @@ public class DB2EngineSchemaTest extends AbstractEngineSchemaTest {
                 "   EXECUTE IMMEDIATE 'DROP SCHEMA \"" + schema + "\" RESTRICT';\n" +
                 "END"
         );
-    }
-
-    /**
-     * Tests if the timeout setting is properly set in the connection socket to the database.
-     * Note: the DB2 and H2 databases don't support setting the connection socket timeout
-     *
-     * @throws DatabaseFactoryException
-     * @throws ClassNotFoundException
-     * @throws InterruptedException
-     * @throws RecoveryException
-     * @throws RetryLimitExceededException
-     * @throws SQLException
-     */
-    @Test
-    public void testTimeout() throws DatabaseFactoryException, InterruptedException, RecoveryException, RetryLimitExceededException, SQLException {
-        final int socketTimeout = 60;// in seconds
-        final int loginTimeout = 30;// in seconds
-        final Properties properties = new Properties() {
-            {
-                setProperty(JDBC, config.jdbc);
-                setProperty(USERNAME, config.username);
-                setProperty(PASSWORD, config.password);
-                setProperty(ENGINE, config.engine);
-                setProperty(SCHEMA_POLICY, "create");
-                setProperty(SOCKET_TIMEOUT, Integer.toString(socketTimeout));
-                setProperty(LOGIN_TIMEOUT, Integer.toString(loginTimeout));
-            }
-        };
-
-        final DatabaseEngine de = DatabaseFactory.getConnection(properties);
-        final int connectionTimeoutInMs = de.getConnection().getNetworkTimeout();
-        // Not supported
-        assertEquals("Is the timeout of the DB connection disabled as expected?", 0, connectionTimeoutInMs);
     }
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/H2EngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/H2EngineSchemaTest.java
@@ -18,29 +18,15 @@ package com.feedzai.commons.sql.abstraction.engine.impl.h2;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
-import com.feedzai.commons.sql.abstraction.engine.RecoveryException;
-import com.feedzai.commons.sql.abstraction.engine.RetryLimitExceededException;
 import com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Properties;
 
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.LOGIN_TIMEOUT;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SOCKET_TIMEOUT;
-import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
 import static com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest.Ieee754Support.SUPPORTED_STRINGS;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -141,38 +127,5 @@ public class H2EngineSchemaTest extends AbstractEngineSchemaTest {
 
     public static int TimesTwo(int value) {
         return value * 2;
-    }
-
-    /**
-     * Tests if the timeout setting is properly set in the connection socket to the database.
-     * Note: the DB2 and H2 databases don't support setting the connection socket timeout
-     *
-     * @throws DatabaseFactoryException
-     * @throws ClassNotFoundException
-     * @throws InterruptedException
-     * @throws RecoveryException
-     * @throws RetryLimitExceededException
-     * @throws SQLException
-     */
-    @Test
-    public void testTimeout() throws DatabaseFactoryException, ClassNotFoundException, InterruptedException, RecoveryException, RetryLimitExceededException, SQLException {
-        final int socketTimeout = 60;// in seconds
-        final int loginTimeout = 30;// in seconds
-        final Properties properties = new Properties() {
-            {
-                setProperty(JDBC, config.jdbc);
-                setProperty(USERNAME, config.username);
-                setProperty(PASSWORD, config.password);
-                setProperty(ENGINE, config.engine);
-                setProperty(SCHEMA_POLICY, "create");
-                setProperty(SOCKET_TIMEOUT, Integer.toString(socketTimeout));
-                setProperty(LOGIN_TIMEOUT, Integer.toString(loginTimeout));
-            }
-        };
-
-        final DatabaseEngine de = DatabaseFactory.getConnection(properties);
-        final int connectionTimeoutInMs = de.getConnection().getNetworkTimeout();
-        // Not supported
-        assertEquals("Is the timeout of the DB connection disabled as expected?", 0, connectionTimeoutInMs);
     }
 }

--- a/src/test/resources/connections.properties
+++ b/src/test/resources/connections.properties
@@ -1,5 +1,11 @@
 # default databases/schemas commented
 
+###############################################################################################
+# IMPORTANT!
+# the ports specified in the JDBC URLs are the default ones and are used by the Timeouts test
+###############################################################################################
+
+
 h2.engine=com.feedzai.commons.sql.abstraction.engine.impl.H2Engine
 h2.jdbc=jdbc:h2:./target/pdb;AUTO_SERVER=FALSE
 h2.username=pdb
@@ -40,8 +46,9 @@ postgresql.password=AaBb12.#
 
 
 oracle.engine=com.feedzai.commons.sql.abstraction.engine.impl.OracleEngine
-oracle.jdbc=jdbc:oracle:thin:@(DESCRIPTION=(ENABLE=broken)(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521)))(CONNECT_DATA=(SID=orcl)))
-# alternate short jdbc URL = jdbc:oracle:thin:@localhost:1521:orcl
+oracle.jdbc=jdbc:oracle:thin:@localhost:1521:orcl
+# alternate long jdbc URL
+#       oracle.jdbc=jdbc:oracle:thin:@(DESCRIPTION=(ENABLE=broken)(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521)))(CONNECT_DATA=(SID=orcl)))
 # default database: orcl is used because it's mandatory in jdbc url and it's the only one in the test server
 oracle.username=system
 oracle.password=oracle


### PR DESCRIPTION
Summary:
The new PDB properties are numeric values, their types were updated to
 "int" accordingly.

Some DB engines had incorrect timeout property names or time units; this
 was fixed, where possible by using the methods available in JDBC to
 specify those timeouts.
A test was created to verify that the timeout settings are working.

NOTE: H2 engine doesn't support setting the timeouts (it only has a
 "global" timeout setting, defined in system properties);
 all other engines are correctly respecting the set timeouts.

This commit also moves the definition of the default SSL mode for
 PostgreSQL to the new getDBProperties() method, to avoid string
 replacements by using the properties instead.

This is a followup on issue #121 