### PR TITLE
Support custom isolation levels, add tests (originated by #126)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -549,7 +549,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>microsoft/mssql-server-linux:2017-CU13</name>
+                                    <name>mcr.microsoft.com/mssql/server:2017-CU17</name>
                                     <alias>pdb-sqlserver</alias>
                                     <run>
                                         <namingStrategy>alias</namingStrategy>
@@ -564,6 +564,16 @@
                                         <wait>
                                             <time>40000</time>
                                             <log>Service Broker manager has started</log>
+                                            <exec>
+                                                <!--
+                                                Prepare a new "pdb" database for tests with READ_COMMITTED_SNAPSHOT enabled
+                                                 (required for SQL server to have the same behavior as other DBs in READ_COMMITTED
+                                                 isolation level) and ALLOW_SNAPSHOT_ISOLATION enabled to allow using the
+                                                 TRANSACTION_SNAPSHOT level (equivalent to SERIALIZABLE in PostgreSQL and Oracle).
+                                                A new database needs to be used because the flags can't be enabled on "master" database.
+                                                -->
+                                                <postStart>/opt/mssql-tools/bin/sqlcmd -l 45 -U sa -P AaBb12.# -Q CREATE\ DATABASE\ pdb;\ ALTER\ DATABASE\ pdb\ SET\ READ_COMMITTED_SNAPSHOT\ ON;\ ALTER\ DATABASE\ pdb\ SET\ ALLOW_SNAPSHOT_ISOLATION\ ON</postStart>
+                                            </exec>
                                         </wait>
                                     </run>
                                 </image>

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -27,10 +27,8 @@ import com.feedzai.commons.sql.abstraction.dml.Expression;
 import com.feedzai.commons.sql.abstraction.dml.K;
 import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.Truncate;
-import com.feedzai.commons.sql.abstraction.dml.Union;
 import com.feedzai.commons.sql.abstraction.dml.Update;
 import com.feedzai.commons.sql.abstraction.dml.Values;
-import com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder;
 import com.feedzai.commons.sql.abstraction.dml.With;
 import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
 import com.feedzai.commons.sql.abstraction.dml.result.ResultIterator;
@@ -44,7 +42,6 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
 import com.feedzai.commons.sql.abstraction.engine.NameAlreadyExistsException;
 import com.feedzai.commons.sql.abstraction.engine.OperationNotSupportedRuntimeException;
-import com.feedzai.commons.sql.abstraction.engine.impl.MySqlEngine;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.BlobTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
@@ -54,7 +51,6 @@ import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Verifications;
-import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -74,7 +70,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
@@ -130,8 +125,8 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.udf;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.union;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.update;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.upper;
-import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.with;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.values;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.with;
 import static com.feedzai.commons.sql.abstraction.engine.EngineTestUtils.buildEntity;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
@@ -564,7 +559,7 @@ public class EngineGeneralTest {
         engine.persist("TEST", entry);
 
         final ResultIterator resultIterator;
-        try (final ResultIterator it = engine.iterator(select(all()).from(table("TEST")))){
+        try (final ResultIterator it = engine.iterator(select(all()).from(table("TEST")))) {
 
             resultIterator = it;
 
@@ -1597,9 +1592,9 @@ public class EngineGeneralTest {
 
         } finally {
             assertTrue("tx active?", engine.isTransactionActive());
-            if (engine.isTransactionActive()) {
-                engine.rollback();
-            }
+
+            engine.rollback();
+
             assertFalse("tx active?", engine.isTransactionActive());
 
             assertEquals("ret 0?", 0, engine.query(select(all()).from(table("TEST"))).size());
@@ -2103,7 +2098,7 @@ public class EngineGeneralTest {
 
         // MySQL does not support With
         if (config.engine.contains("MySqlEngine")) {
-            exception.expect(OperationNotSupportedRuntimeException.class);;
+            exception.expect(OperationNotSupportedRuntimeException.class);
         }
 
         final List<Map<String, ResultColumn>> result = engine.query(with);
@@ -2135,7 +2130,7 @@ public class EngineGeneralTest {
 
         // MySQL does not support With
         if (config.engine.contains("MySqlEngine")) {
-            exception.expect(OperationNotSupportedRuntimeException.class);;
+            exception.expect(OperationNotSupportedRuntimeException.class);
         }
 
         final List<Map<String, ResultColumn>> result = engine.query(with);
@@ -2175,7 +2170,7 @@ public class EngineGeneralTest {
 
         // MySQL does not support With
         if (config.engine.contains("MySqlEngine")) {
-            exception.expect(OperationNotSupportedRuntimeException.class);;
+            exception.expect(OperationNotSupportedRuntimeException.class);
         }
 
         final List<Map<String, ResultColumn>> result = engine.query(with);

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineIsolationTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineIsolationTest.java
@@ -15,8 +15,12 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
+import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
+import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
 import org.junit.Before;
@@ -24,15 +28,35 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.sql.Connection;
 import java.util.Collection;
 import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.StampedLock;
 
+import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.INT;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.all;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.count;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.dbEntity;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.entry;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.select;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.table;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ISOLATION_LEVEL;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * @author Rui Vilao (rui.vilao@feedzai.com)
@@ -58,7 +82,7 @@ public class EngineIsolationTest {
                 setProperty(USERNAME, config.username);
                 setProperty(PASSWORD, config.password);
                 setProperty(ENGINE, config.engine);
-                setProperty(SCHEMA_POLICY, "create");
+                setProperty(SCHEMA_POLICY, "drop-create");
             }
         };
     }
@@ -77,13 +101,189 @@ public class EngineIsolationTest {
 
     @Test
     public void repeatableReadTest() throws DatabaseFactoryException {
-        this.properties.setProperty(ISOLATION_LEVEL, "read_uncommitted");
+        this.properties.setProperty(ISOLATION_LEVEL, "repeatable_read");
         DatabaseFactory.getConnection(properties);
     }
 
     @Test
     public void serializableTest() throws DatabaseFactoryException {
-        this.properties.setProperty(ISOLATION_LEVEL, "read_uncommitted");
+        this.properties.setProperty(ISOLATION_LEVEL, "serializable");
         DatabaseFactory.getConnection(properties);
+    }
+
+    /**
+     * Tests whether the current DB engine in the default isolation level (usually "read committed") will cause
+     * deadlocks when there are concurrent transactions acquiring DB locks (writes) and Java locks in different order.
+     * <p>
+     * Besides testing current DB engines with default isolation level, this test will allow verification of new DB
+     * engines, and with small modifications, different isolation levels.
+     *
+     * The following table describes the sequence of events of both transactions used in the test. A deadlock may occur
+     * at T4 if the "SELECT *" query in Transaction 2 gets blocked by the previous persist operation in Transaction 1:
+     * Transaction 2 gets blocked until Transaction 1 commits or rolls back, but Transaction 1 can only advance when it
+     * is able to acquire the Java lock (which is only released after Transaction2 advances).
+     * <table>
+     *     <tr><th>time</th><th>transaction 1</th><th>transaction 2</th></tr>
+     *     <tr><td>T0</td><td>begin</td></tr>
+     *     <tr><td>T1</td><td>persist (DB write lock)</td></tr>
+     *     <tr><td>T2</td><td/><td>begin</td></tr>
+     *     <tr><td>T3</td><td/><td>acquire Java lock</td></tr>
+     *     <tr><td>T4</td><td>try acquire Java lock</td><td>query select *</td></tr>
+     *     <tr><td>T5</td><td></td><td>commit</td></tr>
+     *     <tr><td>T6</td><td></td><td>release Java lock</td></tr>
+     *     <tr><td>T7</td><td>acquire Java lock</td><td></td></tr>
+     *     <tr><td>T8</td><td>commit</td></tr>
+     *     <tr><td>T9</td><td>release Java lock</td></tr>
+     * </table>
+     * @throws Exception if something goes wrong in the test.
+     * @since 2.4.7
+     */
+    @Test
+    public void deadlockTransactionTest() throws Exception {
+        final StampedLock lock = new StampedLock();
+        final Phaser phaser = new Phaser(1);
+        final ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        final DbEntity entity = dbEntity().name("TEST")
+                .addColumn("COL1", INT, true)
+                .addColumn("COL2", INT)
+                .pkFields("COL1")
+                .build();
+
+        final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
+        engine.updateEntity(entity);
+        final DatabaseEngine engine2 = DatabaseFactory.getConnection(properties);
+        engine2.updateEntity(entity);
+
+        // persist an initial entry
+        engine.persist("TEST", entry().set("COL2", 1).build());
+
+        // start Transaction 1
+        final Future<?> tx1 = executorService.submit(() -> {
+            engine.beginTransaction();
+            try {
+                final Long persist = engine.persist("TEST", entry().set("COL2", 2).build());
+                assertNotNull("Persist in Transaction 1 should be successful", persist);
+
+                // arrive phase 0 - begin phase 1 (start Transaction 2)
+                phaser.arrive();
+                // wait for phase 1 to complete - Transaction 2 should have began and acquired the Java lock
+                phaser.awaitAdvance(1);
+
+                lock.writeLockInterruptibly();
+
+                engine.commit();
+            } catch (final Exception ex) {
+                throw new RuntimeException("Error occurred on Transaction 1", ex);
+            } finally {
+                if (engine.isTransactionActive()) {
+                    engine.rollback();
+                }
+                lock.tryUnlockWrite();
+
+                // arrive phase 2 - begin phase 3 (proceed to end of test)
+                phaser.arrive();
+            }
+        });
+
+        // wait for phase 0 to complete - Transaction 1 should have began and persisted an entry to DB (acquiring a DB write lock)
+        phaser.awaitAdvance(0);
+
+        final AtomicInteger countResult = new AtomicInteger();
+        // start Transaction 2
+        final Future<?> tx2 = executorService.submit(() -> {
+            try {
+                engine2.beginTransaction();
+
+                long tstamp = lock.readLockInterruptibly();
+                if (isRealSerializableLevel(engine2)) {
+                    lock.tryConvertToOptimisticRead(tstamp);
+                }
+
+                // arrive phase 1 - begin phase 2 (transaction 1 can now try to acquire the lock,
+                // only being able to do so after it is unlocked below)
+                phaser.arrive();
+
+                // possible deadlock occurs on the next line if the engine blocks reads after a write in another transaction
+                final Integer result = engine2.query(select(count(all()).alias("testcount"))
+                        .from(table("TEST")))
+                        .get(0)
+                        .get("testcount")
+                        .toInt();
+                countResult.set(result);
+
+                engine2.commit();
+            } catch (final Exception ex) {
+                throw new RuntimeException("Error occurred on Transaction 2", ex);
+            } finally {
+                if (engine2.isTransactionActive()) {
+                    engine2.rollback();
+                }
+                // at this point, if using only optimistic read, we would be validating the timestamp;
+                // if invalid (i.e. a write occurred in the meantime) then we would retry the code inside the lock
+                lock.tryUnlockRead();
+            }
+        });
+
+        // wait for phase 1 to complete (no issues are expected up to this point;
+        // only on the next test phase a deadlock might prevent a phase advance and timeout on the next wait point below)
+        phaser.awaitAdvance(1);
+        final int finalPhase;
+        try {
+            finalPhase = phaser.awaitAdvanceInterruptibly(2, 5, TimeUnit.SECONDS);
+        } catch (final Exception ex) {
+            fail("The transaction threads are deadlocked");
+            throw ex;
+        }
+        assertEquals(
+                "Both transactions should have completed successfully, causing the main test thread to arrive at phase 3 of the test",
+                3, finalPhase
+        );
+
+        assertThatCode(() -> tx1.get(1, TimeUnit.SECONDS))
+                .as("Code for Transaction 1 shouldn't have thrown any exceptions")
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> tx2.get(1, TimeUnit.SECONDS))
+                .as("Code for Transaction 2 shouldn't have thrown any exceptions")
+                .doesNotThrowAnyException();
+
+        /*
+         check that the SELECT query returned a correct result (and indirectly, if the write completed)
+          - if using a "real" SERIALIZABLE isolation level, the SELECT should wait for the write operation on the DB to
+            complete (when using Java optimistic read lock), thus the result should reflect 2 rows
+          - if not using a "real" SERIALIZABLE isolation level, the SELECT should complete before the write in the other
+            transaction, thus seeing only the initial persisted row
+         */
+        assertThat(countResult)
+                .as("The SELECT query should return  correct result (2 for \"real\" SERIALIZABLE isolation level, 1 otherwise)")
+                .hasValue(isRealSerializableLevel(engine) ? 2 : 1);
+
+        executorService.shutdownNow();
+        engine.close();
+        engine2.close();
+    }
+
+    /**
+     * Returns whether the current engine is using a "real" SERIALIZABLE isolation level (the supported DB engines
+     * oconfigured to be SERIALIZABLE are in fact normally using snapshot isolation).
+     *
+     * @param engine the {@link DatabaseEngine} to get isolation level information from.
+     * @return whether the current engine is using a "real" SERIALIZABLE isolation level.
+     * @throws Exception if something goes wrong in the verification.
+     * @since 2.4.7
+     */
+    protected boolean isRealSerializableLevel(final DatabaseEngine engine) throws Exception {
+        final PdbProperties pdbProps = new PdbProperties(this.properties, true);
+        final DatabaseEngineDriver engineDriver = DatabaseEngineDriver.fromEngine(pdbProps.getEngine());
+
+        switch (engine.getConnection().getTransactionIsolation()) {
+            case Connection.TRANSACTION_SERIALIZABLE:
+                if (engineDriver == DatabaseEngineDriver.SQLSERVER) {
+                    return true;
+                }
+            default:
+                return false;
+        }
     }
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineIsolationTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineIsolationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl.sqlserver;
+
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
+import com.feedzai.commons.sql.abstraction.engine.impl.abs.EngineIsolationTest;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
+import com.microsoft.sqlserver.jdbc.SQLServerConnection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ISOLATION_LEVEL;
+
+/**
+ * Additional isolation tests for SQL Server.
+ *
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ * @since 2.4.7
+ */
+@RunWith(Parameterized.class)
+public class SqlServerEngineIsolationTest extends EngineIsolationTest {
+
+    @Parameterized.Parameters
+    public static Collection<DatabaseConfiguration> data() throws Exception {
+        return DatabaseTestUtil.loadConfigurations("sqlserver");
+    }
+
+    /**
+     * Tests support for the custom isolation level "transaction snapshot" available in SQL Server (which has the same
+     * behavior as "serializable" in other DB engines like PostgreSQL and Oracle).
+     *
+     * @throws DatabaseFactoryException if something goes wrong in the test.
+     */
+    @Test
+    public void snapshotTest() throws DatabaseFactoryException {
+        this.properties.setProperty(ISOLATION_LEVEL, Objects.toString(SQLServerConnection.TRANSACTION_SNAPSHOT));
+        DatabaseFactory.getConnection(properties);
+    }
+
+}

--- a/src/test/resources/connections.properties
+++ b/src/test/resources/connections.properties
@@ -29,9 +29,12 @@ mysql.password=AaBb12.#
 
 
 sqlserver.engine=com.feedzai.commons.sql.abstraction.engine.impl.SqlServerEngine
-sqlserver.jdbc=jdbc:sqlserver://localhost:1433
-# default database: master
-# used in jdbc url: jdbc:sqlserver://localhost:1433;databaseName=master
+sqlserver.jdbc=jdbc:sqlserver://localhost:1433;databaseName=pdb
+# default database (not mandatory): master
+# using "pdb" for tests because READ_COMMITTED_SNAPSHOT is required for SQL server to have the same behavior
+# as other DBs in READ_COMMITTED isolation level and that flag can't be enabled on "master" database;
+# the same applies to ALLOW_SNAPSHOT_ISOLATION, that makes available the TRANSACTION_SNAPSHOT level which is equivalent
+# to SERIALIZABLE in PostgreSQL and Oracle
 sqlserver.username=sa
 sqlserver.password=AaBb12.#
 #sqlserver.schema=dbo


### PR DESCRIPTION
Summary:
SQL Server has a default behavior for certain isolation levels different
 from other DB engines: with READ COMMITTED or stricter, it will block
 on reads when another transaction is changing (but not committed yet)
 the rows being read; other engines simply return the currently
 committed value.

To make SQL Server have the same behavior, the current database must
 have enabled the flag READ_COMMITTED_SNAPSHOT.
With SERIALIZABLE isolation level the behavior isn't changed, the
 TRANSACTION SNAPSHOT level must be used instead (which is equivalent to
 SERIALIZABLE in PostgreSQL and Oracle) - this requires the current
 database to have the flag ALLOW_SNAPSHOT_ISOLATION enabled.

To allow and test these behaviors, the following changes were made in
 this commit:
- PdbProperties now allows setting custom numeric isolation levels (for
 example, setting it to "4096" will set TRANSACTION SNAPSHOT level for
 SQL Server;
- the SQL Server container that is used for tests now has a new database
 with the flags READ_COMMITTED_SNAPSHOT and ALLOW_SNAPSHOT_ISOLATION
 enabled (this was also reflected in the test connections.properties);
- new tests were created, to test that the custom TRANSACTION SNAPSHOT
 isolation level works, and check that a deadlock doesn't occur in a
 specific scenario.