### PR TITLE
Add support for CockroachDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -486,6 +486,9 @@
 
         <profile>
             <id>mysql</id>
+            <properties>
+                <image.mysql>mysql:5.7.22</image.mysql>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -504,7 +507,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>mysql:5.7.22</name>
+                                    <name>${image.mysql}</name>
                                     <alias>pdb-mysql</alias>
                                     <run>
                                         <namingStrategy>alias</namingStrategy>
@@ -531,6 +534,9 @@
 
         <profile>
             <id>sqlserver</id>
+            <properties>
+                <image.sqlserver>mcr.microsoft.com/mssql/server:2017-CU17</image.sqlserver>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -549,7 +555,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>mcr.microsoft.com/mssql/server:2017-CU17</name>
+                                    <name>${image.sqlserver}</name>
                                     <alias>pdb-sqlserver</alias>
                                     <run>
                                         <namingStrategy>alias</namingStrategy>
@@ -586,6 +592,9 @@
 
         <profile>
             <id>postgresql</id>
+            <properties>
+                <image.postgresql>postgres:9.6.14</image.postgresql>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -604,7 +613,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>postgres:9.6.14</name>
+                                    <name>${image.postgresql}</name>
                                     <alias>pdb-postgresql</alias>
                                     <run>
                                         <namingStrategy>alias</namingStrategy>
@@ -629,7 +638,10 @@
         </profile>
 
         <profile>
-            <id>postgresql11</id>
+            <id>cockroach</id>
+            <properties>
+                <image.cockroach>cockroachdb/cockroach:v19.2.0</image.cockroach>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -637,8 +649,9 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemProperties>
-                                <instances>postgresql</instances>
+                                <instances>cockroach</instances>
                             </systemProperties>
+                            <excludedGroups>com.feedzai.commons.sql.abstraction.engine.impl.cockroach.SkipTestCockroachDB</excludedGroups>
                         </configuration>
                     </plugin>
 
@@ -648,20 +661,19 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>postgres:11.4</name>
-                                    <alias>pdb-postgresql11</alias>
+                                    <name>${image.cockroach}</name>
+                                    <alias>pdb-cockroach</alias>
                                     <run>
                                         <namingStrategy>alias</namingStrategy>
-                                        <hostname>pdb-postgresql11</hostname>
+                                        <hostname>pdb-cockroach</hostname>
                                         <ports>
-                                            <port>5432:5432</port>
+                                            <port>8080:8080</port>
+                                            <port>26257:26257</port>
                                         </ports>
-                                        <env>
-                                            <POSTGRES_PASSWORD>AaBb12.#</POSTGRES_PASSWORD>
-                                        </env>
+                                        <cmd>start --insecure</cmd>
                                         <wait>
                                             <time>40000</time>
-                                            <log>PostgreSQL init process complete; ready for start up</log>
+                                            <log>CockroachDB node starting</log>
                                         </wait>
                                     </run>
                                 </image>
@@ -674,6 +686,9 @@
 
         <profile>
             <id>oracle</id>
+            <properties>
+                <image.oracle>iatebes/oracle_11g:latest</image.oracle>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -697,7 +712,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>iatebes/oracle_11g:latest</name>
+                                    <name>${image.oracle}</name>
                                     <alias>pdb-oracle</alias>
                                     <run>
                                         <namingStrategy>alias</namingStrategy>
@@ -720,6 +735,9 @@
 
         <profile>
             <id>db2</id>
+            <properties>
+                <image.db2>ibmcom/db2:11.5.0.0</image.db2>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -738,7 +756,7 @@
                         <configuration>
                             <images>
                                 <image>
-                                    <name>ibmcom/db2:11.5.0.0</name>
+                                    <name>${image.db2}</name>
                                     <alias>pdb-db2</alias>
                                     <run>
                                         <namingStrategy>alias</namingStrategy>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/Dialect.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/Dialect.java
@@ -31,6 +31,11 @@ public enum Dialect {
      */
     POSTGRESQL,
     /**
+     * CockroachDB dialect.
+     * @since 2.5.0
+     */
+    COCKROACHDB,
+    /**
      * MySQL SQL dialect.
      */
     MYSQL,

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -701,6 +701,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      */
     @Override
     public synchronized void dropEntity(final DbEntity entity) throws DatabaseEngineException {
+        // DROP table before sequences, since the table may be using them and prevent them from being dropped
         dropTable(entity);
         dropSequences(entity);
         entities.remove(entity.getName());

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -701,8 +701,8 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      */
     @Override
     public synchronized void dropEntity(final DbEntity entity) throws DatabaseEngineException {
-        dropSequences(entity);
         dropTable(entity);
+        dropSequences(entity);
         entities.remove(entity.getName());
         logger.trace("Entity {} dropped", entity.getName());
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngineDriver.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngineDriver.java
@@ -43,10 +43,15 @@ public enum DatabaseEngineDriver {
      */
     POSTGRES("Postgres", "com.feedzai.commons.sql.abstraction.engine.impl.PostgreSqlEngine", "org.postgresql.Driver", 5432) {
         @Override
-        public String connectionStringFor(String hostname, String database) {
-            return connectionStringFor(hostname, database, 5432);
+        public String connectionStringFor(String hostname, String database, int port) {
+            return String.format("jdbc:postgresql://%s:%d/%s", hostname, port, database);
         }
-
+    },
+    /**
+     * The CockroachDB vendor.
+     * @since 2.5.0
+     */
+    COCKROACHDB("CockroachDB", "com.feedzai.commons.sql.abstraction.engine.impl.CockroachDBEngine", "org.postgresql.Driver", 26257) {
         @Override
         public String connectionStringFor(String hostname, String database, int port) {
             return String.format("jdbc:postgresql://%s:%d/%s", hostname, port, database);
@@ -57,11 +62,6 @@ public enum DatabaseEngineDriver {
      */
     SQLSERVER("SQLServer", "com.feedzai.commons.sql.abstraction.engine.impl.SqlServerEngine", "com.microsoft.sqlserver.jdbc.SQLServerDriver", 1433) {
         @Override
-        public String connectionStringFor(String hostname, String database) {
-            return connectionStringFor(hostname, database, 1433);
-        }
-
-        @Override
         public String connectionStringFor(String hostname, String database, int port) {
             return String.format("jdbc:sqlserver://%s:%d;database=%s", hostname, port, database);
         }
@@ -70,11 +70,6 @@ public enum DatabaseEngineDriver {
      * The Oracle vendor.
      */
     ORACLE("Oracle", "com.feedzai.commons.sql.abstraction.engine.impl.OracleEngine", "oracle.jdbc.OracleDriver", 1521) {
-        @Override
-        public String connectionStringFor(String hostname, String database) {
-            return connectionStringFor(hostname, database, 1521);
-        }
-
         @Override
         public String connectionStringFor(String hostname, String database, int port) {
             return String.format("jdbc:oracle:thin:@%s:%d:%s", hostname, port, database);
@@ -85,11 +80,6 @@ public enum DatabaseEngineDriver {
      */
     MYSQL("MySQL", "com.feedzai.commons.sql.abstraction.engine.impl.MySqlEngine", "com.mysql.jdbc.Driver", 3306) {
         @Override
-        public String connectionStringFor(String hostname, String database) {
-            return connectionStringFor(hostname, database, 3306);
-        }
-
-        @Override
         public String connectionStringFor(String hostname, String database, int port) {
             return String.format("jdbc:mysql://%s:%d/%s", hostname, port, database);
         }
@@ -98,11 +88,6 @@ public enum DatabaseEngineDriver {
      * The DB2 vendor.
      */
     DB2("DB2", "com.feedzai.commons.sql.abstraction.engine.impl.DB2Engine", "com.ibm.db2.jcc.DB2Driver", 50000) {
-        @Override
-        public String connectionStringFor(String hostname, String database) {
-            return connectionStringFor(hostname, database, 50000);
-        }
-
         @Override
         public String connectionStringFor(String hostname, String database, int port) {
             return String.format("jdbc:db2://%s:%d/%s", hostname, port, database);
@@ -215,7 +200,9 @@ public enum DatabaseEngineDriver {
      * @param database The database.
      * @return The formatted string to create a JDBC connection.
      */
-    public abstract String connectionStringFor(String hostname, String database);
+    public String connectionStringFor(final String hostname, final String database) {
+        return connectionStringFor(hostname, database, defaultPort());
+    }
 
     /**
      * Gets the JDBC connection string given the hostname and the database.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/CockroachDBEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/CockroachDBEngine.java
@@ -199,7 +199,7 @@ public class CockroachDBEngine extends PostgreSqlEngine {
                 }
             } else if (hasIdentityColumn(me.getEntity())) {
                 final List<Map<String, ResultColumn>> q = query(
-                        "SELECT max(" + quotize(me.getAutoIncColumn()) + ") FROM" + quotize(name)
+                        format("SELECT max(%s) FROM %s", quotize(me.getAutoIncColumn()), quotize(name))
                 );
                 if (!q.isEmpty()) {
                     ret = q.get(0).values().iterator().next().toLong();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/CockroachDBEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/CockroachDBEngine.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl;
+
+import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumnType;
+import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
+import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
+import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
+import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
+import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
+import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.join;
+
+/**
+ * CockroachDB specific database implementation.
+ *
+ * @author Mário Pereira (mario.arzileiro@feedzai.com)
+ * @since 2.5.0
+ */
+public class CockroachDBEngine extends PostgreSqlEngine {
+
+    /**
+     * The Cockroach JDBC (PostgreSQL) driver.
+     */
+    protected static final String COCKROACHDB_DRIVER = DatabaseEngineDriver.COCKROACHDB.driver();
+
+    /**
+     * Constraint name already exists.
+     *
+     * Note: CockroachDB v19.2.x returns this SQL state when trying to add a foreign key relation that already exists.
+     * This constant is needed because PosgtgreSQL uses code 42710 - ERRCODE_DUPLICATE_OBJECT instead.
+     * In this situation CockroachDB v19.2.x uses code 23503 - ERRCODE_FOREIGN_KEY_VIOLATION (a column in a table has
+     * a value that is not present in the column of other table in the foreign key relation);
+     * in the same situation CockroachDB v19.1.x returns state 42830 - ERRCODE_INVALID_FOREIGN_KEY (which can occur for
+     * example when the types of columns in the relation have incompatible types).
+     * @see <a href="https://github.com/cockroachdb/cockroach/issues/42858">CockroachDB issue #42858</a>
+     */
+    public static final String CONSTRAINT_NAME_ALREADY_EXISTS_COCKROACH = "23503";
+
+    /**
+     * Creates a new CockroachDB connection.
+     *
+     * @param properties The properties for the database connection.
+     * @throws DatabaseEngineException When the connection fails.
+     */
+    public CockroachDBEngine(final PdbProperties properties) throws DatabaseEngineException {
+        super(properties, COCKROACHDB_DRIVER);
+    }
+
+    @Override
+    protected void createTable(final DbEntity entity) throws DatabaseEngineException {
+
+        List<String> createTable = new ArrayList<>();
+
+        createTable.add("CREATE TABLE");
+        createTable.add(quotize(entity.getName()));
+
+        // COLUMNS
+        List<String> columns = new ArrayList<>();
+        for (DbColumn c : entity.getColumns()) {
+            List<String> column = new ArrayList<>();
+            column.add(quotize(c.getName()));
+            column.add(translateType(c));
+
+            for (DbColumnConstraint cc : c.getColumnConstraints()) {
+                column.add(cc.translate());
+            }
+
+            if (c.isDefaultValueSet()) {
+                column.add("DEFAULT");
+                column.add(translate(c.getDefaultValue()));
+            }
+
+            columns.add(join(column, " "));
+        }
+        createTable.add("(" + join(columns, ", "));
+        // COLUMNS end
+
+
+        // PRIMARY KEY
+        List<String> pks = new ArrayList<>();
+        for (String pk : entity.getPkFields()) {
+            pks.add(quotize(pk));
+        }
+
+        if (!pks.isEmpty()) {
+            createTable.add(",");
+
+            final String pkName = md5(format("PK_%s", entity.getName()), properties.getMaxIdentifierSize());
+
+            createTable.add("CONSTRAINT");
+            createTable.add(quotize(pkName));
+            createTable.add("PRIMARY KEY");
+            createTable.add("(" + join(pks, ", ") + ")");
+        }
+        // PK end
+
+        createTable.add(")");
+
+        final String createTableStatement = join(createTable, " ");
+
+        logger.trace(createTableStatement);
+
+        Statement s = null;
+        try {
+            s = conn.createStatement();
+            s.executeUpdate(createTableStatement);
+        } catch (final SQLException ex) {
+            if (ex.getSQLState().equals(NAME_ALREADY_EXISTS)) {
+                logger.debug(dev, "'{}' is already defined", entity.getName());
+                handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_ALREADY_EXISTS), ex);
+            } else {
+                throw new DatabaseEngineException("Something went wrong handling statement", ex);
+            }
+        } finally {
+            try {
+                if (s != null) {
+                    s.close();
+                }
+            } catch (final Exception e) {
+                logger.trace("Error closing statement.", e);
+            }
+        }
+    }
+
+    @Override
+    protected void addPrimaryKey(final DbEntity entity) throws DatabaseEngineException {
+        // Do nothing because Primary Keys are added at creation table time.
+    }
+
+    @Override
+    public Class<? extends AbstractTranslator> getTranslatorClass() {
+        return CockroachDBTranslator.class;
+    }
+
+    @Override
+    public synchronized Long persist(final String name,
+                                     final EntityEntry entry,
+                                     final boolean useAutoInc) throws DatabaseEngineException {
+        ResultSet generatedKeys = null;
+        try {
+            getConnection();
+
+            final MappedEntity me = entities.get(name);
+
+            if (me == null) {
+                throw new DatabaseEngineException(String.format("Unknown entity '%s'", name));
+            }
+
+            final PreparedStatement ps;
+            if (useAutoInc) {
+                ps = me.getInsertReturning();
+            } else {
+                ps = me.getInsertWithAutoInc();
+            }
+
+            entityToPreparedStatement(me.getEntity(), ps, entry, useAutoInc);
+            generatedKeys = ps.executeQuery();
+
+
+            long ret = 0;
+
+            if (useAutoInc) {
+                if (generatedKeys.next()) {
+                    ret = generatedKeys.getLong(1);
+                }
+            } else if (hasIdentityColumn(me.getEntity())) {
+                final List<Map<String, ResultColumn>> q = query(
+                        "SELECT max(" + quotize(me.getAutoIncColumn()) + ") FROM" + quotize(name)
+                );
+                if (!q.isEmpty()) {
+                    ret = q.get(0).values().iterator().next().toLong();
+                }
+
+                executeUpdateSilently(format("SELECT setval('%s', %d, false)",
+                        getQuotizedSequenceName(me.getEntity(), me.getAutoIncColumn()), ret + 1
+                ));
+                ret = 0;
+            }
+
+            return ret == 0 ? null : ret;
+        } catch (final Exception ex) {
+            throw new DatabaseEngineException("Something went wrong persisting the entity", ex);
+        } finally {
+            try {
+                if (generatedKeys != null) {
+                    generatedKeys.close();
+                }
+            } catch (final Exception e) {
+                logger.trace("Error closing result set.", e);
+            }
+        }
+    }
+
+    protected void addFks(final DbEntity entity) throws DatabaseEngineException {
+        try {
+            super.addFks(entity);
+        } catch (final DatabaseEngineException ex) {
+            if (ex.getCause() instanceof SQLException) {
+                final SQLException sqlException = (SQLException) ex.getCause();
+                if (sqlException.getSQLState().equals(CONSTRAINT_NAME_ALREADY_EXISTS_COCKROACH)) {
+                    logger.debug(dev, "Foreign key for table '{}' already exists. Error code: {}.", entity.getName(), sqlException.getSQLState());
+                    return;
+                }
+            }
+            throw ex;
+        }
+    }
+
+    @Override
+    protected void addSequences(final DbEntity entity) throws DatabaseEngineException {
+        for (final DbColumn column : entity.getColumns()) {
+            if (!column.isAutoInc()) {
+                continue;
+            }
+
+            final String sequenceName = getQuotizedSequenceName(entity, column.getName());
+
+            final StringBuilder createSequence = new StringBuilder()
+                    .append("CREATE SEQUENCE ")
+                    .append(sequenceName)
+                    .append(" MINVALUE 0 MAXVALUE ");
+            switch (column.getDbColumnType()) {
+                case INT:
+                    createSequence.append(Integer.MAX_VALUE);
+                    break;
+                case LONG:
+                    createSequence.append(Long.MAX_VALUE);
+                    break;
+                default:
+                    throw new DatabaseEngineException("Auto incrementation is only supported on INT and LONG");
+            }
+            createSequence.append(" START 1 INCREMENT 1;");
+
+            createSequence.append("ALTER TABLE ")
+                    .append(quotize(entity.getName()))
+                    .append(" ALTER COLUMN ")
+                    .append(quotize(column.getName()))
+                    .append(" SET DEFAULT nextval('").append(sequenceName).append("')");
+
+            final String statement = createSequence.toString();
+
+            logger.trace(statement);
+
+            Statement s = null;
+            try {
+                s = conn.createStatement();
+                s.executeUpdate(statement);
+            } catch (final SQLException ex) {
+                if (ex.getSQLState().equals(NAME_ALREADY_EXISTS)) {
+                    logger.debug(dev, "Sequence {} is already defined", sequenceName);
+                    handleOperation(
+                            new OperationFault(entity.getName(), OperationFault.Type.SEQUENCE_ALREADY_EXISTS), ex
+                    );
+                } else {
+                    throw new DatabaseEngineException("Something went wrong handling statement", ex);
+                }
+            } finally {
+                try {
+                    if (s != null) {
+                        s.close();
+                    }
+                } catch (final Exception e) {
+                    logger.trace("Error closing statement.", e);
+                }
+            }
+
+
+        }
+    }
+
+    @Override
+    protected void dropSequences(final DbEntity entity) throws DatabaseEngineException {
+        for (final DbColumn column : entity.getColumns()) {
+            if (!column.isAutoInc()) {
+                continue;
+            }
+
+            final String sequenceName = getQuotizedSequenceName(entity, column.getName());
+            final String stmt = format("DROP SEQUENCE %s", sequenceName);
+
+            Statement drop = null;
+            try {
+                drop = conn.createStatement();
+                logger.trace(stmt);
+                drop.executeUpdate(stmt);
+            } catch (final SQLException ex) {
+                if (ex.getSQLState().equals(TABLE_OR_VIEW_DOES_NOT_EXIST)) {
+                    logger.debug(dev, "Sequence {} does not exist", sequenceName);
+                    handleOperation(
+                            new OperationFault(entity.getName(), OperationFault.Type.SEQUENCE_DOES_NOT_EXIST), ex
+                    );
+                } else {
+                    throw new DatabaseEngineException("Error dropping sequence", ex);
+                }
+            } finally {
+                try {
+                    if (drop != null) {
+                        drop.close();
+                    }
+                } catch (final Exception e) {
+                    logger.trace("Error closing statement.", e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public synchronized Map<String, DbColumnType> getMetadata(final String schemaPattern,
+                                                              final String tableNamePattern) throws DatabaseEngineException {
+        final Map<String, DbColumnType> metaMap = new LinkedHashMap<>();
+
+        ResultSet rsColumns = null;
+        try {
+            getConnection();
+
+            final DatabaseMetaData meta = this.conn.getMetaData();
+            rsColumns = meta.getColumns(null, schemaPattern, tableNamePattern, null);
+            while (rsColumns.next()) {
+                final String columnName = rsColumns.getString("COLUMN_NAME");
+                if (columnName.equals("rowid")) {
+                    continue;
+                }
+                metaMap.put(columnName, toPdbType(rsColumns.getInt("DATA_TYPE"), rsColumns.getString("TYPE_NAME")));
+            }
+
+            return metaMap;
+        } catch (final Exception e) {
+            throw new DatabaseEngineException("Could not get metadata", e);
+        } finally {
+            try {
+                if (rsColumns != null) {
+                    rsColumns.close();
+                }
+            } catch (final Exception a) {
+                logger.trace("Error closing result set.", a);
+            }
+        }
+    }
+
+    /**
+     * Gets a name to use in a sequence, already quotized.
+     *
+     * @param entity  The entity for which the sequence will be used.
+     * @param colName The name of the column that will be using the sequence.
+     * @return the quotized sequence name.
+     */
+    private String getQuotizedSequenceName(final DbEntity entity, final String colName) {
+        return quotize(md5(format("%s_%s_SEQ", entity.getName(), colName), properties.getMaxIdentifierSize()));
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/CockroachDBTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/CockroachDBTranslator.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl;
+
+import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
+import com.feedzai.commons.sql.abstraction.dml.Cast;
+import com.feedzai.commons.sql.abstraction.dml.Expression;
+import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
+import com.feedzai.commons.sql.abstraction.engine.OperationNotSupportedRuntimeException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.VARCHAR_SIZE;
+import static java.lang.String.format;
+
+/**
+ * Provides SQL translation for CockroachDB.
+ *
+ * @author Mário Pereira (mario.arzileiro@feedzai.com)
+ * @since 2.5.0
+ */
+public class CockroachDBTranslator extends PostgreSqlTranslator {
+
+    @Override
+    public String translate(final DbColumn c) {
+        switch (c.getDbColumnType()) {
+            case BOOLEAN:
+                return "BOOLEAN";
+
+            case DOUBLE:
+                return "DOUBLE PRECISION";
+
+            case INT:
+                if (c.isAutoInc()) {
+                    return "INT4";
+                } else {
+                    return "INT4";
+                }
+
+            case LONG:
+                if (c.isAutoInc()) {
+                    return "INT8";
+                } else {
+                    return "INT8";
+                }
+
+            case STRING:
+                return format("VARCHAR(%s)", c.isSizeSet() ? c.getSize().toString() : properties.getProperty(VARCHAR_SIZE));
+
+            case CLOB:
+                return "TEXT";
+
+            case BLOB:
+                return "BYTEA";
+
+            case JSON:
+                return "JSONB";
+
+            default:
+                throw new DatabaseEngineRuntimeException(format(
+                        "Mapping not found for '%s'. Please report this error.",
+                        c.getDbColumnType()
+                ));
+        }
+    }
+
+    @Override
+    public String translate(final Cast cast) {
+        final String type;
+
+        // Cast to type.
+        switch (cast.getType()) {
+            case BOOLEAN:
+                type = "BOOLEAN";
+                break;
+            case DOUBLE:
+                type = "DOUBLE PRECISION";
+                break;
+            case INT:
+                type = "INT4";
+                break;
+            case LONG:
+                type = "INT8";
+                break;
+            case STRING:
+                type = "VARCHAR";
+                break;
+            default:
+                throw new OperationNotSupportedRuntimeException(format("Cannot cast to '%s'.", cast.getType()));
+        }
+
+        inject(cast.getExpression());
+        final String translation = format("CAST(%s AS %s)",
+                cast.getExpression().translate(),
+                type);
+
+        return cast.isEnclosed() ? "(" + translation + ")" : translation;
+    }
+
+    @Override
+    public String translate(final RepeatDelimiter rd) {
+        final String delimiter = rd.getDelimiter();
+        final List<String> all = new ArrayList<>();
+
+        // unlike PostgreSQL, CockroachDB needs *all* parameters in the division to be CAST as DOUBLE
+        for (final Expression expression : rd.getExpressions()) {
+            inject(expression);
+            if (RepeatDelimiter.DIV.equals(delimiter)) {
+                all.add(String.format("CAST(%s AS DOUBLE PRECISION)", expression.translate()));
+            } else {
+                all.add(expression.translate());
+            }
+        }
+
+        if (rd.isEnclosed()) {
+            return "(" + join(all, delimiter) + ")";
+        } else {
+            return join(all, delimiter);
+        }
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/CockroachDBTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/CockroachDBTranslator.java
@@ -47,18 +47,10 @@ public class CockroachDBTranslator extends PostgreSqlTranslator {
                 return "DOUBLE PRECISION";
 
             case INT:
-                if (c.isAutoInc()) {
-                    return "INT4";
-                } else {
-                    return "INT4";
-                }
+                return "INT4";
 
             case LONG:
-                if (c.isAutoInc()) {
-                    return "INT8";
-                } else {
-                    return "INT8";
-                }
+                return "INT8";
 
             case STRING:
                 return format("VARCHAR(%s)", c.isSizeSet() ? c.getSize().toString() : properties.getProperty(VARCHAR_SIZE));

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -124,7 +124,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
      * @throws DatabaseEngineException When the connection fails.
      * @since 2.5.0
      */
-    public PostgreSqlEngine(final PdbProperties properties, final String driver) throws DatabaseEngineException {
+    protected PostgreSqlEngine(final PdbProperties properties, final String driver) throws DatabaseEngineException {
         super(driver, properties, Dialect.POSTGRESQL);
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -113,6 +113,21 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         super(POSTGRESQL_DRIVER, properties, Dialect.POSTGRESQL);
     }
 
+    /**
+     * Creates a new PostgreSql connection.
+     *
+     * Note: this constructor exists so that most of the code in this implementation can be reused
+     * by (almost) compatible engines, like CockroachDB.
+     *
+     * @param properties The properties for the database connection.
+     * @param driver     The driver to connect to the database.
+     * @throws DatabaseEngineException When the connection fails.
+     * @since 2.5.0
+     */
+    public PostgreSqlEngine(final PdbProperties properties, final String driver) throws DatabaseEngineException {
+        super(driver, properties, Dialect.POSTGRESQL);
+    }
+
     @Override
     protected int entityToPreparedStatement(final DbEntity entity, final PreparedStatement ps, final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -42,6 +42,7 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
 import com.feedzai.commons.sql.abstraction.engine.NameAlreadyExistsException;
 import com.feedzai.commons.sql.abstraction.engine.OperationNotSupportedRuntimeException;
+import com.feedzai.commons.sql.abstraction.engine.impl.cockroach.SkipTestCockroachDB;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.BlobTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
@@ -56,6 +57,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -1806,6 +1808,9 @@ public class EngineGeneralTest {
     }
 
     @Test
+    @Category(SkipTestCockroachDB.class)
+    // unimplemented in CockroachDB: views do not currently support * expressions
+    // https://github.com/cockroachdb/cockroach/issues/10028
     public void createViewTest() throws DatabaseEngineException {
         test5Columns();
 
@@ -1820,6 +1825,9 @@ public class EngineGeneralTest {
     }
 
     @Test
+    @Category(SkipTestCockroachDB.class)
+    // unimplemented in CockroachDB: views do not currently support * expressions
+    // https://github.com/cockroachdb/cockroach/issues/10028
     public void createOrReplaceViewTest() throws DatabaseEngineException {
         test5Columns();
 
@@ -3861,6 +3869,7 @@ public class EngineGeneralTest {
     }
 
     @Test
+    @Category(SkipTestCockroachDB.class)
     public void dropPrimaryKeyWithOneColumnTest() throws Exception {
         DbEntity entity =
                 dbEntity()
@@ -3877,6 +3886,7 @@ public class EngineGeneralTest {
     }
 
     @Test
+    @Category(SkipTestCockroachDB.class)
     public void dropPrimaryKeyWithTwoColumnsTest() throws Exception {
         DbEntity entity =
                 dbEntity()
@@ -3912,6 +3922,7 @@ public class EngineGeneralTest {
     }
 
     @Test
+    @Category(SkipTestCockroachDB.class)
     public void alterColumnToDifferentTypeTest() throws DatabaseEngineException {
         DbEntity entity =
                 dbEntity()

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineIsolationTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineIsolationTest.java
@@ -273,17 +273,13 @@ public class EngineIsolationTest {
      * @throws Exception if something goes wrong in the verification.
      * @since 2.4.7
      */
-    protected boolean isRealSerializableLevel(final DatabaseEngine engine) throws Exception {
+    private boolean isRealSerializableLevel(final DatabaseEngine engine) throws Exception {
         final PdbProperties pdbProps = new PdbProperties(this.properties, true);
         final DatabaseEngineDriver engineDriver = DatabaseEngineDriver.fromEngine(pdbProps.getEngine());
 
-        switch (engine.getConnection().getTransactionIsolation()) {
-            case Connection.TRANSACTION_SERIALIZABLE:
-                if (engineDriver == DatabaseEngineDriver.SQLSERVER) {
-                    return true;
-                }
-            default:
-                return false;
+        if (engine.getConnection().getTransactionIsolation() == Connection.TRANSACTION_SERIALIZABLE) {
+            return engineDriver == DatabaseEngineDriver.SQLSERVER || engineDriver == DatabaseEngineDriver.COCKROACHDB;
         }
+        return false;
     }
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/cockroach/SkipTestCockroachDB.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/cockroach/SkipTestCockroachDB.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl.cockroach;
+
+/**
+ * Interface used to mark the tests that need to be ignored when running test with CockroachDB
+ *
+ * @author Mário Pereira (mario.arzileiro@feedzai.com)
+ * @since 2.5.0
+ */
+public interface SkipTestCockroachDB {
+}

--- a/src/test/resources/connections.properties
+++ b/src/test/resources/connections.properties
@@ -66,3 +66,10 @@ db2.username=db2inst1
 db2.password=AaBb12.#
 # for DB2, default schema is the same as user name
 #db2.schema=db2inst1
+
+cockroach.engine=com.feedzai.commons.sql.abstraction.engine.impl.CockroachDBEngine
+cockroach.jdbc=jdbc:postgresql://localhost:26257/postgres
+# default database: postgres is used because it's mandatory
+cockroach.username=root
+cockroach.password=
+#postgresql.schema=public


### PR DESCRIPTION
Summary:
CockroachDB uses the same driver as PostgreSQL, but there are some
incompatibilities, and a new profile needed to be setup for tests to
allow using a CockroachDB Docker image.

This commit adds a new CockroachDB engine that extends the one for
PostgreSQL to address the incompatibilities and makes some small
adjustments to all code accordingly.
A new "cockroach" profile was added to the pom to run the tests with a
CockroachDB instance.

The pom was changed by adding new "image.<profile_name>" flags, one for
each profile, that allows specifying docker images different from the
defaults (e.g. new versions) to run the tests with.
Those defaults are the images/versions that were already in the pom.