### PR TITLE
Adds support for timeouts in select queries (#123)

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/MySqlResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/MySqlResultIterator.java
@@ -17,6 +17,7 @@ package com.feedzai.commons.sql.abstraction.dml.result;
 
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.impl.MySqlEngine;
+import com.mysql.jdbc.exceptions.MySQLTimeoutException;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
@@ -52,5 +53,10 @@ public class MySqlResultIterator extends ResultIterator {
     @Override
     public ResultColumn createResultColumn(String name, Object value) {
         return new MySqlResultColumn(name, value);
+    }
+
+    @Override
+    protected boolean isTimeoutException(final Exception exception) {
+        return exception instanceof MySQLTimeoutException;
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/PostgreSqlResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/PostgreSqlResultIterator.java
@@ -63,6 +63,7 @@ public class PostgreSqlResultIterator extends ResultIterator {
 
     @Override
     protected boolean isTimeoutException(Exception exception) {
-        return (exception instanceof SQLException && TIMEOUT_SQL_STATE.equals(((SQLException) exception).getSQLState()));
+        return super.isTimeoutException (exception) ||
+                exception instanceof SQLException && TIMEOUT_SQL_STATE.equals(((SQLException) exception).getSQLState());
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/PostgreSqlResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/PostgreSqlResultIterator.java
@@ -19,6 +19,7 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.impl.PostgreSqlEngine;
 
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Statement;
 
 /**
@@ -28,6 +29,12 @@ import java.sql.Statement;
  * @since 2.0.0
  */
 public class PostgreSqlResultIterator extends ResultIterator {
+
+    /**
+     * The SQL State that indicates a timeout occurred.
+     */
+    private static final String TIMEOUT_SQL_STATE = "57014";
+
     /**
      * Creates a new instance of {@link PostgreSqlResultIterator}.
      *
@@ -52,5 +59,10 @@ public class PostgreSqlResultIterator extends ResultIterator {
     @Override
     public ResultColumn createResultColumn(String name, Object value) {
         return new PostgreSqlResultColumn(name, value);
+    }
+
+    @Override
+    protected boolean isTimeoutException(Exception exception) {
+        return (exception instanceof SQLException && TIMEOUT_SQL_STATE.equals(((SQLException) exception).getSQLState()));
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultIterator.java
@@ -24,6 +24,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -108,14 +109,14 @@ public abstract class ResultIterator implements AutoCloseable {
     }
 
     /**
-     * Indicates if a given exception is a timeout. Logic for this is driver-specific, so
-     * drivers that support query timeouts must override this method..
+     * Indicates if a given exception is a timeout. Logic for this may be driver-specific, so
+     * drivers that support query timeouts may have to override this method.
      *
      * @param exception  The exception to check.
      * @return {@code true} if the exception is a timeout, {@code false} otherwise.
      */
     protected boolean isTimeoutException(final Exception exception) {
-        return false;
+        return (exception instanceof SQLTimeoutException);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultIterator.java
@@ -44,10 +44,6 @@ public abstract class ResultIterator implements AutoCloseable {
     private static final Logger logger = LoggerFactory.getLogger(ResultIterator.class);
 
     /**
-     * The SQL State that indicates a timeout occurred.
-     */
-    private static final String TIMEOUT_SQL_STATE = "57014";
-    /**
      * The statement.
      */
     private final Statement statement;
@@ -112,14 +108,14 @@ public abstract class ResultIterator implements AutoCloseable {
     }
 
     /**
-     * Indicates if a given exception is a timeout. The default checks for SQL state 57014 (query
-     * cancelled by user), this method should be overrided for drivers where this is not the case.
+     * Indicates if a given exception is a timeout. Logic for this is driver-specific, so
+     * drivers that support query timeouts must override this method..
      *
      * @param exception  The exception to check.
      * @return {@code true} if the exception is a timeout, {@code false} otherwise.
      */
     protected boolean isTimeoutException(final Exception exception) {
-        return (exception instanceof SQLException && TIMEOUT_SQL_STATE.equals(((SQLException) exception).getSQLState()));
+        return false;
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -1124,7 +1124,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * @throws DatabaseEngineException If something goes wrong executing the query.
      */
     @Override
-    public synchronized List<Map<String, ResultColumn>> query(final Expression query) throws DatabaseEngineException {
+    public List<Map<String, ResultColumn>> query(final Expression query) throws DatabaseEngineException {
         return query(translate(query));
     }
 
@@ -1140,13 +1140,13 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * @throws DatabaseEngineException If something goes wrong executing the query.
      */
     @Override
-    public synchronized List<Map<String, ResultColumn>> query(final String query) throws DatabaseEngineException {
+    public List<Map<String, ResultColumn>> query(final String query) throws DatabaseEngineException {
         return processResultIterator(iterator(query));
     }
 
     @Override
     public List<Map<String, ResultColumn>> query(String query, int readTimeoutOverride) throws DatabaseEngineException {
-        return processResultIterator(iterator(query, DEFAULT_FETCH_SIZE, readTimeoutOverride));
+        return processResultIterator(iterator(query, properties.getFetchSize(), readTimeoutOverride));
     }
 
     /**
@@ -1156,7 +1156,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * @return A list of rows in the form of {@link Map}.
      * @throws DatabaseEngineException If a database access error occurs.
      */
-    protected List<Map<String, ResultColumn>> processResultIterator(ResultIterator it) throws DatabaseEngineException {
+    protected synchronized List<Map<String, ResultColumn>> processResultIterator(ResultIterator it) throws DatabaseEngineException {
         List<Map<String, ResultColumn>> res = new ArrayList<>();
 
         Map<String, ResultColumn> temp;
@@ -1168,12 +1168,12 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     }
 
     @Override
-    public synchronized ResultIterator iterator(String query) throws DatabaseEngineException {
+    public ResultIterator iterator(String query) throws DatabaseEngineException {
         return iterator(query, properties.getFetchSize());
     }
 
     @Override
-    public synchronized ResultIterator iterator(Expression query) throws DatabaseEngineException {
+    public ResultIterator iterator(Expression query) throws DatabaseEngineException {
         return iterator(query, properties.getFetchSize());
     }
 
@@ -1193,7 +1193,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     }
 
     @Override
-    public ResultIterator iterator(String query, int fetchSize, int readTimeoutOverride) throws DatabaseEngineException {
+    public synchronized ResultIterator iterator(String query, int fetchSize, int readTimeoutOverride) throws DatabaseEngineException {
         try {
             getConnection();
             Statement stmt = createSelectStatement(readTimeoutOverride);

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -76,7 +76,7 @@ import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProper
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENCRYPTED_USERNAME;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SECRET_LOCATION;
-import static com.feedzai.commons.sql.abstraction.util.Constants.NO_SELECT_TIMEOUT;
+import static com.feedzai.commons.sql.abstraction.util.Constants.NO_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.readString;
 
@@ -872,7 +872,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      */
     protected Statement createSelectStatement(int readTimeout) throws SQLException {
         final Statement s = conn.createStatement();
-        if (readTimeout != NO_SELECT_TIMEOUT) {
+        if (readTimeout != NO_TIMEOUT) {
             s.setQueryTimeout(readTimeout);
         }
         return s;
@@ -1525,7 +1525,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
 
         try {
             getConnection();
-            stmt = createSelectStatement(Constants.NO_SELECT_TIMEOUT);  // No timeout on metadata queries
+            stmt = createSelectStatement(Constants.NO_TIMEOUT);  // No timeout on metadata queries
             long start = System.currentTimeMillis();
             rs = stmt.executeQuery(query);
             logger.trace("[{} ms] {}", (System.currentTimeMillis() - start), query);

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -1188,6 +1188,11 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     }
 
     @Override
+    public ResultIterator iterator(Expression query, int fetchSize, int readTimeoutOverride) throws DatabaseEngineException {
+        return iterator(translate(query), fetchSize, readTimeoutOverride);
+    }
+
+    @Override
     public ResultIterator iterator(String query, int fetchSize, int readTimeoutOverride) throws DatabaseEngineException {
         try {
             getConnection();
@@ -1195,6 +1200,9 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
             stmt.setFetchSize(fetchSize);
             logger.trace(query);
             return createResultIterator(stmt, query);
+
+        } catch (final DatabaseEngineTimeoutException e) {
+            throw e;
 
         } catch (final Exception e) {
             throw new DatabaseEngineException("Error querying", e);

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -304,12 +304,30 @@ public interface DatabaseEngine extends AutoCloseable {
     List<Map<String, ResultColumn>> query(final Expression query) throws DatabaseEngineException;
 
     /**
+     * Executes the given query overriding the configured query timeout (see {@link PdbProperties#getSelectQueryTimeout()}).
+     *
+     * @param query The query to execute.
+     * @param readTimeoutOverride The query timeout to use.
+     * @throws DatabaseEngineException If something goes wrong executing the query.
+     */
+    List<Map<String, ResultColumn>> query(final Expression query, final int readTimeoutOverride) throws DatabaseEngineException;
+
+    /**
      * Executes the given native query.
      *
      * @param query The query to execute.
      * @throws DatabaseEngineException If something goes wrong executing the query.
      */
     List<Map<String, ResultColumn>> query(final String query) throws DatabaseEngineException;
+
+    /**
+     * Executes the given native query overriding the configured query timeout (see {@link PdbProperties#getSelectQueryTimeout()})..
+     *
+     * @param query The query to execute.
+     * @param readTimeoutOverride The query timeout to use.
+     * @throws DatabaseEngineException If something goes wrong executing the query.
+     */
+    List<Map<String, ResultColumn>> query(final String query, final int readTimeoutOverride) throws DatabaseEngineException;
 
     /**
      * Gets the database entities for the current schema.
@@ -571,6 +589,18 @@ public interface DatabaseEngine extends AutoCloseable {
      * @throws DatabaseEngineException If a database access error occurs.
      */
     ResultIterator iterator(final String query, final int fetchSize) throws DatabaseEngineException;
+
+    /**
+     * Creates an iterator for the given SQL sentence overriding the configured query
+     * timeout (see {@link PdbProperties#getSelectQueryTimeout()})..
+     *
+     * @param query     The query.
+     * @param fetchSize The number of rows to fetch each time.
+     * @param readTimeoutOverride The query timeout to use.
+     * @return An iterator for the results of the given SQL query.
+     * @throws DatabaseEngineException If a database access error occurs.
+     */
+    ResultIterator iterator(final String query, final int fetchSize, final int readTimeoutOverride) throws DatabaseEngineException;
 
     /**
      * Creates an iterator for the given SQL expression.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -321,7 +321,7 @@ public interface DatabaseEngine extends AutoCloseable {
     List<Map<String, ResultColumn>> query(final String query) throws DatabaseEngineException;
 
     /**
-     * Executes the given native query overriding the configured query timeout (see {@link PdbProperties#getSelectQueryTimeout()})..
+     * Executes the given native query overriding the configured query timeout (see {@link PdbProperties#getSelectQueryTimeout()}).
      *
      * @param query The query to execute.
      * @param readTimeoutOverride The query timeout to use.
@@ -592,7 +592,7 @@ public interface DatabaseEngine extends AutoCloseable {
 
     /**
      * Creates an iterator for the given SQL sentence overriding the configured query
-     * timeout (see {@link PdbProperties#getSelectQueryTimeout()})..
+     * timeout (see {@link PdbProperties#getSelectQueryTimeout()}).
      *
      * @param query     The query.
      * @param fetchSize The number of rows to fetch each time.
@@ -611,6 +611,18 @@ public interface DatabaseEngine extends AutoCloseable {
      * @throws DatabaseEngineException If a database access error occurs.
      */
     ResultIterator iterator(final Expression query, final int fetchSize) throws DatabaseEngineException;
+
+    /**
+     * Creates an iterator for the given SQL expression overriding the configured query
+     * timeout (see {@link PdbProperties#getSelectQueryTimeout()}).
+     *
+     * @param query     The expression that represents the query.
+     * @param fetchSize The number of rows to fetch each time.
+     * @param readTimeoutOverride The query timeout to use.
+     * @return An iterator for the results of the given SQL expression.
+     * @throws DatabaseEngineException If a database access error occurs.
+     */
+    ResultIterator iterator(final Expression query, final int fetchSize, final int readTimeoutOverride) throws DatabaseEngineException;
 
     /**
      * Creates an iterator for the {@link java.sql.PreparedStatement} bound to the given name.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngineTimeoutException.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngineTimeoutException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.feedzai.commons.sql.abstraction.engine;
+
+/**
+ * A {@link DatabaseEngineException} that represents a timeout error.
+ */
+public class DatabaseEngineTimeoutException extends DatabaseEngineException {
+
+    /**
+     * Constructs a new exception with the specified detail message and
+     * cause.  <p>Note that the detail message associated with
+     * {@code cause} is <i>not</i> automatically incorporated in
+     * this exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *                by the {@link #getMessage()} method).
+     * @param cause   the cause (which is saved for later retrieval by the
+     *                {@link #getCause()} method).  (A <tt>null</tt> value is
+     *                permitted, and indicates that the cause is nonexistent or
+     *                unknown.)
+     */
+    public DatabaseEngineTimeoutException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
@@ -36,6 +36,7 @@ import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_ISOLATI
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_LOGIN_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_MAXIMUM_TIME_BATCH_SHUTDOWN;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_MAX_IDENTIFIER_SIZE;
+import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SELECT_QUERY_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_RECONNECT_ON_LOST;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_RETRY_INTERVAL;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_SCHEMA_POLICY;
@@ -174,6 +175,12 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
     public static final String SOCKET_TIMEOUT = "pdb.socket_timeout";
 
     /**
+     * Property that indicates the maximum time a select query is allowed to run, in seconds. No limit if zero.
+     * See {@link java.sql.Statement#setQueryTimeout(int)}.
+     */
+    public static final String SELECT_QUERY_TIMEOUT = "pdb.query_select_timeout";
+
+    /**
      * Creates a new instance of an empty {@link PdbProperties}.
      */
     public PdbProperties() {
@@ -206,6 +213,7 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
             setProperty(DISABLE_LOB_CACHING, DEFAULT_DISABLE_LOB_CACHING);
             setProperty(LOGIN_TIMEOUT, DEFAULT_LOGIN_TIMEOUT);
             setProperty(SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
+            setProperty(SELECT_QUERY_TIMEOUT, DEFAULT_SELECT_QUERY_TIMEOUT);
         }
     }
 
@@ -510,6 +518,15 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
      */
     public int getSocketTimeout() {
         return Integer.parseInt(getProperty(SOCKET_TIMEOUT));
+    }
+
+    /**
+     * Gets the query select timeout (in seconds).
+     *
+     * @return The query select timeout.
+     */
+    public int getSelectQueryTimeout() {
+        return Integer.parseInt(getProperty(SELECT_QUERY_TIMEOUT));
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.feedzai.commons.sql.abstraction.util.Constants.NO_SELECT_TIMEOUT;
+import static com.feedzai.commons.sql.abstraction.util.Constants.NO_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
@@ -873,7 +873,7 @@ public class MySqlEngine extends AbstractDatabaseEngine {
             getConnection();
             final Statement stmt = conn.createStatement(TYPE_FORWARD_ONLY, CONCUR_READ_ONLY);
             stmt.setFetchSize(fetchSize);
-            if (readTimeout != NO_SELECT_TIMEOUT) {
+            if (readTimeout != NO_TIMEOUT) {
                 stmt.setQueryTimeout(readTimeout);
             }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -863,31 +863,6 @@ public class MySqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    public ResultIterator iterator(String query) throws DatabaseEngineException {
-        return iterator(query, properties.getFetchSize(), properties.getSelectQueryTimeout());
-    }
-
-    @Override
-    public ResultIterator iterator(String query, int fetchSize, int readTimeout) throws DatabaseEngineException {
-        try {
-            getConnection();
-            final Statement stmt = conn.createStatement(TYPE_FORWARD_ONLY, CONCUR_READ_ONLY);
-            stmt.setFetchSize(fetchSize);
-            if (readTimeout != NO_TIMEOUT) {
-                stmt.setQueryTimeout(readTimeout);
-            }
-
-            return createResultIterator(stmt, query);
-
-        } catch (final DatabaseEngineTimeoutException e) {
-            throw e;
-
-        } catch (final Exception e) {
-            throw new DatabaseEngineException("Error querying", e);
-        }
-    }
-
-    @Override
     public boolean isStringAggDistinctCapable() {
         return true;
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -31,6 +31,10 @@ public final class Constants {
      */
     public static final char UNIT_SEPARATOR_CHARACTER = '\u001F';
     /**
+     * The value that represents absence of a timeout.
+     */
+    public static final int NO_TIMEOUT = 0;
+    /**
      * The default var char size.
      */
     public static final int DEFAULT_VARCHAR_SIZE = 256;
@@ -89,22 +93,17 @@ public final class Constants {
      * Default duration (in seconds) to wait for the database connection to be established.
      * By default, there is no timeout at establishing the connection, so pdb will wait indefinitely for the database.
      */
-    public static final int DEFAULT_LOGIN_TIMEOUT = 0;
+    public static final int DEFAULT_LOGIN_TIMEOUT = NO_TIMEOUT;
 
     /**
      * The default socket connection timeout (in seconds).
      * By default, there is no timeout at the socket level, so pdb will wait indefinitely for the database to respond the queries.
      */
-    public static final int DEFAULT_SOCKET_TIMEOUT = 0;
-
-    /**
-     * The value that represents absence of a timeout in query timeouts.
-     */
-    public static final int NO_SELECT_TIMEOUT = 0;
+    public static final int DEFAULT_SOCKET_TIMEOUT = NO_TIMEOUT;
 
     /**
      * The default select query timeout (in seconds).
      * By default, there is no query timeout, so pdb will wait indefinitely for the database to respond to queries.
      */
-    public static final int DEFAULT_SELECT_QUERY_TIMEOUT = NO_SELECT_TIMEOUT;
+    public static final int DEFAULT_SELECT_QUERY_TIMEOUT = NO_TIMEOUT;
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -96,4 +96,15 @@ public final class Constants {
      * By default, there is no timeout at the socket level, so pdb will wait indefinitely for the database to respond the queries.
      */
     public static final int DEFAULT_SOCKET_TIMEOUT = 0;
+
+    /**
+     * The value that represents absence of a timeout in query timeouts.
+     */
+    public static final int NO_SELECT_TIMEOUT = 0;
+
+    /**
+     * The default select query timeout (in seconds).
+     * By default, there is no query timeout, so pdb will wait indefinitely for the database to respond to queries.
+     */
+    public static final int DEFAULT_SELECT_QUERY_TIMEOUT = NO_SELECT_TIMEOUT;
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/QueryTimeoutsTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/QueryTimeoutsTest.java
@@ -78,15 +78,15 @@ public class QueryTimeoutsTest {
      */
     private static Query HEAVY_QUERY = SqlBuilder
         .select(
-                column("QUERY_TIMEOUT_TEST_1", "COL1")
+                column("T3", "COL1")
         )
         .from(
-                table("QUERY_TIMEOUT_TEST_1"),
-                table("QUERY_TIMEOUT_TEST_2"),
-                table("QUERY_TIMEOUT_TEST_3")
+                table("QUERY_TIMEOUT_TEST").alias("T1"),
+                table("QUERY_TIMEOUT_TEST").alias("T2"),
+                table("QUERY_TIMEOUT_TEST").alias("T3")
         )
         .orderby(
-                column("QUERY_TIMEOUT_TEST_3", "COL1")
+                column("T3", "COL1")
         )
         .limit(
                 1
@@ -135,19 +135,17 @@ public class QueryTimeoutsTest {
         // Create connection
         engine = DatabaseFactory.getConnection(dbProps);
 
-        // Create test tables and load each with 1000 rows.
-        for (int tblIdx = 1; tblIdx <= 3; tblIdx++) {
-            final String tblName = "QUERY_TIMEOUT_TEST_" + tblIdx;
-            final DbEntity.Builder entity = dbEntity()
-                    .name(tblName)
-                    .addColumn("COL1", INT);
-            engine.addEntity(entity.build());
-            for (int i = 0; i < 1000; i++) {
-                engine.persist(tblName, new EntityEntry.Builder()
-                        .set("COL1", i)
-                        .build()
-                );
-            }
+        // Create test table and load it with 1000 rows.
+        final String tblName = "QUERY_TIMEOUT_TEST";
+        final DbEntity.Builder entity = dbEntity()
+                .name(tblName)
+                .addColumn("COL1", INT);
+        engine.addEntity(entity.build());
+        for (int i = 0; i < 1000; i++) {
+            engine.persist(tblName, new EntityEntry.Builder()
+                    .set("COL1", i)
+                    .build()
+            );
         }
     }
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/QueryTimeoutsTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/QueryTimeoutsTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl.abs;
+
+import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
+import com.feedzai.commons.sql.abstraction.dml.Query;
+import com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineTimeoutException;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.INT;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.column;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.dbEntity;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.table;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SELECT_QUERY_TIMEOUT;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+
+/**
+ * Unit tests for the query timeout feature. Tests run a query that takes very long to run
+ * with a short timeout and verify that the statement aborts with the right error code.
+ */
+@RunWith(Parameterized.class)
+public class QueryTimeoutsTest {
+
+    /**
+     * Query timeouts supported only on the Postgres, SQL Server and MySQL. SQL Server is not
+     * included in the list below because it it able to handle the test query in ms, and so
+     * is not testeable in this test.
+     */
+    private static List<DatabaseEngineDriver> SUPPORTED_DRIVERS = ImmutableList.of(
+            DatabaseEngineDriver.POSTGRES,
+            DatabaseEngineDriver.MYSQL
+    );
+
+    /**
+     * A query that makes a sort in 1.000.000.000 rows, taking WAY more than
+     * the test timeout until the first row is returned.
+     */
+    private static Query HEAVY_QUERY = SqlBuilder
+        .select(
+                column("QUERY_TIMEOUT_TEST_1", "COL1")
+        )
+        .from(
+                table("QUERY_TIMEOUT_TEST_1"),
+                table("QUERY_TIMEOUT_TEST_2"),
+                table("QUERY_TIMEOUT_TEST_3")
+        )
+        .orderby(
+                column("QUERY_TIMEOUT_TEST_3", "COL1")
+        )
+        .limit(
+                1
+        );
+
+    /**
+     * Default timeout in all tests.
+     */
+    private static final int TEST_TIMEOUT_SECS = 2;
+
+    /**
+     * Timeout override in all tests with timeout overrides.
+     */
+    private static final int TEST_TIMEOUT_OVERRIDE_SECS = 6;
+
+    /**
+     * The {@link DatabaseEngine} used in each tests.
+     */
+    private DatabaseEngine engine;
+
+    @Parameterized.Parameters
+    public static Collection<DatabaseConfiguration> data() throws Exception {
+        return DatabaseTestUtil.loadConfigurations();
+    }
+
+    @Parameterized.Parameter
+    public DatabaseConfiguration config;
+
+    @Before
+    public void setupTest() throws DatabaseFactoryException, DatabaseEngineException {
+        final Properties dbProps = new Properties() {
+            {
+                setProperty(JDBC, config.jdbc);
+                setProperty(USERNAME, config.username);
+                setProperty(PASSWORD, config.password);
+                setProperty(ENGINE, config.engine);
+                setProperty(SCHEMA_POLICY, "create-drop");
+                put(SELECT_QUERY_TIMEOUT, TEST_TIMEOUT_SECS);
+            }
+        };
+
+        final DatabaseEngineDriver driver = DatabaseEngineDriver.fromEngine(dbProps.getProperty(ENGINE));
+        assumeTrue(driver + " engine doesn't support setting timeouts, tests will be skipped",
+                SUPPORTED_DRIVERS.contains(driver));
+
+        // Create connection
+        engine = DatabaseFactory.getConnection(dbProps);
+
+        // Create test tables and load each with 1000 rows.
+        for (int tblIdx = 1; tblIdx <= 3; tblIdx++) {
+            final String tblName = "QUERY_TIMEOUT_TEST_" + tblIdx;
+            final DbEntity.Builder entity = dbEntity()
+                    .name(tblName)
+                    .addColumn("COL1", INT);
+            engine.addEntity(entity.build());
+            for (int i = 0; i < 1000; i++) {
+                engine.persist(tblName, new EntityEntry.Builder()
+                        .set("COL1", i)
+                        .build()
+                );
+            }
+        }
+    }
+
+    @After
+    public void cleanResources() {
+        if (engine != null) {
+            engine.close();
+        }
+    }
+
+    @Test(expected = DatabaseEngineTimeoutException.class)
+    public void iteratorWithDefaultsTest() throws DatabaseEngineException {
+        engine.iterator(HEAVY_QUERY).nextResult();
+    }
+
+    @Test(expected = DatabaseEngineTimeoutException.class)
+    public void iteratorWithOverrideTest() throws DatabaseEngineException {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        try {
+            engine.iterator(HEAVY_QUERY, 1000, TEST_TIMEOUT_OVERRIDE_SECS).nextResult();
+        } finally {
+            assertTrue(stopwatch.elapsed(TimeUnit.SECONDS) >= TEST_TIMEOUT_OVERRIDE_SECS - 1);
+        }
+    }
+
+    @Test(expected = DatabaseEngineTimeoutException.class)
+    public void queryWithDefaultsTest() throws DatabaseEngineException {
+        engine.query(HEAVY_QUERY);
+    }
+
+    @Test(expected = DatabaseEngineTimeoutException.class)
+    public void queryWithOverrideTest() throws DatabaseEngineException {
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        try {
+            engine.query(HEAVY_QUERY, 10);
+        } finally {
+            assertTrue(stopwatch.elapsed(TimeUnit.SECONDS) >= TEST_TIMEOUT_OVERRIDE_SECS - 1);
+        }
+    }
+
+}


### PR DESCRIPTION
This adds a configuration property (query_timeout) to specify a default timeout for all select queries created by a DatabaseEngine, allowing it to be overridden on individual queries. It also exposes the Statement#cancel() method, that allows a thread to cancel a query running on other thread.

This relies on the underlying JDBC driver supporting the Statement#setQueryTimeout()/cancel() methods, which is not supported by all database drivers.
