### PR TITLE
Fix javadoc plugin configuration and remove default implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,19 +327,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>
@@ -355,7 +342,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <additionalOptions>
+                        <additionalOption>-Xdoclint:none</additionalOption>
+                    </additionalOptions>
                 </configuration>
                 <executions>
                     <execution>
@@ -363,6 +352,20 @@
                         <phase>deploy</phase>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>sign</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -137,12 +137,10 @@ public interface DatabaseEngine extends AutoCloseable {
      *
      * @param view The view name.
      * @throws DatabaseEngineException If something goes wrong while dropping the view.
-     * @implNote This method has a default to not create a breaking change.
-     * @since 2.5.3
+     *
+     * @since 2.6.0
      */
-    default void dropView(final String view) throws DatabaseEngineException {
-        // NoOp
-    }
+    void dropView(final String view) throws DatabaseEngineException;
 
     /**
      * Persists a given entry. Persisting a query implies executing the statement.


### PR DESCRIPTION
The javadoc plugin configuration was wrong for the version 3.0.0, this commit fixes it.
Also the default implementation of the new interface method DatabaseEngine#dropView was removed since next release will be a new minor.