### PR TITLE
pom: Bump mysql Java connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.46</version>
+                <version>5.1.49</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>


### PR DESCRIPTION
This commit upgrades MySQL Java connector driver to the version `5.1.49`.
The MySQL tests (with profile -Pmysql) passed locally.