### PR TITLE
Use native connection checks where possible and with configurable timout

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -165,7 +165,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * An {@link ExecutorService} to be used by the DB drivers to break a connection if it has been blocked for longer
      * than the specified socket timeout
      */
-    private final ExecutorService socketTimeoutExecutor = Executors.newSingleThreadExecutor();
+    protected final ExecutorService socketTimeoutExecutor = Executors.newSingleThreadExecutor();
 
     /**
      * The default instance of {@link QueryExceptionHandler} to be used in disambiguating SQL exceptions.
@@ -1101,7 +1101,14 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * @param conn The connection to test.
      * @return True if the connection is valid, false otherwise.
      */
-    protected abstract boolean checkConnection(final Connection conn);
+    protected boolean checkConnection(final Connection conn) {
+        try {
+            return conn.isValid(this.properties.getCheckConnectionTimeout());
+        } catch (final Exception ex) {
+            logger.debug("Connection is down.", ex);
+            return false;
+        }
+    };
 
     /**
      * Checks if the connection is alive.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseFactory.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseFactory.java
@@ -55,6 +55,11 @@ public final class DatabaseFactory {
             throw new DatabaseFactoryException("pdb.engine property is mandatory");
         }
 
+        if (pdbProperties.getSocketTimeout() > 0 &&
+                pdbProperties.getCheckConnectionTimeout() > pdbProperties.getSocketTimeout()) {
+            throw new DatabaseFactoryException("pdb.check_connection_timeout cannot be greater than pdb.socket_timeout");
+        }
+
         try {
             Class<?> c = Class.forName(engine);
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/configuration/PdbProperties.java
@@ -29,6 +29,7 @@ import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_ALLOW_COLUMN_DROP;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_BLOB_BUFFER_SIZE;
+import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_CHECK_CONNECTION_TIMEOUT;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_COMPRESS_LOBS;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_DISABLE_LOB_CACHING;
 import static com.feedzai.commons.sql.abstraction.util.Constants.DEFAULT_FETCH_SIZE;
@@ -181,6 +182,12 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
     public static final String SELECT_QUERY_TIMEOUT = "pdb.query_select_timeout";
 
     /**
+     * Property that indicates the maximum time taken when checking if a connection is available.
+     * @since 2.7.2
+     */
+    public static final String CHECK_CONNECTION_TIMEOUT = "pdb.check_connection_timeout";
+
+    /**
      * Creates a new instance of an empty {@link PdbProperties}.
      */
     public PdbProperties() {
@@ -214,6 +221,7 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
             setProperty(LOGIN_TIMEOUT, DEFAULT_LOGIN_TIMEOUT);
             setProperty(SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
             setProperty(SELECT_QUERY_TIMEOUT, DEFAULT_SELECT_QUERY_TIMEOUT);
+            setProperty(CHECK_CONNECTION_TIMEOUT, DEFAULT_CHECK_CONNECTION_TIMEOUT);
         }
     }
 
@@ -527,6 +535,21 @@ public class PdbProperties extends Properties implements com.feedzai.commons.sql
      */
     public int getSelectQueryTimeout() {
         return Integer.parseInt(getProperty(SELECT_QUERY_TIMEOUT));
+    }
+
+    /**
+     * Gets the check connection timeout (in seconds).
+     *
+     * @return The check connection timeout.
+     * @since 2.7.2
+     */
+    public int getCheckConnectionTimeout() {
+        final int checkConnectionTimeout = Integer.parseInt(getProperty(CHECK_CONNECTION_TIMEOUT));
+        if (checkConnectionTimeout > 0) {
+            return checkConnectionTimeout;
+        } else {
+            return getSocketTimeout();
+        }
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -803,6 +803,43 @@ public class DB2Engine extends AbstractDatabaseEngine {
 
     @Override
     protected boolean checkConnection(final Connection conn) {
+        final int timeout = this.properties.getCheckConnectionTimeout();
+        final int socketTimeout;
+        try {
+            socketTimeout = conn.getNetworkTimeout();
+            try {
+                // Set the socket timeout to verify the connection.
+                conn.setNetworkTimeout(socketTimeoutExecutor, timeout * 1000);
+                return pingConnection(conn);
+            } catch (final Exception ex) {
+                logger.debug("It wasn't possible to verify the connection state within the timeout of {} seconds.",
+                        timeout,
+                        ex);
+                return false;
+            } finally {
+                // Make sure to respect it afterwards.
+                conn.setNetworkTimeout(socketTimeoutExecutor, socketTimeout);
+            }
+        } catch (final Exception ex) {
+            logger.warn("It wasn't possible to reset the connection / fetch the timeout.");
+
+            try {
+                conn.close();
+            } catch (final Exception e) {
+                logger.debug("Error closing the connection.", e);
+            }
+
+            return false;
+        }
+    }
+
+    /**
+     * Executes a dummy query to verify if the connection is alive.
+     *
+     * @param conn The connection to test.
+     * @return {@code true} if the connection is valid, {@code false} otherwise.
+     */
+    private boolean pingConnection(final Connection conn) {
         Statement s = null;
         try {
             s = conn.createStatement();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -603,28 +603,6 @@ public class H2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected boolean checkConnection(final Connection conn) {
-        Statement s = null;
-        try {
-            s = conn.createStatement();
-            s.executeQuery("select 1");
-
-            return true;
-        } catch (final SQLException e) {
-            logger.debug("Connection is down.", e);
-            return false;
-        } finally {
-            try {
-                if (s != null) {
-                    s.close();
-                }
-            } catch (final Exception e) {
-                logger.trace("Error closing statement.", e);
-            }
-        }
-    }
-
-    @Override
     protected String getSchema() throws DatabaseEngineException {
         try {
             return this.conn.getSchema();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -752,28 +752,6 @@ public class MySqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected boolean checkConnection(final Connection conn) {
-        Statement s = null;
-        try {
-            s = conn.createStatement();
-            s.executeQuery("select 1");
-
-            return true;
-        } catch (final SQLException e) {
-            logger.debug("Connection is down.", e);
-            return false;
-        } finally {
-            try {
-                if (s != null) {
-                    s.close();
-                }
-            } catch (final Exception e) {
-                logger.trace("Error closing statement.", e);
-            }
-        }
-    }
-
-    @Override
     protected String getSchema() throws DatabaseEngineException {
         try {
             return this.conn.getCatalog();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -1034,28 +1034,6 @@ public class OracleEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected boolean checkConnection(final Connection conn) {
-        Statement s = null;
-        try {
-            s = conn.createStatement();
-            s.executeQuery("select 1 from dual");
-
-            return true;
-        } catch (final SQLException e) {
-            logger.debug("Connection is down.", e);
-            return false;
-        } finally {
-            try {
-                if (s != null) {
-                    s.close();
-                }
-            } catch (final Exception e) {
-                logger.trace("Error closing statement.", e);
-            }
-        }
-    }
-
-    @Override
     public synchronized Map<String, DbColumnType> getMetadata(final String schemaPattern,
                                                               final String tableNamePattern) throws DatabaseEngineException {
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -684,6 +684,43 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
 
     @Override
     protected boolean checkConnection(final Connection conn) {
+        final int timeout = this.properties.getCheckConnectionTimeout();
+        final int socketTimeout;
+        try {
+            socketTimeout = conn.getNetworkTimeout();
+            try {
+                // Set the socket timeout to verify the connection.
+                conn.setNetworkTimeout(socketTimeoutExecutor, timeout * 1000);
+                return pingConnection(conn);
+            } catch (final Exception ex) {
+                logger.debug("It wasn't possible to verify the connection state within the timeout of {} seconds.",
+                        timeout,
+                        ex);
+                return false;
+            } finally {
+                // Make sure to respect it afterwards.
+                conn.setNetworkTimeout(socketTimeoutExecutor, socketTimeout);
+            }
+        } catch (final Exception ex) {
+            logger.debug("It wasn't possible to reset the connection. Connection might be closed.");
+
+            try {
+                conn.close();
+            } catch (final Exception e) {
+                logger.debug("Error closing the connection.", e);
+            }
+
+            return false;
+        }
+    }
+
+    /**
+     * Executes a dummy query to verify if the connection is alive.
+     *
+     * @param conn The connection to test.
+     * @return {@code true} if the connection is valid, {@code false} otherwise.
+     */
+    private boolean pingConnection(final Connection conn) {
         Statement s = null;
         try {
             s = conn.createStatement();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -732,28 +732,6 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected boolean checkConnection(final Connection conn) {
-        Statement s = null;
-        try {
-            s = conn.createStatement();
-            s.executeQuery("select 1");
-
-            return true;
-        } catch (final SQLException e) {
-            logger.debug("Connection is down.", e);
-            return false;
-        } finally {
-            try {
-                if (s != null) {
-                    s.close();
-                }
-            } catch (final Exception e) {
-                logger.trace("Error closing statement.", e);
-            }
-        }
-    }
-
-    @Override
     protected void setSchema(final String schema) throws DatabaseEngineException {
         if (!properties.getSchema().equals(getSchema())) {
             throw new DatabaseEngineException(

--- a/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/util/Constants.java
@@ -129,4 +129,10 @@ public final class Constants {
             DatabaseEngineRetryableRuntimeException.class,
             DatabaseEngineTimeoutException.class
     );
+
+    /**
+     * The default timeout when checking if a connection is down.
+     * @since 2.7.2
+     */
+    public static final int DEFAULT_CHECK_CONNECTION_TIMEOUT = 60;
 }


### PR DESCRIPTION
This commit introduces changes to the verification of the JDBC connections.
When verifying database connections, PDB should do it in a timely manner to allow a faster failover of the database. To achieve this goal, a new property is included to configure the timeout of the verification.
Most of the engines are now using JDBC standard `isValid()`. 
PostgreSQL, do not respect it and unit tests had failed consistently. (see: https://github.com/pgjdbc/pgjdbc/pull/1943)
DB2 does not correctly recover connections using `isValid()`.