### PR TITLE
Throw retryable exceptions in the methods where they can occur

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/H2ResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/H2ResultIterator.java
@@ -16,10 +16,13 @@
 package com.feedzai.commons.sql.abstraction.dml.result;
 
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.engine.impl.H2Engine;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
+
+import static com.feedzai.commons.sql.abstraction.engine.impl.H2Engine.H2_QUERY_EXCEPTION_HANDLER;
 
 /**
  * Result iterator for the {@link H2Engine} engine.
@@ -52,5 +55,10 @@ public class H2ResultIterator extends ResultIterator {
     @Override
     public ResultColumn createResultColumn(String name, Object value) {
         return new H2ResultColumn(name, value);
+    }
+
+    @Override
+    protected QueryExceptionHandler getQueryExceptionHandler() {
+        return H2_QUERY_EXCEPTION_HANDLER;
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/MySqlResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/MySqlResultIterator.java
@@ -16,11 +16,13 @@
 package com.feedzai.commons.sql.abstraction.dml.result;
 
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.engine.impl.MySqlEngine;
-import com.mysql.jdbc.exceptions.MySQLTimeoutException;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
+
+import static com.feedzai.commons.sql.abstraction.engine.impl.MySqlEngine.MYSQL_QUERY_EXCEPTION_HANDLER;
 
 /**
  * Result iterator for the {@link MySqlEngine} engine.
@@ -56,7 +58,7 @@ public class MySqlResultIterator extends ResultIterator {
     }
 
     @Override
-    protected boolean isTimeoutException(final Exception exception) {
-        return exception instanceof MySQLTimeoutException;
+    protected QueryExceptionHandler getQueryExceptionHandler() {
+        return MYSQL_QUERY_EXCEPTION_HANDLER;
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/OracleResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/OracleResultIterator.java
@@ -16,10 +16,13 @@
 package com.feedzai.commons.sql.abstraction.dml.result;
 
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.engine.impl.OracleEngine;
 
 import java.sql.PreparedStatement;
 import java.sql.Statement;
+
+import static com.feedzai.commons.sql.abstraction.engine.impl.OracleEngine.ORACLE_QUERY_EXCEPTION_HANDLER;
 
 /**
  * Result iterator for the {@link OracleEngine} engine.
@@ -52,5 +55,10 @@ public class OracleResultIterator extends ResultIterator {
     @Override
     public ResultColumn createResultColumn(String name, Object value) {
         return new OracleResultColumn(name, value);
+    }
+
+    @Override
+    protected QueryExceptionHandler getQueryExceptionHandler() {
+        return ORACLE_QUERY_EXCEPTION_HANDLER;
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/PostgreSqlResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/PostgreSqlResultIterator.java
@@ -16,11 +16,13 @@
 package com.feedzai.commons.sql.abstraction.dml.result;
 
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.engine.impl.PostgreSqlEngine;
 
 import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import java.sql.Statement;
+
+import static com.feedzai.commons.sql.abstraction.engine.impl.PostgreSqlEngine.PG_QUERY_EXCEPTION_HANDLER;
 
 /**
  * Result iterator for the {@link PostgreSqlEngine} engine.
@@ -29,11 +31,6 @@ import java.sql.Statement;
  * @since 2.0.0
  */
 public class PostgreSqlResultIterator extends ResultIterator {
-
-    /**
-     * The SQL State that indicates a timeout occurred.
-     */
-    private static final String TIMEOUT_SQL_STATE = "57014";
 
     /**
      * Creates a new instance of {@link PostgreSqlResultIterator}.
@@ -62,8 +59,7 @@ public class PostgreSqlResultIterator extends ResultIterator {
     }
 
     @Override
-    protected boolean isTimeoutException(Exception exception) {
-        return super.isTimeoutException (exception) ||
-                exception instanceof SQLException && TIMEOUT_SQL_STATE.equals(((SQLException) exception).getSQLState());
+    protected QueryExceptionHandler getQueryExceptionHandler() {
+        return PG_QUERY_EXCEPTION_HANDLER;
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultIterator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultIterator.java
@@ -17,6 +17,8 @@ package com.feedzai.commons.sql.abstraction.dml.result;
 
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineTimeoutException;
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
+import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,12 +26,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.SQLTimeoutException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine.DEFAULT_QUERY_EXCEPTION_HANDLER;
 
 /**
  * The abstract result iterator. Extending classes will create the specific {@link ResultColumn}
@@ -81,7 +84,6 @@ public abstract class ResultIterator implements AutoCloseable {
         this.columnNames = new ArrayList<>();
 
         // Process column names.
-        ResultSetMetaData meta;
         try {
             long start = System.currentTimeMillis();
             if (isPreparedStatement) {
@@ -94,29 +96,15 @@ public abstract class ResultIterator implements AutoCloseable {
 
             logger.trace("[{} ms] {}", (System.currentTimeMillis() - start), sql == null ? "" : sql);
 
-            meta = resultSet.getMetaData();
+            final ResultSetMetaData meta = resultSet.getMetaData();
             final int columnCount = meta.getColumnCount();
             for (int i = 1; i <= columnCount; i++) {
                 columnNames.add(meta.getColumnLabel(i));
             }
 
         } catch (final Exception e) {
-            close();
-            throw (isTimeoutException(e) ?
-                new DatabaseEngineTimeoutException("Timeout waiting for query execution", e) :
-                new DatabaseEngineException("Could not process result set.", e));
+            throw handleException(e, "Could not process result set.");
         }
-    }
-
-    /**
-     * Indicates if a given exception is a timeout. Logic for this may be driver-specific, so
-     * drivers that support query timeouts may have to override this method.
-     *
-     * @param exception  The exception to check.
-     * @return {@code true} if the exception is a timeout, {@code false} otherwise.
-     */
-    protected boolean isTimeoutException(final Exception exception) {
-        return (exception instanceof SQLTimeoutException);
     }
 
     /**
@@ -177,8 +165,7 @@ public abstract class ResultIterator implements AutoCloseable {
 
             return temp;
         } catch (final Exception e) {
-            close();
-            throw new DatabaseEngineException("Could not fetch data.", e);
+            throw handleException(e, "Could not fetch data.");
         }
     }
 
@@ -219,8 +206,7 @@ public abstract class ResultIterator implements AutoCloseable {
             }
             return temp;
         } catch (final Exception e) {
-            close();
-            throw new DatabaseEngineException("Could not fetch data.", e);
+            throw handleException(e, "Could not fetch data.");
         }
     }
 
@@ -301,4 +287,45 @@ public abstract class ResultIterator implements AutoCloseable {
      * @return A specific result column given the implementation.
      */
     public abstract ResultColumn createResultColumn(final String name, final Object value);
+
+    /**
+     * Closes this iterator and handles the Exception, disambiguating it into a specific PDB Exception and throwing it.
+     * <p>
+     * If a specific type does not match the info in the provided Exception, throws a {@link DatabaseEngineException}.
+     *
+     * @param exception The exception to handle.
+     * @param message   The message to associate with the thrown exception.
+     * @return the {@link PreparedStatement}.
+     * @implNote This method uses the specific engine {@link QueryExceptionHandler} (obtained from
+     * {@link #getQueryExceptionHandler()}); even though this method throws exceptions, to keep Java type system happy
+     * it also declares that it returns {@link DatabaseEngineException}.
+     * @since 2.5.1
+     */
+    private DatabaseEngineException handleException(final Exception exception,
+                                                    final String message) throws DatabaseEngineException {
+        close();
+
+        if (exception instanceof SQLException) {
+            final SQLException sqlException = (SQLException) exception;
+            if (getQueryExceptionHandler().isTimeoutException(sqlException)) {
+                throw new DatabaseEngineTimeoutException(message + " [timeout]", sqlException);
+            }
+
+            if (getQueryExceptionHandler().isRetryableException(sqlException)) {
+                throw new DatabaseEngineRetryableException(message + " [retryable]", sqlException);
+            }
+
+        }
+        throw new DatabaseEngineException(message, exception);
+    }
+
+    /**
+     * Gets the instance of {@link QueryExceptionHandler} to be used in disambiguating SQL exceptions.
+     *
+     * @return the {@link QueryExceptionHandler}.
+     * @since 2.5.1
+     */
+    protected QueryExceptionHandler getQueryExceptionHandler() {
+        return DEFAULT_QUERY_EXCEPTION_HANDLER;
+    }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/handler/QueryExceptionHandler.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/handler/QueryExceptionHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.handler;
+
+import com.feedzai.commons.sql.abstraction.util.Constants;
+
+import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
+
+/**
+ * A handler that can be used to disambiguate the meaning of an {@link SQLException} thrown when executing a JDBC
+ * method.
+ *
+ * The methods in this class can be used for example to tell whether an exception is retryable, or more in particular
+ * if it is a timeout (which can also be considered retryable).
+ *
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ * @since 2.5.1
+ */
+public class QueryExceptionHandler {
+
+    /**
+     * Indicates if a given exception is a timeout. Logic for this may be driver-specific, so
+     * drivers that support query timeouts may have to override this method.
+     *
+     * A timeout exception can also be considered retryable.
+     *
+     * @param exception  The exception to check.
+     * @return {@code true} if the exception is a timeout, {@code false} otherwise.
+     */
+    public boolean isTimeoutException(final SQLException exception) {
+        return exception instanceof SQLTimeoutException;
+    }
+
+    /**
+     * Checks if an Exception occurred due to serialization failures in concurrent transactions and may be retried on
+     * the client-side.
+     *
+     * @param exception  The exception to check.
+     * @return {@code true} if the exception is retryable, {@code false} otherwise.
+     */
+    public boolean isRetryableException(final SQLException exception) {
+        return Constants.SQL_STATE_TRANSACTION_FAILURE.equals(exception.getSQLState());
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -686,7 +686,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                                           int lastBindPosition) throws Exception {
         ps.execute();
 
-        if (me.getAutoIncColumn() != null) {
+        if (me.getAutoIncColumn() == null) {
             return 0;
         }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -680,75 +680,62 @@ public class DB2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    public synchronized Long persist(String name, EntityEntry entry, boolean useAutoInc) throws DatabaseEngineException {
-        try {
-            getConnection();
+    protected synchronized long doPersist(final PreparedStatement ps,
+                                          final MappedEntity me,
+                                          final boolean useAutoInc,
+                                          int lastBindPosition) throws Exception {
+        ps.execute();
 
-            final MappedEntity me = entities.get(name);
+        if (me.getAutoIncColumn() != null) {
+            return 0;
+        }
 
-            if (me == null) {
-                throw new DatabaseEngineException(String.format("Unknown entity '%s'", name));
+        // the entity has autoinc columns: retrieve the sequence number or adjust it
+
+        final String name = me.getEntity().getName();
+        final String quotizedSeqName = quotize(
+                md5(format("%s_%s_SEQ", name, me.getAutoIncColumn()), properties.getMaxIdentifierSize())
+        );
+
+        long ret = 0;
+
+        if (useAutoInc) {
+            final List<Map<String, ResultColumn>> q = query(format("SELECT PREVIOUS VALUE FOR %s FROM sysibm.sysdummy1", quotizedSeqName));
+            if (!q.isEmpty()) {
+                for (final ResultColumn rc : q.get(0).values()) {
+                    return rc.toLong();
+                }
             }
 
-            final PreparedStatement ps;
-            if (useAutoInc) {
-                ps = me.getInsertReturning();
-            } else {
-                ps = me.getInsertWithAutoInc();
-            }
-            entityToPreparedStatement(me.getEntity(), ps, entry, useAutoInc);
+        } else {
+            final String sql = "select (select max(\"" + me.getAutoIncColumn() + "\") from \"" + name + "\") , " + quotizedSeqName + ".NEXTVAL FROM sysibm.sysdummy1";
+            final List<Map<String, ResultColumn>> q = query(sql);
 
-            ps.execute();
+            if (!q.isEmpty()) {
+                final Iterator<ResultColumn> it = q.get(0).values().iterator();
+                long max = Optional.ofNullable(it.next().toLong()).orElse(-1L);
+                long seqCurVal = Optional.ofNullable(it.next().toLong()).orElse(-1L);
 
-            long ret = 0;
-
-            // if the entity has autoinc columns then retrieve the sequence number or adjust it
-            if (me.getAutoIncColumn() != null) {
-                final String sequenceName = md5(format("%s_%s_SEQ", name, me.getAutoIncColumn()), properties.getMaxIdentifierSize());
-                if (useAutoInc) {
-
-                    final List<Map<String, ResultColumn>> q = query(String.format("SELECT PREVIOUS VALUE FOR \"%s\" FROM sysibm.sysdummy1", sequenceName));
-                    if (!q.isEmpty()) {
-                        for (ResultColumn rc : q.get(0).values()) {
-                            ret = rc.toLong();
-                            break;
-                        }
-                    }
-
-                } else {
-                    final String sql = "select (select max(\"" + me.getAutoIncColumn() + "\") from \"" + name + "\") , \"" + sequenceName + "\".NEXTVAL FROM sysibm.sysdummy1";
-                    final List<Map<String, ResultColumn>> q = query(sql);
-
-                    if (!q.isEmpty()) {
-                        final Iterator<ResultColumn> it = q.get(0).values().iterator();
-                        long max = Optional.ofNullable(it.next().toLong()).orElse(-1L);
-                        long seqCurVal = Optional.ofNullable(it.next().toLong()).orElse(-1L);
-
-                        if (seqCurVal != max) {
-                            //table and sequence are not synchronized, readjust sequence max+1 (next val will return max+1)
-                            executeUpdateSilently("ALTER SEQUENCE \"" + sequenceName + "\" RESTART WITH " + (ret + 1));
-                        }
-                    }
-
-
-                    final List<Map<String, ResultColumn>> keys = query(sql);
-                    if (!keys.isEmpty()) {
-                        final Iterator<ResultColumn> it = keys.get(0).values().iterator();
-                        ret = it.next().toLong();
-                        long seqCurVal = it.next().toLong();
-                        if (seqCurVal != ret) {
-                            // table and sequence are not synchronized, readjust sequence max+1 (next val will return max+1)
-                            executeUpdateSilently("ALTER SEQUENCE \"" + sequenceName + "\" RESTART WITH " + (ret + 1));
-                        }
-                    }
+                if (seqCurVal != max) {
+                    //table and sequence are not synchronized, readjust sequence max+1 (next val will return max+1)
+                    executeUpdateSilently("ALTER SEQUENCE " + quotizedSeqName + " RESTART WITH " + (ret + 1));
                 }
             }
 
 
-            return ret == 0 ? null : ret;
-        } catch (final Exception ex) {
-            throw new DatabaseEngineException("Something went wrong persisting the entity", ex);
+            final List<Map<String, ResultColumn>> keys = query(sql);
+            if (!keys.isEmpty()) {
+                final Iterator<ResultColumn> it = keys.get(0).values().iterator();
+                ret = it.next().toLong();
+                long seqCurVal = it.next().toLong();
+                if (seqCurVal != ret) {
+                    // table and sequence are not synchronized, readjust sequence max+1 (next val will return max+1)
+                    executeUpdateSilently("ALTER SEQUENCE " + quotizedSeqName + " RESTART WITH " + (ret + 1));
+                }
+            }
         }
+
+        return ret;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/H2QueryExceptionHandler.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/H2QueryExceptionHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl.h2;
+
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
+
+import java.sql.SQLException;
+
+/**
+ * A specific implementation of {@link QueryExceptionHandler} for H2 engine.
+ *
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ * @since 2.5.1
+ */
+public class H2QueryExceptionHandler extends QueryExceptionHandler {
+
+    /**
+     * H2 uses this error code when another connection locked an object longer than the lock timeout set for this
+     * connection, or when a deadlock occurred.
+     * This may be caused by serialization failure due to a deadlock detected in the DB server in concurrent; this code
+     * indicates that the client app may retry the transaction.
+     */
+    private static final int LOCK_TIMEOUT_ERROR_CODE = 50200;
+
+    @Override
+    public boolean isRetryableException(final SQLException exception) {
+        return exception.getErrorCode() == LOCK_TIMEOUT_ERROR_CODE || super.isRetryableException(exception);
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/mysql/MySqlQueryExceptionHandler.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/mysql/MySqlQueryExceptionHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl.mysql;
+
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
+import com.mysql.jdbc.exceptions.MySQLTimeoutException;
+
+import java.sql.SQLException;
+
+/**
+ * A specific implementation of {@link QueryExceptionHandler} for MySQL engine.
+ *
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ * @since 2.5.1
+ */
+public class MySqlQueryExceptionHandler extends QueryExceptionHandler {
+
+    @Override
+    public boolean isTimeoutException(final SQLException exception) {
+        return exception instanceof MySQLTimeoutException || super.isTimeoutException(exception);
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleQueryExceptionHandler.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleQueryExceptionHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl.oracle;
+
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
+import com.google.common.collect.ImmutableSet;
+
+import java.sql.SQLException;
+import java.util.Set;
+
+/**
+ * A specific implementation of {@link QueryExceptionHandler} for Oracle engine.
+ *
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ * @since 2.5.1
+ */
+public class OracleQueryExceptionHandler extends QueryExceptionHandler {
+
+    /**
+     * Oracle uses these error codes when deadlocks occur.
+     *
+     * Both may be caused by serialization failure due to a deadlock detected in the DB server in concurrent; these
+     * codes indicate that the client app may retry the transaction.
+     *
+     * - ORA-00060: deadlock detected while waiting
+     * - ORA-08177: can't serialize access for this transaction
+     */
+    private static final Set<Integer> DEADLOCK_ERROR_CODES = ImmutableSet.of(60, 8177);
+
+    @Override
+    public boolean isRetryableException(final SQLException exception) {
+        return DEADLOCK_ERROR_CODES.contains(exception.getErrorCode()) || super.isRetryableException(exception);
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/postgresql/PostgresSqlQueryExceptionHandler.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/postgresql/PostgresSqlQueryExceptionHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl.postgresql;
+
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
+
+import java.sql.SQLException;
+
+/**
+ * A specific implementation of {@link QueryExceptionHandler} for PostgreSQL engine.
+ *
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ * @since 2.5.1
+ */
+public class PostgresSqlQueryExceptionHandler extends QueryExceptionHandler {
+    /**
+     * The SQL State code PostgreSQL uses for "transaction failure due to deadlocks".
+     * This may be caused by serialization failure due to a deadlock detected in the DB server in concurrent; this code
+     * indicates that the client app may retry the transaction.
+     */
+    private static final String DEADLOCK_SQL_STATE = "40P01";
+
+    /**
+     * The SQL State that indicates a timeout occurred.
+     */
+    private static final String TIMEOUT_SQL_STATE = "57014";
+
+    @Override
+    public boolean isTimeoutException(final SQLException exception) {
+        return TIMEOUT_SQL_STATE.equals(exception.getSQLState()) || super.isTimeoutException(exception);
+    }
+
+    @Override
+    public boolean isRetryableException(final SQLException exception) {
+        return DEADLOCK_SQL_STATE.equals(exception.getSQLState()) || super.isRetryableException(exception);
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/exceptions/DatabaseEngineRetryableException.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/exceptions/DatabaseEngineRetryableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Feedzai
+ * Copyright 2019 Feedzai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,30 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.feedzai.commons.sql.abstraction.engine;
+package com.feedzai.commons.sql.abstraction.exceptions;
+
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 
 /**
- * To be thrown when faults happen during regular database operations.
+ * To be thrown when faults happen during regular database operations and can be retried with a chance of success.
  *
- * @author Rui Vilao (rui.vilao@feedzai.com)
- * @since 2.0.0
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ * @since 2.5.1
  */
-public class DatabaseEngineRuntimeException extends RuntimeException {
-
-    /**
-     * Property that indicates if Exception is retryable or not.
-     * This property must be defined 'true' if the Transaction Retry must be done on client side.
-     *
-     * @see <a href=https://www.cockroachlabs.com/docs/stable/transactions.html#client-side-intervention>CockroachDB - transactions</a>
-     */
-    private boolean isRetryable = false;
+public class DatabaseEngineRetryableException extends DatabaseEngineException {
 
     /**
      * Constructs a new runtime exception with {@code null} as its
      * detail message.  The cause is not initialized, and may subsequently be
      * initialized by a call to {@link #initCause}.
      */
-    public DatabaseEngineRuntimeException() {
+    public DatabaseEngineRetryableException() {
         super();
     }
 
@@ -48,7 +42,7 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      * @param message the detail message. The detail message is saved for
      *                later retrieval by the {@link #getMessage()} method.
      */
-    public DatabaseEngineRuntimeException(final String message) {
+    public DatabaseEngineRetryableException(final String message) {
         super(message);
     }
 
@@ -65,7 +59,7 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      *                permitted, and indicates that the cause is nonexistent or
      *                unknown.)
      */
-    public DatabaseEngineRuntimeException(final String message, final Throwable cause) {
+    public DatabaseEngineRetryableException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
@@ -81,7 +75,7 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      *              permitted, and indicates that the cause is nonexistent or
      *              unknown.)
      */
-    public DatabaseEngineRuntimeException(final Throwable cause) {
+    public DatabaseEngineRetryableException(final Throwable cause) {
         super(cause);
     }
 
@@ -98,46 +92,10 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      * @param writableStackTrace whether or not the stack trace should
      *                           be writable
      */
-    protected DatabaseEngineRuntimeException(final String message,
-                                             final Throwable cause,
-                                             final boolean enableSuppression,
-                                             final boolean writableStackTrace) {
+    protected DatabaseEngineRetryableException(final String message,
+                                               final Throwable cause,
+                                               final boolean enableSuppression,
+                                               final boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
-    }
-
-    /**
-     * Constructs a new runtime exception with the specified detail message,
-     * cause and a specified isRetryable state.  <p>Note that the detail message associated with
-     * {@code cause} is <i>not</i> automatically incorporated in
-     * this runtime exception's detail message.
-     *
-     * @param message     The detail message (which is saved for later retrieval
-     *                    by the {@link #getMessage()} method).
-     * @param cause       The cause (which is saved for later retrieval by the
-     *                    {@link #getCause()} method).  (A <tt>null</tt> value is
-     *                    permitted, and indicates that the cause is nonexistent or
-     *                    unknown.)
-     * @param isRetryable The property must be true if generated Exception must be retried.
-     * @deprecated use {@link com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableRuntimeException}
-     * instead.
-     */
-    @Deprecated
-    public DatabaseEngineRuntimeException(final String message, final Throwable cause, final boolean isRetryable) {
-        super(message, cause);
-        this.isRetryable = isRetryable;
-    }
-
-    /**
-     * Gets whether the error that caused this exception is retryable or not.
-     *
-     * In particular, if a transaction commit resulted in this exception, the client can attempt to retry it.
-     *
-     * @return whether this exception is retryable or not.
-     * @deprecated use {@link com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableRuntimeException}
-     * instead.
-     */
-    @Deprecated
-    public boolean isRetryable() {
-        return isRetryable;
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/exceptions/DatabaseEngineRetryableRuntimeException.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/exceptions/DatabaseEngineRetryableRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Feedzai
+ * Copyright 2019 Feedzai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,30 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.feedzai.commons.sql.abstraction.engine;
+package com.feedzai.commons.sql.abstraction.exceptions;
+
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 
 /**
- * To be thrown when faults happen during regular database operations.
+ * To be thrown when faults happen during regular database operations and can be retried with a chance of success.
  *
- * @author Rui Vilao (rui.vilao@feedzai.com)
- * @since 2.0.0
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ * @since 2.5.1
  */
-public class DatabaseEngineRuntimeException extends RuntimeException {
-
-    /**
-     * Property that indicates if Exception is retryable or not.
-     * This property must be defined 'true' if the Transaction Retry must be done on client side.
-     *
-     * @see <a href=https://www.cockroachlabs.com/docs/stable/transactions.html#client-side-intervention>CockroachDB - transactions</a>
-     */
-    private boolean isRetryable = false;
+public class DatabaseEngineRetryableRuntimeException extends DatabaseEngineRuntimeException {
 
     /**
      * Constructs a new runtime exception with {@code null} as its
      * detail message.  The cause is not initialized, and may subsequently be
      * initialized by a call to {@link #initCause}.
      */
-    public DatabaseEngineRuntimeException() {
+    public DatabaseEngineRetryableRuntimeException() {
         super();
     }
 
@@ -48,7 +42,7 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      * @param message the detail message. The detail message is saved for
      *                later retrieval by the {@link #getMessage()} method.
      */
-    public DatabaseEngineRuntimeException(final String message) {
+    public DatabaseEngineRetryableRuntimeException(final String message) {
         super(message);
     }
 
@@ -65,7 +59,7 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      *                permitted, and indicates that the cause is nonexistent or
      *                unknown.)
      */
-    public DatabaseEngineRuntimeException(final String message, final Throwable cause) {
+    public DatabaseEngineRetryableRuntimeException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
@@ -81,7 +75,7 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      *              permitted, and indicates that the cause is nonexistent or
      *              unknown.)
      */
-    public DatabaseEngineRuntimeException(final Throwable cause) {
+    public DatabaseEngineRetryableRuntimeException(final Throwable cause) {
         super(cause);
     }
 
@@ -98,46 +92,19 @@ public class DatabaseEngineRuntimeException extends RuntimeException {
      * @param writableStackTrace whether or not the stack trace should
      *                           be writable
      */
-    protected DatabaseEngineRuntimeException(final String message,
-                                             final Throwable cause,
-                                             final boolean enableSuppression,
-                                             final boolean writableStackTrace) {
+    protected DatabaseEngineRetryableRuntimeException(final String message,
+                                                      final Throwable cause,
+                                                      final boolean enableSuppression,
+                                                      final boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
 
     /**
-     * Constructs a new runtime exception with the specified detail message,
-     * cause and a specified isRetryable state.  <p>Note that the detail message associated with
-     * {@code cause} is <i>not</i> automatically incorporated in
-     * this runtime exception's detail message.
-     *
-     * @param message     The detail message (which is saved for later retrieval
-     *                    by the {@link #getMessage()} method).
-     * @param cause       The cause (which is saved for later retrieval by the
-     *                    {@link #getCause()} method).  (A <tt>null</tt> value is
-     *                    permitted, and indicates that the cause is nonexistent or
-     *                    unknown.)
-     * @param isRetryable The property must be true if generated Exception must be retried.
-     * @deprecated use {@link com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableRuntimeException}
-     * instead.
+     * @deprecated only implemented here to avoid breaking changes with the availability of this method in the super class.
      */
-    @Deprecated
-    public DatabaseEngineRuntimeException(final String message, final Throwable cause, final boolean isRetryable) {
-        super(message, cause);
-        this.isRetryable = isRetryable;
-    }
-
-    /**
-     * Gets whether the error that caused this exception is retryable or not.
-     *
-     * In particular, if a transaction commit resulted in this exception, the client can attempt to retry it.
-     *
-     * @return whether this exception is retryable or not.
-     * @deprecated use {@link com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableRuntimeException}
-     * instead.
-     */
+    @Override
     @Deprecated
     public boolean isRetryable() {
-        return isRetryable;
+        return true;
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -15,8 +15,13 @@
  */
 package com.feedzai.commons.sql.abstraction.util;
 
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineTimeoutException;
 import com.feedzai.commons.sql.abstraction.engine.configuration.IsolationLevel;
+import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableException;
+import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableRuntimeException;
+import com.google.common.collect.ImmutableSet;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -113,4 +118,15 @@ public final class Constants {
      * this code indicates that the client app may retry the transaction.
      */
     public static final String SQL_STATE_TRANSACTION_FAILURE = "40001";
+
+    /**
+     * A set of PDB Exceptions that can be considered retryable (when these are thrown, it is possible that a client
+     * application will be successfull if it performs again the same actions that resulted in the exception).
+     * @since 2.5.1
+     */
+    public static final Set<Class<?extends Throwable>> RETRYABLE_EXCEPTIONS = ImmutableSet.of(
+            DatabaseEngineRetryableException.class,
+            DatabaseEngineRetryableRuntimeException.class,
+            DatabaseEngineTimeoutException.class
+    );
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCreateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCreateTest.java
@@ -221,8 +221,11 @@ public class EngineCreateTest {
                     .build();
 
             expected.expect(DatabaseEngineException.class);
-            expected.expectMessage(AnyOf.anyOf(IsEqual.equalTo("Something went wrong persisting the entity"),
-                    IsEqual.equalTo("Something went wrong handling statement")));
+            expected.expectMessage(AnyOf.anyOf(
+                    IsEqual.equalTo("Something went wrong persisting the entity"),
+                    IsEqual.equalTo("Something went wrong handling statement"),
+                    IsEqual.equalTo("Error while mapping variables to database")
+            ));
             engine.loadEntity(entity);
 
             // some of the databases will throw the error on loadEntity, the others only on persist

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -3005,7 +3005,7 @@ public class EngineGeneralTest {
             fail("Should throw an exception if trying to persist an entity before calling addEntity/updateEntity a first time");
         } catch (final DatabaseEngineException e) {
             assertTrue("Should fail because the entity is still unknown to this DatabaseEngine instance",
-                e.getCause().getMessage().contains("Unknown entity"));
+                e.getMessage().contains("Unknown entity"));
         }
 
         schemaNoneEngine.updateEntity(entity);

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineIsolationTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineIsolationTest.java
@@ -18,44 +18,59 @@ package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.sql.Connection;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.StampedLock;
 
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.INT;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.all;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.column;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.count;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.dbEntity;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.entry;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.eq;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.k;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.select;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.table;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.update;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ISOLATION_LEVEL;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
+import static com.feedzai.commons.sql.abstraction.util.Constants.RETRYABLE_EXCEPTIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -74,6 +89,16 @@ public class EngineIsolationTest {
     @Parameterized.Parameter
     public DatabaseConfiguration config;
 
+    /**
+     * The {@link DatabaseEngineDriver} corresponding to the current {@link #config test config}.
+     */
+    private DatabaseEngineDriver engineDriver;
+
+    /**
+     * A list of actions to perform when a test finishes.
+     */
+    private List<ThrowableAssert.ThrowingCallable> closeActions = new ArrayList<>();
+
     @Before
     public void init() {
         this.properties = new Properties() {
@@ -82,9 +107,17 @@ public class EngineIsolationTest {
                 setProperty(USERNAME, config.username);
                 setProperty(PASSWORD, config.password);
                 setProperty(ENGINE, config.engine);
-                setProperty(SCHEMA_POLICY, "drop-create");
+                setProperty(SCHEMA_POLICY, "create");
             }
         };
+
+        final PdbProperties pdbProps = new PdbProperties(this.properties, true);
+        this.engineDriver = DatabaseEngineDriver.fromEngine(pdbProps.getEngine());
+    }
+
+    @After
+    public void cleanup() {
+        this.closeActions.forEach(ThrowableAssert::catchThrowable);
     }
 
     @Test
@@ -117,7 +150,7 @@ public class EngineIsolationTest {
      * <p>
      * Besides testing current DB engines with default isolation level, this test will allow verification of new DB
      * engines, and with small modifications, different isolation levels.
-     *
+     * <p>
      * The following table describes the sequence of events of both transactions used in the test. A deadlock may occur
      * at T4 if the "SELECT *" query in Transaction 2 gets blocked by the previous persist operation in Transaction 1:
      * Transaction 2 gets blocked until Transaction 1 commits or rolls back, but Transaction 1 can only advance when it
@@ -135,6 +168,7 @@ public class EngineIsolationTest {
      *     <tr><td>T8</td><td>commit</td></tr>
      *     <tr><td>T9</td><td>release Java lock</td></tr>
      * </table>
+     *
      * @throws Exception if something goes wrong in the test.
      * @since 2.4.7
      */
@@ -142,7 +176,9 @@ public class EngineIsolationTest {
     public void deadlockTransactionTest() throws Exception {
         final StampedLock lock = new StampedLock();
         final Phaser phaser = new Phaser(1);
+
         final ExecutorService executorService = Executors.newFixedThreadPool(2);
+        this.closeActions.add(executorService::shutdownNow);
 
         final DbEntity entity = dbEntity().name("TEST")
                 .addColumn("COL1", INT, true)
@@ -151,9 +187,12 @@ public class EngineIsolationTest {
                 .build();
 
         final DatabaseEngine engine = DatabaseFactory.getConnection(properties);
+        engine.dropEntity(entity);
         engine.updateEntity(entity);
-        final DatabaseEngine engine2 = DatabaseFactory.getConnection(properties);
-        engine2.updateEntity(entity);
+        final DatabaseEngine engine2 = engine.duplicate(null, true);
+
+        this.closeActions.add(engine::close);
+        this.closeActions.add(engine2::close);
 
         // persist an initial entry
         engine.persist("TEST", entry().set("COL2", 1).build());
@@ -258,10 +297,6 @@ public class EngineIsolationTest {
         assertThat(countResult)
                 .as("The SELECT query should return  correct result (2 for \"real\" SERIALIZABLE isolation level, 1 otherwise)")
                 .hasValue(isRealSerializableLevel(engine) ? 2 : 1);
-
-        executorService.shutdownNow();
-        engine.close();
-        engine2.close();
     }
 
     /**
@@ -274,12 +309,361 @@ public class EngineIsolationTest {
      * @since 2.4.7
      */
     private boolean isRealSerializableLevel(final DatabaseEngine engine) throws Exception {
-        final PdbProperties pdbProps = new PdbProperties(this.properties, true);
-        final DatabaseEngineDriver engineDriver = DatabaseEngineDriver.fromEngine(pdbProps.getEngine());
-
         if (engine.getConnection().getTransactionIsolation() == Connection.TRANSACTION_SERIALIZABLE) {
             return engineDriver == DatabaseEngineDriver.SQLSERVER || engineDriver == DatabaseEngineDriver.COCKROACHDB;
         }
         return false;
+    }
+
+    /**
+     * This test causes deadlocks using concurrent transactions and verifies that those deadlocks are detected by the
+     * database, PDB correctly signals such errors as retryable, and finally that when the failed transactions are
+     * retried they are successful.
+     * <p>
+     * The actions to perform can be selects, updates or persists (each verification uses a pair of actions in which at
+     * least one must perform a write on the DB).
+     * Each transaction is ran on its own DB engine.
+     * Additionally, the test can run with first transaction (transaction 0) finishing either before or after the second
+     * action on the second transaction runs.
+     * <p>
+     * The following table describes the sequence of events of both transactions used in the test:
+     * <table>
+     *     <tr><th>time</th><th>transaction 0</th><th>transaction 1</th></tr>
+     *     <tr><td>T0</td><td>BEGIN</td><td>BEGIN</td></tr>
+     *     <tr><td>T1</td><td>action1 on TEST0</td><td>action1 on TEST1</td></tr>
+     *     <tr><td>T2</td><td>action2 on TEST1</td></tr>
+     *     <tr>** if transaction 0 waits for transaction 1</tr>
+     *     <tr><td>T3</td><td/><td>action2 on TEST0</td></tr>
+     *     <tr><td>T4</td><td>COMMIT</td></tr>
+     *     <tr><td>T5</td><td></td><td>COMMIT (fails?)</td></tr>
+     *     <tr>** if transaction 0 commits before action2 on transaction 1</tr>
+     *     <tr><td>T3</td><td>COMMIT</td></tr>
+     *     <tr><td>T4</td><td/><td>action2 on TEST0 (fails?)</td></tr>
+     * </table>
+     * The COMMIT/action2 may fail or not at the indicated timestamps, depending on the database.
+     * Some database may block on some of the actions until the other interfering transaction either finishes (commit)
+     * or fails (e.g. a deadlock is detected by the database) - hence the use of asynchronous actions.
+     * <p>
+     * Finally, the test will check that the failed actions return an exception that is "retryable".
+     * After that, the failed transaction is rolled back and ran again from the beginning.
+     * In the end, the test checks if the tables have the expected data.
+     *
+     * @throws Exception if a problem occurs in the test.
+     * @since 2.5.1
+     */
+    @Test
+    public void deadlockRecoveryTest() throws Exception {
+        final DbEngineAction selectAction = (engine, tableIdx) -> engine.query(select(all()).from(table("TEST" + tableIdx)));
+
+        final DbEngineAction updateAction = (engine, tableIdx) -> engine.executeUpdate(
+                update(table("TEST" + tableIdx))
+                        .set(eq(column("COL2"), k(tableIdx + 1)))
+                        .where(eq(column("COL1"), k(1)))
+        );
+
+        final DbEngineAction persistAction = (engine, tableIdx) -> engine.persist(
+                "TEST" + tableIdx, entry().set("COL2", tableIdx + 1).build()
+        );
+
+        Integer[][] expected = new Integer[][]{{1, 1}, {2, 2}};
+        runDeadlockExceptionTest(false, updateAction, persistAction, expected);
+        runDeadlockExceptionTest(true, updateAction, persistAction, expected);
+
+        expected = new Integer[][]{{0, 1}, {0, 2}};
+
+        runDeadlockExceptionTest(false, selectAction, persistAction, expected);
+        runDeadlockExceptionTest(true, selectAction, persistAction, expected);
+
+        runDeadlockExceptionTest(false, persistAction, selectAction, expected);
+        runDeadlockExceptionTest(true, persistAction, selectAction, expected);
+    }
+
+    /**
+     * This method runs the actions for {@link #deadlockRecoveryTest()}.
+     *
+     * @param waitAction2FromEngine2 Whether engine/transaction 0 waits for action 2 to execute on engine/transaction 1
+     *                               before proceeding to commit.
+     * @param action1                The first action to run after beginning transaction.
+     * @param action2                The second action to run after beginning transaction.
+     * @param expected               The expected values (first dimension corresponds to the table index, second
+     *                               dimension contains the several expected values for that particular table).
+     * @throws Exception if a problem occurs in the test.
+     * @since 2.5.1
+     */
+    private void runDeadlockExceptionTest(final boolean waitAction2FromEngine2,
+                                          final DbEngineAction action1,
+                                          final DbEngineAction action2,
+                                          final Integer[][] expected) throws Exception {
+        final DatabaseEngine[] engines = prepareEngineForDeadlockRecoveryTest();
+        final ExecutorService executorService = Executors.newCachedThreadPool();
+        this.closeActions.add(executorService::shutdownNow);
+
+        for (int i = 0; i < engines.length; i++) {
+            engines[i].beginTransaction();
+            action1.runFor(engines[i], i);
+        }
+
+        final CompletableFuture<Boolean> success0Future = CompletableFuture.supplyAsync(
+                () -> runAction(engines[0], () -> action2.runFor(engines[0], 1)),
+                executorService
+        );
+
+        final AtomicReference<CompletableFuture<Boolean>> success1FutureRef = new AtomicReference<>();
+        if (waitAction2FromEngine2) {
+            success1FutureRef.set(CompletableFuture.supplyAsync(
+                    () -> runAction(engines[1], () -> action2.runFor(engines[1], 0)),
+                    executorService
+            ));
+
+            catchThrowable(() -> success1FutureRef.get().get(5, TimeUnit.SECONDS));
+        }
+
+        final CompletableFuture<Boolean> success0Future1 = success0Future.thenApplyAsync(
+                success0 -> success0 && runAction(engines[0], engines[0]::commit),
+                executorService
+        );
+
+        catchThrowable(() -> success0Future1.get(5, TimeUnit.SECONDS));
+
+        boolean success1;
+        if (waitAction2FromEngine2) {
+            success1 = success1FutureRef.get().get(5, TimeUnit.SECONDS);
+        } else {
+            success1 = runAction(engines[1], () -> action2.runFor(engines[1], 0));
+        }
+
+        if (success1) {
+            success1 = runAction(engines[1], engines[1]::commit);
+        }
+
+        if (!success1) {
+            repeatTransaction(engines, 1, action1, action2);
+        } else if (!Boolean.TRUE.equals(success0Future1.get(5, TimeUnit.SECONDS))) {
+            repeatTransaction(engines, 0, action1, action2);
+        }
+
+        assertEntityValues(engines[0], expected);
+
+        for (final DatabaseEngine engine : engines) {
+            catchThrowable(engine::close);
+        }
+    }
+
+    /**
+     * This test causes deadlocks using concurrent transactions and verifies that those deadlocks are detected by the
+     * database, PDB correctly signals such errors as retryable, and finally that when the failed transactions are
+     * retried they are successful.
+     *
+     * This test is similar to {@link #deadlockRecoveryTest()}, but both actions used in this test perform writes (they
+     * are both UPDATEs) and always act on the same row (identified by COL1=1).
+     * Each transaction is ran on its own DB engine.
+     * By using only writes and directly interfering on row level, this test may cause slightly different outcomes
+     * depending on the database (on PostgreSQL this results in a 40P01 error instead of 40001; on Oracle it results in
+     * ORA-08177 instead of ORA-00060).
+     * <p>
+     * The following table describes the sequence of events of both transactions used in the test:
+     * <table>
+     *     <tr><th>time</th><th>transaction 0</th><th>transaction 1</th></tr>
+     *     <tr><td>T0</td><td>BEGIN</td><td>BEGIN</td></tr>
+     *     <tr><td>T1</td><td>update on TEST0</td><td>update on TEST1</td></tr>
+     *     <tr><td>T2</td><td>update on TEST1</td></tr>
+     *     <tr><td>T3</td><td>COMMIT</td></tr>
+     *     <tr><td>T4</td><td/><td>update on TEST0</td></tr>
+     *     <tr><td>T5</td><td></td><td>COMMIT</td></tr>
+     * </table>
+     * The actions on T2 to T5 are ran asynchronously and may occur in a different order than what's shown in the table.
+     * Different databases may block and/or fail at different points.
+     * Like in {@link #deadlockRecoveryTest()}, the test will check that the failed actions return an exception that
+     * is "retryable" and will rollback and retry those.
+     * In the end, the test checks if the tables have the expected data.
+     *
+     * @throws Exception if a problem occurs in the test.
+     * @since 2.5.1
+     */
+    @Test
+    public void directDeadlockRecoveryTest() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final DbEngineAction updateAction = (engine, tableIdx) -> engine.executeUpdate(
+                update(table("TEST" + tableIdx))
+                        .set(eq(column("COL2"), k(counter.incrementAndGet())))
+                        .where(eq(column("COL1"), k(1)))
+        );
+
+        final DatabaseEngine[] engines = prepareEngineForDeadlockRecoveryTest();
+        final ExecutorService executorService = Executors.newCachedThreadPool();
+        this.closeActions.add(executorService::shutdownNow);
+
+        final CompletableFuture<Boolean>[] successFutures = new CompletableFuture[2];
+        for (int i = 0; i < engines.length; i++) {
+            engines[i].beginTransaction();
+            final int idx = i;
+            successFutures[i] = CompletableFuture.supplyAsync(
+                    () -> runAction(engines[idx], () -> updateAction.runFor(engines[idx], idx)),
+                    executorService
+            );
+        }
+
+        successFutures[0] = successFutures[0]
+                .thenApplyAsync(
+                        success0 -> success0 && runAction(engines[0], () -> updateAction.runFor(engines[0], 1)),
+                        executorService
+                )
+                .thenApplyAsync(
+                        success0 -> success0 && runAction(engines[0], engines[0]::commit),
+                        executorService
+                );
+
+        catchThrowable(() -> successFutures[0].get(5, TimeUnit.SECONDS));
+
+        successFutures[1] = successFutures[1]
+                .thenApplyAsync(
+                        success0 -> success0 && runAction(engines[1], () -> updateAction.runFor(engines[1], 0)),
+                        executorService
+                )
+                .thenApplyAsync(
+                        success0 -> success0 && runAction(engines[1], engines[1]::commit),
+                        executorService
+                );
+
+        catchThrowable(() -> successFutures[0].get(5, TimeUnit.SECONDS));
+
+        // retry failed transactions
+        for (int i = 0; i < successFutures.length; i++) {
+            if (!successFutures[i].get(5, TimeUnit.SECONDS)) {
+                repeatTransaction(engines, i, updateAction, updateAction);
+            }
+        }
+
+        final Integer[][] expected = successFutures[0].get() ? new Integer[][]{{6}, {5}} : new Integer[][]{{5}, {6}};
+        assertEntityValues(engines[0], expected);
+    }
+
+    /**
+     * Prepares 2 {@link DatabaseEngine}s for deadlock recovery tests.
+     * <p>
+     * This method sets the session isolation level to SERIALIZABLE so that the expected deadlocks can occur and creates
+     * 2 tables (TEST0 and TEST1) with an initial entry persisted.
+     *
+     * @return an array of {@link DatabaseEngine}.
+     * @throws Exception if a problem occurs in the preparation.
+     * @since 2.5.1
+     */
+    protected DatabaseEngine[] prepareEngineForDeadlockRecoveryTest() throws Exception {
+        this.properties.setProperty(ISOLATION_LEVEL, "serializable");
+
+        final DbEntity.Builder entityBuilder = dbEntity()
+                .addColumn("COL1", INT, true)
+                .addColumn("COL2", INT)
+                .pkFields("COL1");
+
+        final DatabaseEngine[] engines = new DatabaseEngine[2];
+        engines[0] = DatabaseFactory.getConnection(properties);
+        final EntityEntry entry = entry().set("COL1", 1).set("COL2", 0).build();
+
+        for (int i = 0; i < 2; i++) {
+            final DbEntity entity0 = entityBuilder.name("TEST" + i).build();
+            engines[0].dropEntity(entity0);
+            engines[0].updateEntity(entity0);
+            engines[0].persist(entity0.getName(), entry);
+        }
+
+        engines[1] = engines[0].duplicate(null, true);
+
+        for (final DatabaseEngine engine : engines) {
+            this.closeActions.add(engine::close);
+
+            if (this.engineDriver.equals(DatabaseEngineDriver.MYSQL)) {
+                // MySQL is too slow detecting deadlocks by default (default is 50 seconds)
+                // for the purpose of the test, it can be reduced
+                engine.executeUpdate("SET SESSION innodb_lock_wait_timeout = 1");
+            }
+        }
+
+        return engines;
+    }
+
+    /**
+     * Runs an action on a database (for use in deadlock recovery tests).
+     * <p>
+     * If the action fails, this method asserts that the resulting exception is retryable, and if so confirms that the
+     * transaction is still active and rolls it back.
+     *
+     * @param engine The DB engine to use to run the action.
+     * @param action The action to perform.
+     * @return {@code true} if the action succeeded, {@code false} otherwise.
+     * @since 2.5.1
+     */
+    private boolean runAction(final DatabaseEngine engine, final ThrowableAssert.ThrowingCallable action) {
+        final Throwable throwable = catchThrowable(action);
+
+        if (throwable == null) {
+            return true;
+        }
+
+        assertThat(throwable)
+                .as("If a DB action fails due to deadlock, it should indicate it is retryable")
+                .isInstanceOfAny(RETRYABLE_EXCEPTIONS.toArray(new Class[0]));
+
+        assertTrue("A transaction failed due to deadlock should still be active and needs to be rolled back",
+                engine.isTransactionActive());
+        engine.rollback();
+
+        return false;
+    }
+
+    /**
+     * Repeats a transaction that failed due to deadlock in a deadlock recovery test.
+     *
+     * @param engines   The engines setup by {@link #prepareEngineForDeadlockRecoveryTest()}.
+     * @param engineIdx The index of the engine to be used to repeat the transaction.
+     * @param action1   The first action to run after beginning transaction.
+     * @param action2   The second action to run after beginning transaction.
+     * @throws Exception if a problem occurs in the test.
+     * @since 2.5.1
+     */
+    private void repeatTransaction(final DatabaseEngine[] engines,
+                                   final int engineIdx,
+                                   final DbEngineAction action1,
+                                   final DbEngineAction action2) throws Exception {
+        final DatabaseEngine engine = engines[engineIdx];
+
+        engine.beginTransaction();
+        action1.runFor(engine, engineIdx);
+        action2.runFor(engine, 1 - engineIdx);
+        engine.commit();
+    }
+
+    /**
+     * Performs an assertion on the values present in the tables setup by {@link #prepareEngineForDeadlockRecoveryTest()}.
+     *
+     * @param dbEngine The DB engine to use to get the values in the tables.
+     * @param expected The expected values (first dimension corresponds to the table index, second dimension contains
+     *                 the several expected values for that particular table).
+     * @throws DatabaseEngineException if a problem occurs running the query to get data for the assertion.
+     * @since 2.5.1
+     */
+    private static void assertEntityValues(final DatabaseEngine dbEngine,
+                                           final Integer[][] expected) throws DatabaseEngineException {
+        for (int i = 0; i < 1; i++) {
+            assertThat(dbEngine.query(select(column("COL2")).from(table("TEST" + i))))
+                    .as("COL2 in 'TEST%d' should have the expected value", i)
+                    .extracting(res -> res.get("COL2").toInt())
+                    .containsExactly(expected[i]);
+        }
+    }
+
+    /**
+     * Represents an action to be performed on the database that can throw any exception.
+     * This is meant to be used in the deadlock recovery tests, with the DB engines as setup by
+     * {@link #prepareEngineForDeadlockRecoveryTest()}.
+     *
+     * @since 2.5.1
+     */
+    @FunctionalInterface
+    private interface DbEngineAction {
+        /**
+         * Executes the action using the specified engine in the table referred to by the provided table index.
+         */
+        void runFor(DatabaseEngine engine, int tableIdx) throws Exception;
     }
 }


### PR DESCRIPTION
Summary:
A previous commit added a flag/method on DatabaseEngineRuntimeException
to indicate that the error that occurred was retryable.

However, deadlocks may occur not only on commits but also on any other
operation in a transaction, even in reads. In some cases a deadlocks
may even occur on queries not running in transactions.

This commit adds SQL exception handling to the other methods, so that
if the action is retryable, a corresponding "retryable" exception will
be thrown to indicate that.

Tests were added to verify that when deadlocks occur an appropriate
"retryable" exception is thrown and a rollback+retry solves the
problem.