### PR TITLE
Change "allowColumnDrop" default to false

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -67,9 +67,9 @@ public final class Constants {
      */
     public static final String DEFAULT_SECRET_LOCATION = "secret.key";
     /**
-     * By default allow column drops.
+     * By default don't allow column drops.
      */
-    public static final boolean DEFAULT_ALLOW_COLUMN_DROP = true;
+    public static final boolean DEFAULT_ALLOW_COLUMN_DROP = false;
     /**
      * The default fetch size.
      */


### PR DESCRIPTION
Summary:
Having the default at true, although convenient to keep the DB tables
synchronized with the respective PDB entities, may lead to unintended
loss of data (by default, if a column disappears from an entity, PDB
will update the table by dropping the respective column along with the
historical data in it.

For safety, this commit changes that default to false.