### PR TITLE
Bump Postgresql image version from 9.6.14 to 12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -570,7 +570,7 @@
         <profile>
             <id>postgresql</id>
             <properties>
-                <image.postgresql>postgres:9.6.14</image.postgresql>
+                <image.postgresql>postgres:12.3</image.postgresql>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
Upgrades the version for the Postgresql image used from 9.6.14 to 12.3.