### PR TITLE
Bump PostgreSQL driver to 42.2.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.2.6</version>
+                <version>42.2.14</version>
             </dependency>
             <dependency>
                 <groupId>com.oracle.ojdbc</groupId>


### PR DESCRIPTION
There is a vulnerability on postgresql driver before 42.2.13 (CVE-2020-13692)

This commit aims to stop using vulnerable version and proactively bump 
postgresql driver to the latest released version.