### PR TITLE
Bump H2 version to 1.4.200

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 .idea
 *.iml
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add the following dependency to your Maven pom (example for PDB v2.1.13):
 ## Breaking changes
 The timeout properties have been redefined in PdbProperties as numeric instead of strings since v2.4.6 - avoid using versions 2.4.4 and 2.4.5.
 
-DatabaseEngine interface has a new method #dropView() since v2.5.3. This method was created without a default so this lead to a breaking change. Use 2.5.5 and avoid using 2.5.3 and 2.5.4.
+DatabaseEngine interface has a new method #dropView() since v2.5.3. This method was created without a default so this led to a breaking change. Use 2.5.5 and avoid using 2.5.3 and 2.5.4.
 
 ## Changes from 2.0.0
 * It is now possible to call built-in database vendor functions [e.g. f("lower", column("COL1"))]
@@ -53,7 +53,7 @@ Alternatively you can setup the username/password for accessing Oracle's Maven r
 ## Running PDB tests
 
 To test PDB with different database engines there are several Maven profiles that can be used,
-one for each vendor (check list of supported vendors below, under [Establishing connection](#establishing-connection)).
+one for each vendor (check list of supported vendors below, under [Establishing a connection](#establishing-a-connection)).
 
 Run the following to run the tests for the chosen vendor **specified in lowercase**:
 ```bash
@@ -75,7 +75,7 @@ IBM DB2: https://hub.docker.com/r/ibmcom/db2express-c/
 ### Index
 
 - [Example Description](#example-description)
-- [Establishing connection](#establishing-connection)
+- [Establishing a connection](#establishing-a-connection)
 - Table Manipulation
 	- [Create Table](#create-table)
 	- [Drop Table](#drop-table)

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.197</version>
+                <version>1.4.200</version>
             </dependency>
             <dependency>
                 <groupId>com.ibm.db2</groupId>
@@ -440,6 +440,8 @@
                                 <!-- set local file inside test output directory -->
                                 <argument>-baseDir</argument>
                                 <argument>${project.build.testOutputDirectory}/pdb-h2-remote</argument>
+                                <!-- allows databases to be created when accessed -->
+                                <argument>-ifNotExists</argument>
                             </arguments>
                             <async>true</async>
                             <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>


### PR DESCRIPTION
**Summary**

This patch bumps the H2 Database Engine version to 1.4.200.

For version 1.4.197 of the H2 Database Engine, there are at least two CVEs reported:

* [CVE-2018-10054](https://nvd.nist.gov/vuln/detail/CVE-2018-10054)
* [CVE-2018-14335](https://nvd.nist.gov/vuln/detail/CVE-2018-14335)

There are no reported CVEs for version 1.4.200 as of today, Jul 06 2020.
See a reference [here](https://nvd.nist.gov/products/cpe/search/results?keyword=cpe%3a2.3%3aa%3ah2database%3ah2%3a1.4.200&status=FINAL&orderBy=CPEURI&namingFormat=2.3).

Additionally,

* `-ifNotExists` parameter was added to the `h2remote` profile to allow databases to be created when accessed
* A few typos on the README file were fixed
* Added macOS `.DS_Store` files to the `.gitignore` file

**Test Plan**

`mvn test`
`mvn -P h2remote test`