### PR TITLE
H2Engine: Verify if the table has an auto increment column before trying to read the generated value

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -818,7 +818,8 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * @param me               The mapped entity on which to persist.
      * @param useAutoInc       Whether to use autoInc.
      * @param lastBindPosition The position (1-based) of the last bind parameter that was filled in the prepared statement.
-     * @return The ID of the auto generated value ({@code 0} if there's no auto generated value).
+     * @return The ID of the auto generated value ({@code 0} if there's no auto generated value). If the table has more
+     * than 1 column with auto generated values, then it will return the first column found.
      * @throws Exception if any problem occurs while persisting.
      * @since 2.5.1
      */


### PR DESCRIPTION
This commit fixes the H2 Engine when trying to persist a given entry in the database.

When persisting an entry with auto increment as `true`, it is returned the auto generated value from the generated keys, but in the newest version of H2 1.4.200, the method `PreparedStatement#getGeneratedKeys` returns all the columns as containing auto generated values by default, so it is necessary check if the that table has an auto increment column.