### PR TITLE
pom: Bump Guava to version 25.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>18.0</version>
+                <version>25.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
This commit upgrades `Guava` to version `25.1-jre`.