### PR TITLE
Add retryable flag to DatabaseEngineRuntimeException

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngineRuntimeException.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngineRuntimeException.java
@@ -22,6 +22,15 @@ package com.feedzai.commons.sql.abstraction.engine;
  * @since 2.0.0
  */
 public class DatabaseEngineRuntimeException extends RuntimeException {
+
+    /**
+     * Property that indicates if Exception is retryable or not.
+     * This property must be defined 'true' if the Transaction Retry must be done on client side.
+     *
+     * @see <a href=https://www.cockroachlabs.com/docs/stable/transactions.html#client-side-intervention>CockroachDB - transactions</a>
+     */
+    private boolean isRetryable = false;
+
     /**
      * Constructs a new runtime exception with {@code null} as its
      * detail message.  The cause is not initialized, and may subsequently be
@@ -39,7 +48,7 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      * @param message the detail message. The detail message is saved for
      *                later retrieval by the {@link #getMessage()} method.
      */
-    public DatabaseEngineRuntimeException(String message) {
+    public DatabaseEngineRuntimeException(final String message) {
         super(message);
     }
 
@@ -56,7 +65,7 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      *                permitted, and indicates that the cause is nonexistent or
      *                unknown.)
      */
-    public DatabaseEngineRuntimeException(String message, Throwable cause) {
+    public DatabaseEngineRuntimeException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
@@ -72,7 +81,7 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      *              permitted, and indicates that the cause is nonexistent or
      *              unknown.)
      */
-    public DatabaseEngineRuntimeException(Throwable cause) {
+    public DatabaseEngineRuntimeException(final Throwable cause) {
         super(cause);
     }
 
@@ -89,9 +98,40 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      * @param writableStackTrace whether or not the stack trace should
      *                           be writable
      */
-    protected DatabaseEngineRuntimeException(String message, Throwable cause,
-                                             boolean enableSuppression,
-                                             boolean writableStackTrace) {
+    protected DatabaseEngineRuntimeException(final String message,
+                                             final Throwable cause,
+                                             final boolean enableSuppression,
+                                             final boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message,
+     * cause and a specified isRetryable state.  <p>Note that the detail message associated with
+     * {@code cause} is <i>not</i> automatically incorporated in
+     * this runtime exception's detail message.
+     *
+     * @param message     The detail message (which is saved for later retrieval
+     *                    by the {@link #getMessage()} method).
+     * @param cause       The cause (which is saved for later retrieval by the
+     *                    {@link #getCause()} method).  (A <tt>null</tt> value is
+     *                    permitted, and indicates that the cause is nonexistent or
+     *                    unknown.)
+     * @param isRetryable The property must be true if generated Exception must be retried.
+     */
+    public DatabaseEngineRuntimeException(final String message, final Throwable cause, final boolean isRetryable) {
+        super(message, cause);
+        this.isRetryable = isRetryable;
+    }
+
+    /**
+     * Gets whether the error that caused this exception is retryable or not.
+     *
+     * In particular, if a transaction commit resulted in this exception, the client can attempt to retry it.
+     *
+     * @return whether this exception is retryable or not.
+     */
+    public boolean isRetryable() {
+        return isRetryable;
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -79,9 +79,16 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
      */
     public static final String TABLE_OR_VIEW_DOES_NOT_EXIST = "42P01";
     /**
-     * Table or view does not exist.
+     * Constraint name already exists.
      */
     public static final String CONSTRAINT_NAME_ALREADY_EXISTS = "42710";
+    /**
+     * The SQL State code PostgreSQL uses for "transaction failure due to deadlocks".
+     * This may be caused by serialization failure due to a deadlock detected in the DB server in concurrent; this code
+     * indicates that the client app may retry the transaction.
+     */
+    public static final String SQL_STATE_DEADLOCK_TRANSACTION_FAILURE = "40P01";
+
     /**
      * The default SSL mode for the connection, when that PostgreSQL property is not set in the JDBC URL but SSL is
      * enabled.
@@ -172,6 +179,11 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     @Override
     public boolean isStringAggDistinctCapable() {
         return true;
+    }
+
+    @Override
+    protected boolean isRetryableException(final SQLException ex) {
+        return super.isRetryableException(ex) || ex.getSQLState().equals(SQL_STATE_DEADLOCK_TRANSACTION_FAILURE);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -106,4 +106,11 @@ public final class Constants {
      * By default, there is no query timeout, so pdb will wait indefinitely for the database to respond to queries.
      */
     public static final int DEFAULT_SELECT_QUERY_TIMEOUT = NO_TIMEOUT;
+
+    /**
+     * The SQL standard State code for "transaction failure".
+     * This may be caused by serialization failures in concurrent transactions in the DB server and possibly deadlocks;
+     * this code indicates that the client app may retry the transaction.
+     */
+    public static final String SQL_STATE_TRANSACTION_FAILURE = "40001";
 }


### PR DESCRIPTION
Summary:
When a transaction fails on commit, because a concurrent transaction
interfered with it (server was unable to serialize, or deadlock was
detected), the server sends back information indicating the error.

These errors can be retried (and will probably succeed then), so this
commit adds the information that something can be retried in a flag of
DatabaseEngineRuntimeException, so that the client application knows
that it can retry the transaction.