### PR TITLE
Include connection recovery to prepared statement result iterator related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The timeout properties have been redefined in PdbProperties as numeric instead o
 
 DatabaseEngine interface has a new method #dropView() since v2.5.3. This method was created without a default so this led to a breaking change. Use 2.5.5 and avoid using 2.5.3 and 2.5.4.
 
+DatabaseEngine methods `#getPSResultSet(final String name)`, `#getPSIterator(final String name)`, `#getPSIterator
+(final String name, final int fetchSize)`, since 2.7.0, throw an extra `ConnectionResetException` when the database
+connection is lost and recovered.
+
 ## Changes from 2.0.0
 * It is now possible to call built-in database vendor functions [e.g. f("lower", column("COL1"))]
 * Added lower and upper functions

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -482,7 +482,7 @@ public interface DatabaseEngine extends AutoCloseable {
      * @return The result.
      * @throws DatabaseEngineException If something occurs getting the result.
      */
-    List<Map<String, ResultColumn>> getPSResultSet(final String name) throws DatabaseEngineException;
+    List<Map<String, ResultColumn>> getPSResultSet(final String name) throws DatabaseEngineException, ConnectionResetException;
 
     /**
      * Sets the parameters on the specified prepared statement.
@@ -653,7 +653,7 @@ public interface DatabaseEngine extends AutoCloseable {
      * @return An iterator for the results of the prepared statement of the given name.
      * @throws DatabaseEngineException If a database access error occurs.
      */
-    ResultIterator getPSIterator(final String name) throws DatabaseEngineException;
+    ResultIterator getPSIterator(final String name) throws DatabaseEngineException, ConnectionResetException;
 
     /**
      * Creates an iterator for the {@link java.sql.PreparedStatement} bound to the given name.
@@ -663,7 +663,7 @@ public interface DatabaseEngine extends AutoCloseable {
      * @return An iterator for the results of the prepared statement of the given name.
      * @throws DatabaseEngineException If a database access error occurs.
      */
-    ResultIterator getPSIterator(final String name, final int fetchSize) throws DatabaseEngineException;
+    ResultIterator getPSIterator(final String name, final int fetchSize) throws DatabaseEngineException, ConnectionResetException;
 
     /**
      * Sets the given exception handler in the engine.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -981,11 +981,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                 }
 
                 // At this point maybe it is an error with the connection, so we try to re-establish it.
-                try {
-                    getConnection();
-                } catch (final Exception e2) {
-                    throw new DatabaseEngineException("Connection is down", e2);
-                }
+                reconnectExceptionally("Connection is down");
 
                 throw new ConnectionResetException("Connection was lost, you must reset the prepared statement parameters and re-execute the statement");
             }
@@ -1012,11 +1008,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
             }
 
             // At this point maybe it is an error with the connection, so we try to re-establish it.
-            try {
-                getConnection();
-            } catch (final Exception e2) {
-                throw new DatabaseEngineException("Connection is down", e2);
-            }
+            reconnectExceptionally("Connection is down");
 
             throw new ConnectionResetException("Connection was lost, you must reset the prepared statement parameters and re-execute the statement");
         }


### PR DESCRIPTION
**Summary**

Include a recovery mechanism to the methods:
    * `#getPSResultSet(final String name)`
    * `#getPSIterator(final String name)`
    * `#getPSIterator(final String name, final int fetchSize)`.

The methods now throws a `ConnectionResetException` when the connection is lost
and successfully recovered.

This PR is the successor of #146 