### PR TITLE
Cleanups in preparation for more retryable exceptions

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -381,7 +381,7 @@ public abstract class AbstractBatch implements Runnable {
                     logger.trace("[{}] Batch failed to check the flush transaction state", name, ee);
                 }
 
-                onFlushFailure(temp.toArray(new BatchEntry[temp.size()]));
+                onFlushFailure(temp.toArray(new BatchEntry[0]));
                 logger.error(dev, "[{}] Error occurred while flushing. Aborting batch flush.", name, e);
             } else {
                 logger.trace("[{}] Batch flushed. Took {} ms, {} retries, {} rows.", name,

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Join.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Join.java
@@ -27,15 +27,15 @@ public class Join extends Expression {
     /**
      * The join type represented in a String (INNER, OUTER, etc).
      */
-    private String join = null;
+    private String join;
     /**
      * The Table to join.
      */
-    private Expression joinTable = null;
+    private Expression joinTable;
     /**
      * The Expression to join.
      */
-    private Expression joinExpr = null;
+    private Expression joinExpr;
 
     /**
      * Creates a new instance of {@link Join}.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -1228,7 +1228,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     protected abstract ResultIterator createResultIterator(Statement statement, String sql) throws DatabaseEngineException;
 
     /**
-     * Creates a specific {@link ResultIterator} for the engine in place given given prepared statement.
+     * Creates a specific {@link ResultIterator} for the engine in place given a prepared statement.
      *
      * @param ps The prepared statement.
      * @return The result iterator.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -312,7 +312,7 @@ public interface DatabaseEngine extends AutoCloseable {
      * @throws DatabaseEngineException If something goes wrong executing the query.
      */
     default List<Map<String, ResultColumn>> query(final Expression query, final int readTimeoutOverride) throws DatabaseEngineException {
-        return query(query);
+        return query(translate(query), readTimeoutOverride);
     }
 
     /**
@@ -633,7 +633,7 @@ public interface DatabaseEngine extends AutoCloseable {
      * @throws DatabaseEngineException If a database access error occurs.
      */
     default ResultIterator iterator(final Expression query, final int fetchSize, final int readTimeoutOverride) throws DatabaseEngineException {
-        return iterator(query, fetchSize);
+        return iterator(translate(query), fetchSize, readTimeoutOverride);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseFactory.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseFactory.java
@@ -58,7 +58,7 @@ public final class DatabaseFactory {
         try {
             Class<?> c = Class.forName(engine);
 
-            Constructor cons = c.getConstructor(PdbProperties.class);
+            final Constructor<?> cons = c.getConstructor(PdbProperties.class);
             final AbstractDatabaseEngine de = (AbstractDatabaseEngine) cons.newInstance(pdbProperties);
 
             Class<? extends AbstractTranslator> tc = de.getTranslatorClass();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -680,16 +680,6 @@ public class DB2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected String translateType(DbColumn c) throws DatabaseEngineException {
-        return translator.translate(c);
-    }
-
-    @Override
-    public synchronized Long persist(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        return persist(name, entry, true);
-    }
-
-    @Override
     public synchronized Long persist(String name, EntityEntry entry, boolean useAutoInc) throws DatabaseEngineException {
         try {
             getConnection();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.MAX_BLOB_SIZE;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.VARCHAR_SIZE;
@@ -155,10 +156,12 @@ public class DB2Translator extends AbstractTranslator {
     public String translate(RepeatDelimiter rd) {
         final String delimiter = rd.getDelimiter();
 
-        final List<Object> all = Lists.transform(rd.getExpressions(), input -> {
-            inject(input);
-            return input.translate();
-        });
+        final List<Object> all = rd.getExpressions().stream()
+                .map(input -> {
+                    inject(input);
+                    return input.translate();
+                })
+                .collect(Collectors.toList());
 
         if (RepeatDelimiter.DIV.equals(delimiter)) {
             /* DB2 operations are type sensitive...must convert to  double first (why IBM??)*/

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -517,16 +517,6 @@ public class H2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected String translateType(DbColumn c) throws DatabaseEngineException {
-        return translator.translate(c);
-    }
-
-    @Override
-    public synchronized Long persist(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        return persist(name, entry, true);
-    }
-
-    @Override
     public synchronized Long persist(String name, EntityEntry entry, boolean useAutoInc) throws DatabaseEngineException {
 
         ResultSet generatedKeys = null;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -29,7 +29,6 @@ import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineTimeoutException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
@@ -51,12 +50,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.feedzai.commons.sql.abstraction.util.Constants.NO_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
-import static java.sql.ResultSet.CONCUR_READ_ONLY;
-import static java.sql.ResultSet.TYPE_FORWARD_ONLY;
 import static org.apache.commons.lang3.StringUtils.join;
 
 /**
@@ -540,18 +536,8 @@ public class MySqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected String translateType(DbColumn c) throws DatabaseEngineException {
-        return translator.translate(c);
-    }
-
-    @Override
     public Class<? extends AbstractTranslator> getTranslatorClass() {
         return MySqlTranslator.class;
-    }
-
-    @Override
-    public synchronized Long persist(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        return persist(name, entry, true);
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.union;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.VARCHAR_SIZE;
@@ -115,10 +116,12 @@ public class MySqlTranslator extends AbstractTranslator {
     public String translate(RepeatDelimiter rd) {
         final String delimiter = rd.getDelimiter();
 
-        List<Object> all = Lists.transform(rd.getExpressions(), input -> {
-            inject(input);
-            return input.translate();
-        });
+        final List<Object> all = rd.getExpressions().stream()
+                .map(input -> {
+                    inject(input);
+                    return input.translate();
+                })
+                .collect(Collectors.toList());
 
         if (rd.isEnclosed()) {
             return "(" + StringUtils.join(all, delimiter) + ")";

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -236,7 +236,7 @@ public class OracleEngine extends AbstractDatabaseEngine {
      * @param fromBatch     Indicates if this is being requested in the context of a
      *                      batch update or not.
      *
-     * @return The prepared statement filled in.
+     * @return The position of the last bind parameter that was filled in a prepared statement.
      * @throws DatabaseEngineException if something occurs during the translation.
      *
      * @since 2.4.2
@@ -855,17 +855,6 @@ public class OracleEngine extends AbstractDatabaseEngine {
                 logger.trace("Error closing statement.", e);
             }
         }
-
-    }
-
-    @Override
-    protected String translateType(DbColumn c) throws DatabaseEngineException {
-        return translator.translate(c);
-    }
-
-    @Override
-    public synchronized Long persist(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        return persist(name, entry, true);
 
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.VARCHAR_SIZE;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -129,10 +130,12 @@ public class OracleTranslator extends AbstractTranslator {
     public String translate(RepeatDelimiter rd) {
         final String delimiter = rd.getDelimiter();
 
-        List<Object> all = Lists.transform(rd.getExpressions(), input -> {
-            inject(input);
-            return input.translate();
-        });
+        final List<Object> all = rd.getExpressions().stream()
+                .map(input -> {
+                    inject(input);
+                    return input.translate();
+                })
+                .collect(Collectors.toList());
 
         if (rd.isEnclosed()) {
             return "(" + org.apache.commons.lang3.StringUtils.join(all, delimiter) + ")";

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -554,18 +554,8 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected String translateType(DbColumn c) throws DatabaseEngineException {
-        return translator.translate(c);
-    }
-
-    @Override
     public Class<? extends AbstractTranslator> getTranslatorClass() {
         return PostgreSqlTranslator.class;
-    }
-
-    @Override
-    public synchronized Long persist(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        return persist(name, entry, true);
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -557,18 +557,8 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected String translateType(final DbColumn c) throws DatabaseEngineException {
-        return translator.translate(c);
-    }
-
-    @Override
     public Class<? extends AbstractTranslator> getTranslatorClass() {
         return SqlServerTranslator.class;
-    }
-
-    @Override
-    public synchronized Long persist(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        return persist(name, entry, true);
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/AESHelper.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/AESHelper.java
@@ -21,7 +21,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /**
  * Class to provide encryption and decryption using AES algorithm.
@@ -141,9 +143,7 @@ public final class AESHelper {
      */
     public static void encryptToFile(String path, byte[] buf, String key) {
         try {
-            FileOutputStream fos = new FileOutputStream(path);
-            fos.write(encrypt(buf, key).getBytes());
-            fos.close();
+            Files.write(Paths.get(path), encrypt(buf, key).getBytes());
         } catch (final Exception e) {
             logger.warn("Could not encrypt to file {}", path, e);
         }
@@ -154,22 +154,9 @@ public final class AESHelper {
      *
      * @param filePath The file path.
      * @return a byte[] The file data.
-     * @throws java.io.IOException if an error occurs reading the file or if the file does not exists.
+     * @throws IOException if an error occurs reading the file or if the file does not exists.
      */
-    public static byte[] readFile(String filePath) throws IOException {
-        byte[] buffer = new byte[(int) new File(filePath).length()];
-        BufferedInputStream f = null;
-        try {
-            f = new BufferedInputStream(new FileInputStream(filePath));
-            f.read(buffer);
-        } finally {
-            if (f != null) {
-                try {
-                    f.close();
-                } catch (final IOException ignored) {
-                }
-            }
-        }
-        return buffer;
+    public static byte[] readFile(final String filePath) throws IOException {
+        return Files.readAllBytes(Paths.get(filePath));
     }
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
@@ -581,12 +581,13 @@ public abstract class AbstractEngineSchemaTest {
                 expectedAllowColumnDrop, engine.getProperties().allowColumnDrop());
 
         // guarantee that is deleted and doesn't come from previous tests.
-        engine.dropEntity(TABLE_NAME);
+        final DbEntity entity = createSpecialValuesEntity();
+        engine.updateEntity(entity);
+        engine.dropEntity(entity);
+        engine.addEntity(entity);
 
         try {
-            final DbEntity entity = createSpecialValuesEntity();
             engine.beginTransaction();
-            engine.updateEntity(entity);
             engine.addBatch(TABLE_NAME, createSpecialValueEntry(10));
             engine.flush();
             engine.commit();
@@ -603,7 +604,7 @@ public abstract class AbstractEngineSchemaTest {
 
         } finally {
             // drop the entity, not needed anymore
-            engine.dropEntity(TABLE_NAME);
+            engine.dropEntity(entity);
 
             if (engine.isTransactionActive()) {
                 engine.rollback();

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCreateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCreateTest.java
@@ -26,6 +26,7 @@ import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.core.AnyOf;
 import org.hamcrest.core.IsEqual;
 import org.junit.Before;
@@ -180,9 +181,6 @@ public class EngineCreateTest {
 
     @Test
     public void stopsWhenTableAlreadyExistsTest() throws Exception {
-        expected.expect(DatabaseEngineException.class);
-        expected.expectMessage("An error occurred adding the entity.");
-
         final DatabaseEngine conn = DatabaseFactory.getConnection(properties);
         DatabaseEngine conn2 = conn.duplicate(new Properties(), false);
 
@@ -193,8 +191,12 @@ public class EngineCreateTest {
                 .addColumn("COL1", INT).build();
 
         conn.addEntity(entity);
-        conn2.addEntity(entity);
 
+        expected.expect(DatabaseEngineException.class);
+        expected.expectMessage(CoreMatchers.startsWith(
+                String.format("An error occurred performing an operation on entity '%s'; cause: ", entity.getName())
+        ));
+        conn2.addEntity(entity);
     }
 
     /**

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineGeneralTest.java
@@ -25,19 +25,17 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.BOOLEAN;
@@ -59,7 +57,6 @@ import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProper
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /**
  * @author Rui Vilao (rui.vilao@feedzai.com)

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineIsolationTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineIsolationTest.java
@@ -18,18 +18,24 @@ package com.feedzai.commons.sql.abstraction.engine.impl.sqlserver;
 
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
-import com.feedzai.commons.sql.abstraction.engine.impl.abs.EngineIsolationTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
 import com.microsoft.sqlserver.jdbc.SQLServerConnection;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Properties;
 
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ISOLATION_LEVEL;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
 
 /**
  * Additional isolation tests for SQL Server.
@@ -38,11 +44,32 @@ import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProper
  * @since 2.4.7
  */
 @RunWith(Parameterized.class)
-public class SqlServerEngineIsolationTest extends EngineIsolationTest {
+public class SqlServerEngineIsolationTest {
+
+    private Properties properties;
 
     @Parameterized.Parameters
     public static Collection<DatabaseConfiguration> data() throws Exception {
         return DatabaseTestUtil.loadConfigurations("sqlserver");
+    }
+
+    @Parameterized.Parameter
+    public DatabaseConfiguration config;
+
+    @Before
+    public void init() throws Exception {
+        final DatabaseConfiguration config = DatabaseTestUtil.loadConfigurations("sqlserver").iterator().next();
+
+        this.properties = new Properties() {
+            {
+                setProperty(JDBC, config.jdbc);
+                setProperty(USERNAME, config.username);
+                setProperty(PASSWORD, config.password);
+                setProperty(ENGINE, config.engine);
+                setProperty(SCHEMA_POLICY, "create");
+                setProperty(ISOLATION_LEVEL, Objects.toString(SQLServerConnection.TRANSACTION_SNAPSHOT));
+            }
+        };
     }
 
     /**

--- a/src/test/resources/connections.properties
+++ b/src/test/resources/connections.properties
@@ -72,4 +72,4 @@ cockroach.jdbc=jdbc:postgresql://localhost:26257/postgres
 # default database: postgres is used because it's mandatory
 cockroach.username=root
 cockroach.password=
-#postgresql.schema=public
+#cockroach.schema=public


### PR DESCRIPTION
Summary:
Retryable errors when running queries may occur in other places
besides the commit.

In preparation for that, the method
 `persist(final String name, final EntityEntry entry)`
was refactored to AbstractDatabaseEngine (it was implemented in
all engines, but the code was always the same).

This way, any try-catch for the retryable exceptions only needs
to be done in the persist with autoInc parameter.

While at it, the method `translateType(DbColumn c)` was also
repeated in all engines and was moved to AbstractDatabaseEngine.

Other cleanups highlighted by the IDE were also done.