### PR TITLE
pom: Bump Apache Commons Codec to version 1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.10</version>
+                <version>1.15</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>


### PR DESCRIPTION
This commit upgrades the `commons-codec` dependency to the version 1.15.