### PR TITLE
Lock down plugin versions set by parent POM on release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,9 +354,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
-                    <additionalOptions>
-                        <additionalOption>-Xdoclint:none</additionalOption>
-                    </additionalOptions>
+                    <doclint>none</doclint>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.feedzai</groupId>
     <artifactId>pdb</artifactId>
@@ -9,7 +10,7 @@
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <version>9</version>
     </parent>
 
     <url>https://github.com/feedzai/pdb</url>
@@ -35,6 +36,10 @@
 
     <properties>
         <project.source>1.8</project.source>
+
+        <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     </properties>
 
     <developers>
@@ -130,7 +135,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-           <scope>provided</scope>
+            <scope>provided</scope>
         </dependency>
         <!-- PostgreSql -->
         <dependency>
@@ -238,12 +243,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>${maven-source-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>${maven-javadoc-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -276,6 +281,11 @@
                         <useColor>true</useColor>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${maven-gpg-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -290,8 +300,8 @@
             </plugin>
             <!-- maven-surefire-plugin -->
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- By default only run the H2 tests. -->
                     <failIfNoTests>false</failIfNoTests>
@@ -328,6 +338,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -341,6 +352,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
                     <additionalOptions>
                         <additionalOption>-Xdoclint:none</additionalOption>
@@ -359,7 +371,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
+                <version>${maven-gpg-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -372,6 +384,7 @@
             </plugin>
             <!-- explicitly define maven-deploy-plugin after others to force exec order -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <executions>
                     <execution>
@@ -433,7 +446,7 @@
                                 <argument>-classpath</argument>
                                 <!-- automatically creates the classpath using all project dependencies,
                                      also adding the project build directory -->
-                                <classpath />
+                                <classpath/>
                                 <argument>org.h2.tools.Server</argument>
                                 <!-- make db available via tcp -->
                                 <argument>-tcp</argument>


### PR DESCRIPTION
**Summary**

This patch forces the plugin versions to the ones desired
by setting the version on the `plugins` section.

When using the release plugin, the `sonatype-oss-release` profile
from the Sonatype OSS Parent POM is activated.

This means that the versions of some plugins (e.g. the
`maven-javadoc-plugin`) are set to different versions than
those specified on the PDB root POM `pluginManagement` section.

Additionally,

* the version of the parent POM was bumped to 9
* the POM file was cleaned up

**Test Plan**

`mvn help:effective-pom | grep -A 3 -E "maven-(javadoc)|(source)|(gpg)-plugin"`

With the `deploy` phase changed to `package` on the affected plugins:

`mvn -Prelease.signature -Darguments=-Dgpg.passphrase=thephrase release:prepare`
`mvn -Prelease.signature -DdryRun=true release:perform`