### PR TITLE
Makes query timeout support non-breaking

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -304,13 +304,16 @@ public interface DatabaseEngine extends AutoCloseable {
     List<Map<String, ResultColumn>> query(final Expression query) throws DatabaseEngineException;
 
     /**
-     * Executes the given query overriding the configured query timeout (see {@link PdbProperties#getSelectQueryTimeout()}).
+     * Executes the given query overriding the configured query timeout (see {@link PdbProperties#getSelectQueryTimeout()})
+     * if the underlying engine supports query timeouts.
      *
      * @param query The query to execute.
      * @param readTimeoutOverride The query timeout to use.
      * @throws DatabaseEngineException If something goes wrong executing the query.
      */
-    List<Map<String, ResultColumn>> query(final Expression query, final int readTimeoutOverride) throws DatabaseEngineException;
+    default List<Map<String, ResultColumn>> query(final Expression query, final int readTimeoutOverride) throws DatabaseEngineException {
+        return query(query);
+    }
 
     /**
      * Executes the given native query.
@@ -321,13 +324,16 @@ public interface DatabaseEngine extends AutoCloseable {
     List<Map<String, ResultColumn>> query(final String query) throws DatabaseEngineException;
 
     /**
-     * Executes the given native query overriding the configured query timeout (see {@link PdbProperties#getSelectQueryTimeout()}).
+     * Executes the given native query overriding the configured query timeout (see {@link PdbProperties#getSelectQueryTimeout()}
+     * if the underlying engine supports query timeouts.
      *
      * @param query The query to execute.
      * @param readTimeoutOverride The query timeout to use.
      * @throws DatabaseEngineException If something goes wrong executing the query.
      */
-    List<Map<String, ResultColumn>> query(final String query, final int readTimeoutOverride) throws DatabaseEngineException;
+    default List<Map<String, ResultColumn>> query(final String query, final int readTimeoutOverride) throws DatabaseEngineException {
+        return query(query);
+    }
 
     /**
      * Gets the database entities for the current schema.
@@ -592,7 +598,8 @@ public interface DatabaseEngine extends AutoCloseable {
 
     /**
      * Creates an iterator for the given SQL sentence overriding the configured query
-     * timeout (see {@link PdbProperties#getSelectQueryTimeout()}).
+     * timeout (see {@link PdbProperties#getSelectQueryTimeout()}) if the underlying engine
+     * supports query timeouts.
      *
      * @param query     The query.
      * @param fetchSize The number of rows to fetch each time.
@@ -600,7 +607,9 @@ public interface DatabaseEngine extends AutoCloseable {
      * @return An iterator for the results of the given SQL query.
      * @throws DatabaseEngineException If a database access error occurs.
      */
-    ResultIterator iterator(final String query, final int fetchSize, final int readTimeoutOverride) throws DatabaseEngineException;
+    default ResultIterator iterator(final String query, final int fetchSize, final int readTimeoutOverride) throws DatabaseEngineException {
+        return iterator(query, fetchSize);
+    }
 
     /**
      * Creates an iterator for the given SQL expression.
@@ -614,7 +623,8 @@ public interface DatabaseEngine extends AutoCloseable {
 
     /**
      * Creates an iterator for the given SQL expression overriding the configured query
-     * timeout (see {@link PdbProperties#getSelectQueryTimeout()}).
+     * timeout (see {@link PdbProperties#getSelectQueryTimeout()}) if the underlying engine
+     * supports query timeouts.
      *
      * @param query     The expression that represents the query.
      * @param fetchSize The number of rows to fetch each time.
@@ -622,7 +632,9 @@ public interface DatabaseEngine extends AutoCloseable {
      * @return An iterator for the results of the given SQL expression.
      * @throws DatabaseEngineException If a database access error occurs.
      */
-    ResultIterator iterator(final Expression query, final int fetchSize, final int readTimeoutOverride) throws DatabaseEngineException;
+    default ResultIterator iterator(final Expression query, final int fetchSize, final int readTimeoutOverride) throws DatabaseEngineException {
+        return iterator(query, fetchSize);
+    }
 
     /**
      * Creates an iterator for the {@link java.sql.PreparedStatement} bound to the given name.


### PR DESCRIPTION
The query timeout feature added some methods to the DatabaseEngine interface that introduce
an API change on classes that implement it (typically wrapper classes). These methods might
not be relevant in all contexts and so a default implementation where the read timeout is
ignored was added.