### PR TITLE
Prevent dropping and adding all foreign keys when updating an entity.

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/ddl/DbFk.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/ddl/DbFk.java
@@ -15,14 +15,13 @@
  */
 package com.feedzai.commons.sql.abstraction.ddl;
 
-import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
@@ -52,7 +51,7 @@ public class DbFk implements Serializable {
     /**
      * Cached hashcode.
      */
-    private int hashCode = -1;
+    private final int hashCode;
 
     /**
      * Creates a new instance of {@link DbFk}.
@@ -63,6 +62,7 @@ public class DbFk implements Serializable {
         this.localColumns = ImmutableList.copyOf(builder.localColumns);
         this.referencedColumns = ImmutableList.copyOf(builder.referencedColumns);
         this.referencedTable = builder.referencedTable;
+        this.hashCode = Objects.hash(this.localColumns, this.referencedColumns, this.referencedTable);
     }
 
     /**
@@ -127,26 +127,23 @@ public class DbFk implements Serializable {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
+    public boolean equals(final Object obj) {
+        if (this == obj) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final DbFk dbFk = (DbFk) o;
-        return Objects.equal(getLocalColumns(), dbFk.getLocalColumns())
-                && Objects.equal(getForeignColumns(), dbFk.getForeignColumns())
-                && Objects.equal(getForeignTable(), dbFk.getForeignTable());
+
+        final DbFk dbFk = (DbFk) obj;
+        return this.localColumns.equals(dbFk.localColumns)
+                && this.referencedColumns.equals(dbFk.referencedColumns)
+                && this.referencedTable.equals(dbFk.referencedTable);
     }
 
     @Override
     public int hashCode() {
-        // Computing the hashcode might be an expensive operation because it goes through 2 lists,
-        // that's why it is being cached.
-        if(this.hashCode == -1) {
-            this.hashCode = Objects.hashCode(getLocalColumns(), getForeignColumns(), getForeignTable());
-        }
         return this.hashCode;
     }
 
@@ -154,8 +151,8 @@ public class DbFk implements Serializable {
      * Builder to create immutable {@link DbFk} objects.
      */
     public static class Builder implements com.feedzai.commons.sql.abstraction.util.Builder<DbFk>, Serializable {
-        private final List<String> localColumns = new ArrayList<>();
-        private final List<String> referencedColumns = new ArrayList<>();
+        private final List<String> localColumns = new LinkedList<>();
+        private final List<String> referencedColumns = new LinkedList<>();
         private String referencedTable = null;
 
         /**
@@ -261,7 +258,11 @@ public class DbFk implements Serializable {
 
         @Override
         public DbFk build() {
-            Objects.requireNonNull(referencedTable, "The referenced table can't be null");
+            Preconditions.checkNotNull(referencedTable, "The referenced table can't be null.");
+            Preconditions.checkArgument(localColumns.size() == referencedColumns.size(),
+                    "The number of local columns and referenced columns must be the same. local: %s ; referenced: %s",
+                    localColumns, referencedColumns
+            );
             return new DbFk(this);
         }
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/ddl/DbFk.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/ddl/DbFk.java
@@ -15,12 +15,14 @@
  */
 package com.feedzai.commons.sql.abstraction.ddl;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -46,6 +48,11 @@ public class DbFk implements Serializable {
      * The referenced table.
      */
     private final String referencedTable;
+
+    /**
+     * Cached hashcode.
+     */
+    private int hashCode = -1;
 
     /**
      * Creates a new instance of {@link DbFk}.
@@ -117,6 +124,30 @@ public class DbFk implements Serializable {
      */
     public String getReferencedTable() {
         return referencedTable;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DbFk dbFk = (DbFk) o;
+        return Objects.equal(getLocalColumns(), dbFk.getLocalColumns())
+                && Objects.equal(getForeignColumns(), dbFk.getForeignColumns())
+                && Objects.equal(getForeignTable(), dbFk.getForeignTable());
+    }
+
+    @Override
+    public int hashCode() {
+        // Computing the hashcode might be an expensive operation because it goes through 2 lists,
+        // that's why it is being cached.
+        if(this.hashCode == -1) {
+            this.hashCode = Objects.hashCode(getLocalColumns(), getForeignColumns(), getForeignTable());
+        }
+        return this.hashCode;
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -638,6 +638,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * @param currentEntityMetadata The existing entity metadata.
      * @param entity                The updated entity.
      * @throws DatabaseEngineException If something goes wrong while updating the entity.
+     * @since 2.8.1
      */
     private void updateColumnsAndFks(final Map<String, DbColumnType> currentEntityMetadata,
                                      final DbEntity entity) throws DatabaseEngineException {
@@ -693,6 +694,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * @param entityName The entity name.
      * @return Mapping between the foreign key constraint name and the {@link DbFk}.
      * @throws DatabaseEngineException If it can't get the foreign keys metadata.
+     * @since 2.8.1
      */
     private Map<String, DbFk> getCurrentFks(final String entityName) throws DatabaseEngineException {
         final Map<String, DbFk.Builder> existentFks = new HashMap<>();
@@ -1471,8 +1473,8 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      *
      * @param entity The entity.
      * @param fks    The foreign keys to be added.
-     *
      * @throws DatabaseEngineException If something goes wrong creating the FKs.
+     * @since 2.8.1
      */
     protected void addFks(final DbEntity entity, final Set<DbFk> fks) throws DatabaseEngineException {
         throw new NotImplementedException();
@@ -1524,6 +1526,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * @param table The table name.
      * @param fkName The foreign key name.
      * @return The query to drop the foreign key.
+     * @since 2.8.1
      */
     protected String dropFkQuery(final String table, final String fkName) {
         return String.format("ALTER TABLE %s DROP CONSTRAINT %s",
@@ -1536,8 +1539,8 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      *
      * @param table The table.
      * @param fks   The foreign key names to be dropped.
-     *
      * @throws DatabaseEngineException If a foreign key can't be dropped.
+     * @since 2.8.1
      */
     protected void dropFks(final String table, final Set<String> fks) throws DatabaseEngineException {
         for (final String fk : fks) {
@@ -1691,6 +1694,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      *
      * @return The metadata.
      * @throws DatabaseEngineException If it isn't possible to get current database metadata.
+     * @since 2.8.1
      */
     private DatabaseMetaData getMetadata() throws DatabaseEngineException {
         try {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -611,7 +611,8 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
         // Only mutate the schema in the DB (i.e. add schema, drop/add columns, if the schema policy allows it.
         if (!properties.isSchemaPolicyNone()) {
             final Map<String, DbColumnType> tableMetadata = getMetadata(entity.getName());
-            if (tableMetadata.isEmpty()) { // the table does not exist
+            // if the table does not exist yet, add it
+            if (tableMetadata.isEmpty()) {
                 addEntity(entity);
             } else if (this.properties.isSchemaPolicyDropCreate()) {
                 dropEntity(entity);

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/CockroachDBEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/CockroachDBEngine.java
@@ -20,6 +20,7 @@ import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
 import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
 import com.feedzai.commons.sql.abstraction.ddl.DbColumnType;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
+import com.feedzai.commons.sql.abstraction.ddl.DbFk;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -172,9 +174,9 @@ public class CockroachDBEngine extends PostgreSqlEngine {
         ));
     }
 
-    protected void addFks(final DbEntity entity) throws DatabaseEngineException {
+    protected void addFks(final DbEntity entity, final Set<DbFk> fks) throws DatabaseEngineException {
         try {
-            super.addFks(entity);
+            super.addFks(entity, fks);
         } catch (final DatabaseEngineException ex) {
             if (ex.getCause() instanceof SQLException) {
                 final SQLException sqlException = (SQLException) ex.getCause();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -37,6 +37,7 @@ import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import com.feedzai.commons.sql.abstraction.util.Constants;
 import com.feedzai.commons.sql.abstraction.util.PreparedStatementCapsule;
+import com.ibm.db2.jcc.am.SqlSyntaxErrorException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
@@ -47,6 +48,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -68,32 +70,32 @@ public class DB2Engine extends AbstractDatabaseEngine {
     /**
      * The DB2 JDBC driver.
      */
-    protected static final String DB2_DRIVER = DatabaseEngineDriver.DB2.driver();
+    private static final String DB2_DRIVER = DatabaseEngineDriver.DB2.driver();
+
     /**
      * Name is already used by an existing object.
      */
-    public static final String NAME_ALREADY_EXISTS = "DB2 SQL Error: SQLCODE=-601, SQLSTATE=42710";
+    private static final int NAME_ALREADY_EXISTS = -601;
+
     /**
      * Table can have only one primary key.
      */
-    public static final String TABLE_CAN_ONLY_HAVE_ONE_PRIMARY_KEY = "DB2 SQL Error: SQLCODE=-624, SQLSTATE=42889";
+    private static final int TABLE_CAN_ONLY_HAVE_ONE_PRIMARY_KEY = -624;
+
     /**
-     * Sequence does not exist.
+     * The name (e.g. of a sequence, table, view, ...) does not exist.
      */
-    public static final String SEQUENCE_DOES_NOT_EXIST = "DB2 SQL Error: SQLCODE=-204, SQLSTATE=42704";
-    /**
-     * Table or view does not exist.
-     */
-    public static final String TABLE_OR_VIEW_DOES_NOT_EXIST = "DB2 SQL Error: SQLCODE=-204, SQLSTATE=42704";
-    /**
-     * Foreign key already exists
-     */
-    public static final String FOREIGN_ALREADY_EXISTS = "DB2 SQL Error: SQLCODE=-601, SQLSTATE=42710";
+    private static final int NAME_DOES_NOT_EXIST = -204;
 
     /**
      * The default size of a BLOB in DB2.
      */
-    public static final String DB2_DEFAULT_BLOB_SIZE = "2G";
+    static final String DB2_DEFAULT_BLOB_SIZE = "2G";
+
+    /**
+     * The column must have a {@link DbColumnConstraint#NOT_NULL NOT NULL column constraint}.
+     */
+    private static final int COLUMN_MUST_BE_NON_NULL = -542;
 
     /**
      * Creates a new DB2 connection.
@@ -162,17 +164,17 @@ public class DB2Engine extends AbstractDatabaseEngine {
     @Override
     protected void createTable(final DbEntity entity) throws DatabaseEngineException {
 
-        List<String> createTable = new ArrayList<>();
+        final List<String> createTable = new LinkedList<>();
 
         createTable.add("CREATE TABLE");
         createTable.add(quotize(entity.getName()));
-        List<String> columns = new ArrayList<>();
-        for (DbColumn c : entity.getColumns()) {
-            List<String> column = new ArrayList<>();
+        final List<String> columns = new LinkedList<>();
+        for (final DbColumn c : entity.getColumns()) {
+            final List<String> column = new LinkedList<>();
             column.add(quotize(c.getName()));
             column.add(translateType(c));
 
-            for (DbColumnConstraint cc : c.getColumnConstraints()) {
+            for (final DbColumnConstraint cc : c.getColumnConstraints()) {
                 column.add(cc.translate());
             }
 
@@ -189,45 +191,49 @@ public class DB2Engine extends AbstractDatabaseEngine {
 
         logger.trace(createTableStatement);
 
-        Statement s = null;
-        try {
-            s = conn.createStatement();
+        try (Statement s = conn.createStatement()) {
             s.executeUpdate(createTableStatement);
         } catch (final SQLException ex) {
-            if (ex.getMessage().startsWith(NAME_ALREADY_EXISTS)) {
-                logger.debug(dev, "'{}' is already defined", entity.getName());
-                handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_ALREADY_EXISTS), ex);
-            } else {
-                throw new DatabaseEngineException("Something went wrong handling statement", ex);
-            }
-        } finally {
-            try {
-                if (s != null) {
-                    s.close();
-                }
-            } catch (final Exception e) {
-                logger.trace("Error closing statement.", e);
+            switch (ex.getErrorCode()) {
+                case NAME_ALREADY_EXISTS:
+                    logger.debug(dev, "'{}' is already defined", entity.getName());
+                    handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_ALREADY_EXISTS), ex);
+                    break;
+
+                case COLUMN_MUST_BE_NON_NULL:
+                    String errorMessage;
+                    try {
+                        errorMessage = ((SqlSyntaxErrorException) ex).getSqlca().getMessage();
+                    } catch (final Exception sqlEx) {
+                        // if this is not SqlSyntaxErrorException, Sqlca is null or there is an error getting message,
+                        // just use the message from the SQL Exception
+                        errorMessage = ex.getMessage();
+                    }
+                    logger.error("Column must use NON_NULL constraint; error message: {}", errorMessage);
+                    // fall through to default (throw general DatabaseEngineException)
+
+                default:
+                    throw new DatabaseEngineException("Something went wrong handling statement", ex);
             }
         }
     }
 
     @Override
     protected void addPrimaryKey(final DbEntity entity) throws DatabaseEngineException {
-        if (entity.getPkFields().size() == 0) {
+        if (entity.getPkFields().isEmpty()) {
             return;
         }
 
-        List<String> pks = new ArrayList<>();
-        for (String pk : entity.getPkFields()) {
+        final List<String> pks = new LinkedList<>();
+        for (final String pk : entity.getPkFields()) {
             pks.add(quotize(pk));
         }
 
-
-        String alterColumnSetNotNull = alterColumnSetNotNull(entity.getName(), entity.getPkFields());
+        final String alterColumnSetNotNull = alterColumnSetNotNull(entity.getName(), entity.getPkFields());
 
         final String pkName = md5(format("PK_%s", entity.getName()), properties.getMaxIdentifierSize());
 
-        List<String> statement = new ArrayList<>();
+        final List<String> statement = new LinkedList<>();
         statement.add("ALTER TABLE");
         statement.add(quotize(entity.getName()));
         statement.add("ADD CONSTRAINT");
@@ -236,43 +242,26 @@ public class DB2Engine extends AbstractDatabaseEngine {
         statement.add("(" + join(pks, ", ") + ")");
 
         final String addPrimaryKey = join(statement, " ");
-        String reorg = reorg(entity.getName());
+        final String reorg = reorg(entity.getName());
 
-
-        Statement s = null;
-        try {
+        try (Statement s = conn.createStatement()) {
             logger.trace(alterColumnSetNotNull);
-            s = conn.createStatement();
             s.executeUpdate(alterColumnSetNotNull);
-            s.close();
 
             logger.trace(reorg);
-            s = conn.createStatement();
             s.executeUpdate(reorg);
-            s.close();
 
             logger.trace(addPrimaryKey);
-            s = conn.createStatement();
             s.executeUpdate(addPrimaryKey);
-            s.close();
 
             logger.trace(reorg);
-            s = conn.createStatement();
             s.executeUpdate(reorg);
         } catch (final SQLException ex) {
-            if (ex.getMessage().startsWith(TABLE_CAN_ONLY_HAVE_ONE_PRIMARY_KEY)) {
+            if (ex.getErrorCode() == TABLE_CAN_ONLY_HAVE_ONE_PRIMARY_KEY) {
                 logger.debug(dev, "'{}' already has a primary key", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.PRIMARY_KEY_ALREADY_EXISTS), ex);
             } else {
                 throw new DatabaseEngineException("Something went wrong handling statement", ex);
-            }
-        } finally {
-            try {
-                if (s != null) {
-                    s.close();
-                }
-            } catch (final Exception e) {
-                logger.trace("Error closing statement.", e);
             }
         }
     }
@@ -283,13 +272,8 @@ public class DB2Engine extends AbstractDatabaseEngine {
      * @param tableName The table name to reorganize.
      * @return The command to perform the operation.
      */
-    private String reorg(String tableName) {
-        List<String> statement = new ArrayList<>();
-        statement.add("CALL sysproc.admin_cmd('REORG TABLE");
-        statement.add(quotize(tableName));
-        statement.add("')");
-
-        return join(statement, " ");
+    private String reorg(final String tableName) {
+        return String.format("CALL sysproc.admin_cmd('REORG TABLE %s')", quotize(tableName));
     }
 
     /**
@@ -315,21 +299,19 @@ public class DB2Engine extends AbstractDatabaseEngine {
 
     @Override
     protected void addIndexes(final DbEntity entity) throws DatabaseEngineException {
-        List<DbIndex> indexes = entity.getIndexes();
+        final List<DbIndex> indexes = entity.getIndexes();
 
-        for (DbIndex index : indexes) {
-
-
-            List<String> createIndex = new ArrayList<>();
+        for (final DbIndex index : indexes) {
+            final List<String> createIndex = new LinkedList<>();
             createIndex.add("CREATE");
             if (index.isUnique()) {
                 createIndex.add("UNIQUE");
             }
             createIndex.add("INDEX");
 
-            List<String> columns = new ArrayList<>();
-            List<String> columnsForName = new ArrayList<>();
-            for (String column : index.getColumns()) {
+            final List<String> columns = new LinkedList<>();
+            final List<String> columnsForName = new LinkedList<>();
+            for (final String column : index.getColumns()) {
                 columns.add(quotize(column));
                 columnsForName.add(column);
             }
@@ -343,46 +325,35 @@ public class DB2Engine extends AbstractDatabaseEngine {
 
             logger.trace(statement);
 
-            Statement s = null;
-            try {
-                s = conn.createStatement();
+            try (Statement s = conn.createStatement()) {
                 s.executeUpdate(statement);
             } catch (final SQLException ex) {
-                if (ex.getMessage().startsWith(NAME_ALREADY_EXISTS)) {
+                if (ex.getErrorCode() == NAME_ALREADY_EXISTS) {
                     logger.debug(dev, "'{}' is already defined", idxName);
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.INDEX_ALREADY_EXISTS), ex);
                 } else {
                     throw new DatabaseEngineException("Something went wrong handling statement", ex);
-                }
-            } finally {
-                try {
-                    if (s != null) {
-                        s.close();
-                    }
-                } catch (final Exception e) {
-                    logger.trace("Error closing statement.", e);
                 }
             }
         }
     }
 
     @Override
-    protected void addSequences(DbEntity entity) throws DatabaseEngineException {
-        for (DbColumn column : entity.getColumns()) {
+    protected void addSequences(final DbEntity entity) throws DatabaseEngineException {
+        for (final DbColumn column : entity.getColumns()) {
             if (!column.isAutoInc()) {
                 continue;
             }
 
             final String sequenceName = md5(format("%s_%s_SEQ", entity.getName(), column.getName()), properties.getMaxIdentifierSize());
 
-            List<String> createSequence = new ArrayList<>();
+            final List<String> createSequence = new LinkedList<>();
             createSequence.add("CREATE SEQUENCE");
             createSequence.add(quotize(sequenceName));
             createSequence.add("MINVALUE 0");
             switch (column.getDbColumnType()) {
                 case INT:
-                    createSequence.add("MAXVALUE");
-                    createSequence.add(format("%d", Integer.MAX_VALUE));
+                    createSequence.add("MAXVALUE " + Integer.MAX_VALUE);
 
                     break;
                 case LONG:
@@ -399,24 +370,14 @@ public class DB2Engine extends AbstractDatabaseEngine {
 
             logger.trace(statement);
 
-            Statement s = null;
-            try {
-                s = conn.createStatement();
+            try (Statement s = conn.createStatement()) {
                 s.executeUpdate(statement);
             } catch (final SQLException ex) {
-                if (ex.getMessage().startsWith(NAME_ALREADY_EXISTS)) {
+                if (ex.getErrorCode() == NAME_ALREADY_EXISTS) {
                     logger.debug(dev, "'{}' is already defined", sequenceName);
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.SEQUENCE_ALREADY_EXISTS), ex);
                 } else {
                     throw new DatabaseEngineException("Something went wrong handling statement", ex);
-                }
-            } finally {
-                try {
-                    if (s != null) {
-                        s.close();
-                    }
-                } catch (final Exception e) {
-                    logger.trace("Error closing statement.", e);
                 }
             }
         }
@@ -496,8 +457,8 @@ public class DB2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void dropSequences(DbEntity entity) throws DatabaseEngineException {
-        for (DbColumn column : entity.getColumns()) {
+    protected void dropSequences(final DbEntity entity) throws DatabaseEngineException {
+        for (final DbColumn column : entity.getColumns()) {
             if (!column.isAutoInc()) {
                 continue;
             }
@@ -506,105 +467,67 @@ public class DB2Engine extends AbstractDatabaseEngine {
 
             final String stmt = format("DROP SEQUENCE %s", quotize(sequenceName));
 
-            Statement drop = null;
-            try {
-                drop = conn.createStatement();
-                logger.trace(stmt);
-                drop.executeUpdate(stmt);
+            logger.trace(stmt);
+
+            try (Statement s = conn.createStatement()) {
+                s.executeUpdate(stmt);
             } catch (final SQLException ex) {
-                if (ex.getMessage().startsWith(SEQUENCE_DOES_NOT_EXIST)) {
+                if (ex.getErrorCode() == NAME_DOES_NOT_EXIST) {
                     logger.debug(dev, "Sequence '{}' does not exist", sequenceName);
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.SEQUENCE_DOES_NOT_EXIST), ex);
                 } else {
                     throw new DatabaseEngineException("Error dropping sequence", ex);
                 }
-            } finally {
-                try {
-                    if (drop != null) {
-                        drop.close();
-                    }
-                } catch (final Exception e) {
-                    logger.trace("Error closing statement.", e);
-                }
             }
         }
     }
 
     @Override
-    protected void dropTable(DbEntity entity) throws DatabaseEngineException {
-        Statement drop = null;
-        try {
-            drop = conn.createStatement();
-            final String query = format("DROP TABLE %s", quotize(entity.getName()));
-            logger.trace(query);
-            drop.executeUpdate(query);
+    protected void dropTable(final DbEntity entity) throws DatabaseEngineException {
+        final String query = format("DROP TABLE %s", quotize(entity.getName()));
+        logger.trace(query);
+
+        try (Statement s = conn.createStatement()) {
+            s.executeUpdate(query);
         } catch (final SQLException ex) {
-            if (ex.getMessage().startsWith(TABLE_OR_VIEW_DOES_NOT_EXIST)) {
+            if (ex.getErrorCode() == NAME_DOES_NOT_EXIST) {
                 logger.debug(dev, "Table '{}' does not exist", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.TABLE_DOES_NOT_EXIST), ex);
             } else {
                 throw new DatabaseEngineException("Error dropping table", ex);
             }
-        } finally {
-            try {
-                if (drop != null) {
-                    drop.close();
-                }
-            } catch (final Exception e) {
-                logger.trace("Error closing statement.", e);
-            }
         }
     }
 
-
     @Override
-    protected void dropColumn(DbEntity entity, String... columns) throws DatabaseEngineException {
-        Statement drop = null;
-        Statement reorgStatement = null;
-
-        List<String> removeColumns = new ArrayList<>();
+    protected void dropColumn(final DbEntity entity, final String... columns) throws DatabaseEngineException {
+        final List<String> removeColumns = new ArrayList<>();
         removeColumns.add("ALTER TABLE");
         removeColumns.add(quotize(entity.getName()));
 
-        for (String col : columns) {
+        for (final String col : columns) {
             removeColumns.add("DROP COLUMN");
             removeColumns.add(quotize(col));
         }
 
-        try {
-            drop = conn.createStatement();
-            final String query = join(removeColumns, " ");
-            logger.trace(query);
-            drop.executeUpdate(query);
+        final String query = join(removeColumns, " ");
+        final String reorg = reorg(entity.getName());
 
-            String reorg = reorg(entity.getName());
+        try (Statement s = conn.createStatement()) {
+            logger.trace(query);
+            s.executeUpdate(query);
+
             logger.trace(reorg);
-            reorgStatement = conn.createStatement();
-            reorgStatement.executeUpdate(reorg);
+            s.executeUpdate(reorg);
+
         } catch (final SQLException ex) {
-            if (ex.getMessage().startsWith(TABLE_OR_VIEW_DOES_NOT_EXIST)) {
+            if (ex.getErrorCode() == NAME_DOES_NOT_EXIST) {
                 logger.debug(dev, "Table '{}' does not exist", entity.getName());
                 handleOperation(new OperationFault(entity.getName(), OperationFault.Type.COLUMN_DOES_NOT_EXIST), ex);
             } else {
                 throw new DatabaseEngineException("Error dropping column", ex);
             }
-        } finally {
-            try {
-                if (drop != null) {
-                    drop.close();
-                }
-            } catch (final Exception e) {
-                logger.trace("Error closing statement.", e);
-            }
-            try {
-                if (reorgStatement != null) {
-                    reorgStatement.close();
-                }
-            } catch (final Exception e) {
-                logger.trace("Error closing statement.", e);
-            }
         }
-
     }
 
     /*
@@ -742,12 +665,12 @@ public class DB2Engine extends AbstractDatabaseEngine {
     @Override
     protected void addFks(final DbEntity entity, final Set<DbFk> fks) throws DatabaseEngineException {
         for (final DbFk fk : fks) {
-            final List<String> quotizedLocalColumns = new ArrayList<>();
+            final List<String> quotizedLocalColumns = new LinkedList<>();
             for (String s : fk.getLocalColumns()) {
                 quotizedLocalColumns.add(quotize(s));
             }
 
-            final List<String> quotizedForeignColumns = new ArrayList<>();
+            final List<String> quotizedForeignColumns = new LinkedList<>();
             for (final String s : fk.getReferencedColumns()) {
                 quotizedForeignColumns.add(quotize(s));
             }
@@ -769,19 +692,17 @@ public class DB2Engine extends AbstractDatabaseEngine {
                             quotizedForeignColumnsString
                     );
 
-            Statement alterTableStmt = null;
-            Statement reorgStatement = null;
-            try {
-                alterTableStmt = conn.createStatement();
-                logger.trace(alterTable);
-                alterTableStmt.executeUpdate(alterTable);
+            final String reorg = reorg(entity.getName());
 
-                String reorg = reorg(entity.getName());
+            try (Statement s = conn.createStatement()) {
+                logger.trace(alterTable);
+                s.executeUpdate(alterTable);
+
                 logger.trace(reorg);
-                reorgStatement = conn.createStatement();
-                reorgStatement.executeUpdate(reorg);
+                s.executeUpdate(reorg);
+
             } catch (final SQLException ex) {
-                if (ex.getMessage().startsWith(FOREIGN_ALREADY_EXISTS)) {
+                if (ex.getErrorCode() == NAME_ALREADY_EXISTS) {
                     logger.debug(dev, "Foreign key for table '{}' already exists. Error code: {}.", entity.getName(), ex.getMessage());
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.FOREIGN_KEY_ALREADY_EXISTS), ex);
                 } else {
@@ -790,21 +711,6 @@ public class DB2Engine extends AbstractDatabaseEngine {
                             entity.getName(),
                             ex.getMessage()
                     ), ex);
-                }
-            } finally {
-                try {
-                    if (alterTableStmt != null) {
-                        alterTableStmt.close();
-                    }
-                } catch (final Exception e) {
-                    logger.trace("Error closing statement.", e);
-                }
-                try {
-                    if (reorgStatement != null) {
-                        reorgStatement.close();
-                    }
-                } catch (final Exception e) {
-                    logger.trace("Error closing statement.", e);
                 }
             }
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -740,7 +740,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addFks(DbEntity entity, final Set<DbFk> fks) throws DatabaseEngineException {
+    protected void addFks(final DbEntity entity, final Set<DbFk> fks) throws DatabaseEngineException {
         for (final DbFk fk : fks) {
             final List<String> quotizedLocalColumns = new ArrayList<>();
             for (String s : fk.getLocalColumns()) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -628,7 +628,9 @@ public class MySqlEngine extends AbstractDatabaseEngine {
 
     @Override
     protected String dropFkQuery(final String table, final String fkName) {
-        return String.format("ALTER TABLE %s DROP FOREIGN KEY %s", table, fkName);
+        return String.format("ALTER TABLE %s DROP FOREIGN KEY %s",
+                quotize(table, escapeCharacter()),
+                quotize(fkName, escapeCharacter()));
     }
 
     protected void dropReferringFks(DbEntity entity) throws DatabaseEngineException {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -56,6 +56,7 @@ import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -1036,6 +1037,55 @@ public class OracleEngine extends AbstractDatabaseEngine {
                 }
             }
         }
+    }
+
+    @Override
+    protected ResultSet getImportedKeys(final String entityName) throws SQLException {
+        Objects.requireNonNull(entityName, "'entityName' must not be null");
+
+        final String query = "SELECT" +
+                "  NULL AS pktable_cat,\n" +
+                "  p.owner as pktable_schem,\n" +
+                "  p.table_name as pktable_name,\n" +
+                "  pc.column_name as pkcolumn_name,\n" +
+                "  NULL as fktable_cat,\n" +
+                "  f.owner as fktable_schem,\n" +
+                "  f.table_name as fktable_name,\n" +
+                "  fc.column_name as fkcolumn_name,\n" +
+                "  fc.position as key_seq,\n" +
+                "  NULL as update_rule,\n" +
+                "  decode (f.delete_rule, 'CASCADE', 0, 'SET NULL', 2, 1) as delete_rule,\n" +
+                "  f.constraint_name as fk_name,\n" +
+                "  p.constraint_name as pk_name,\n" +
+                "  decode(f.deferrable,       'DEFERRABLE',5      ,'NOT DEFERRABLE',7      , 'DEFERRED', 6      ) deferrability \n" +
+                " FROM all_cons_columns pc, all_constraints p, all_cons_columns fc, all_constraints f\n" +
+                " WHERE f.table_name = ?\n" +
+                "  AND f.owner = ?\n" +
+                "  AND f.constraint_type = 'R'\n" +
+                "  AND p.owner = f.r_owner\n" +
+                "  AND p.constraint_name = f.r_constraint_name\n" +
+                /*
+                 In the Oracle driver, the following constraint is used:
+                        AND p.constraint_type = 'P'
+                 This limits the search to foreign keys that reference primary key columns only;
+                 we need it to also return foreign keys that reference columns that have unique key constraints.
+                 */
+                "  AND p.constraint_type IN ('P', 'U')\n" +
+                "  AND pc.owner = p.owner\n" +
+                "  AND pc.constraint_name = p.constraint_name\n" +
+                "  AND pc.table_name = p.table_name\n" +
+                "  AND fc.owner = f.owner\n" +
+                "  AND fc.constraint_name = f.constraint_name\n" +
+                "  AND fc.table_name = f.table_name\n" +
+                "  AND fc.position = pc.position\n" +
+                "  ORDER BY pktable_schem, pktable_name, key_seq";
+
+        final PreparedStatement ps = this.conn.prepareStatement(query);
+        ps.setString(1, entityName);
+        ps.setString(2, this.currentSchema);
+        ps.closeOnCompletion();
+
+        return ps.executeQuery();
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -982,7 +982,7 @@ public class OracleEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addFks(DbEntity entity, final Set<DbFk> fks) throws DatabaseEngineException {
+    protected void addFks(final DbEntity entity, final Set<DbFk> fks) throws DatabaseEngineException {
         for (final DbFk fk : fks) {
             final List<String> quotizedLocalColumns = new ArrayList<>();
             for (String s : fk.getLocalColumns()) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.column;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.max;
@@ -604,8 +605,8 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addFks(DbEntity entity) throws DatabaseEngineException {
-        for (DbFk fk : entity.getFks()) {
+    protected void addFks(DbEntity entity, Set<DbFk> fks) throws DatabaseEngineException {
+        for (final DbFk fk : fks) {
             final List<String> quotizedLocalColumns = new ArrayList<>();
             for (String s : fk.getLocalColumns()) {
                 quotizedLocalColumns.add(quotize(s));
@@ -624,10 +625,14 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                     format(
                             "ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)",
                             table,
-                            quotize(md5("FK_" + table + quotizedLocalColumnsSting + quotizedForeignColumnsString, properties.getMaxIdentifierSize())),
+                            quotize(md5(
+                                    "FK_" + table + quotizedLocalColumnsSting + quotizedForeignColumnsString,
+                                    properties.getMaxIdentifierSize()
+                            )),
                             quotizedLocalColumnsSting,
                             quotize(fk.getReferencedTable()),
-                            quotizedForeignColumnsString);
+                            quotizedForeignColumnsString
+                    );
 
             Statement alterTableStmt = null;
             try {
@@ -638,7 +643,11 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                 if (ex.getSQLState().equals(CONSTRAINT_NAME_ALREADY_EXISTS)) {
                     logger.debug(dev, "Foreign key for table '{}' already exists. Error code: {}.", entity.getName(), ex.getSQLState());
                 } else {
-                    throw new DatabaseEngineException(format("Could not add Foreign Key to entity %s. Error code: %s.", entity.getName(), ex.getSQLState()), ex);
+                    throw new DatabaseEngineException(format(
+                            "Could not add Foreign Key to entity %s. Error code: %s.",
+                            entity.getName(),
+                            ex.getSQLState()
+                    ), ex);
                 }
             } finally {
                 try {
@@ -649,7 +658,6 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                     logger.trace("Error closing statement.", e);
                 }
             }
-
         }
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -605,7 +605,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addFks(DbEntity entity, Set<DbFk> fks) throws DatabaseEngineException {
+    protected void addFks(final DbEntity entity, Set<DbFk> fks) throws DatabaseEngineException {
         for (final DbFk fk : fks) {
             final List<String> quotizedLocalColumns = new ArrayList<>();
             for (String s : fk.getLocalColumns()) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -591,7 +591,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addFks(DbEntity entity, final Set<DbFk> fks) throws DatabaseEngineException {
+    protected void addFks(final DbEntity entity, final Set<DbFk> fks) throws DatabaseEngineException {
         for (final DbFk fk : fks) {
             final List<String> quotizedLocalColumns = new ArrayList<>();
             for (String s : fk.getLocalColumns()) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -43,6 +43,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
@@ -590,8 +591,8 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected void addFks(DbEntity entity) throws DatabaseEngineException {
-        for (DbFk fk : entity.getFks()) {
+    protected void addFks(DbEntity entity, final Set<DbFk> fks) throws DatabaseEngineException {
+        for (final DbFk fk : fks) {
             final List<String> quotizedLocalColumns = new ArrayList<>();
             for (String s : fk.getLocalColumns()) {
                 quotizedLocalColumns.add(quotize(s));
@@ -610,10 +611,14 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                     format(
                             "ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)",
                             table,
-                            quotize(md5("FK_" + table + quotizedLocalColumnsSting + quotizedForeignColumnsString, properties.getMaxIdentifierSize())),
+                            quotize(md5(
+                                    "FK_" + table + quotizedLocalColumnsSting + quotizedForeignColumnsString,
+                                    properties.getMaxIdentifierSize()
+                            )),
                             quotizedLocalColumnsSting,
                             quotize(fk.getReferencedTable()),
-                            quotizedForeignColumnsString);
+                            quotizedForeignColumnsString
+                    );
 
 
             Statement alterTableStmt = null;
@@ -626,7 +631,11 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                     logger.debug(dev, "Foreign key for table '{}' already exists. Error code: {}.", entity.getName(), ex.getErrorCode());
                     handleOperation(new OperationFault(entity.getName(), OperationFault.Type.FOREIGN_KEY_ALREADY_EXISTS), ex);
                 } else {
-                    throw new DatabaseEngineException(format("Could not add Foreign Key to entity %s. Error code: %d.", entity.getName(), ex.getErrorCode()), ex);
+                    throw new DatabaseEngineException(format(
+                            "Could not add Foreign Key to entity %s. Error code: %d.",
+                            entity.getName(),
+                            ex.getErrorCode()
+                    ), ex);
                 }
             } finally {
                 try {
@@ -637,7 +646,6 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                     logger.trace("Error closing statement.", e);
                 }
             }
-
         }
     }
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/ForeignKeyTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/ForeignKeyTest.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright 2021 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.engine.impl.abs;
+
+import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
+import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
+import com.feedzai.commons.sql.abstraction.ddl.DbFk;
+import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import com.google.common.collect.ImmutableList;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.INT;
+import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.STRING;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.all;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.column;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.dbEntity;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.dbFk;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.delete;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.entry;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.eq;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.k;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.select;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.table;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
+import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for foreign keys defined in the entities.
+ *
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ * @since 2.8.1
+ */
+@RunWith(Parameterized.class)
+public class ForeignKeyTest {
+
+    private DatabaseEngine engine;
+    private Properties properties;
+    private DbEntity userEntity;
+
+    @Parameterized.Parameters
+    public static Collection<DatabaseConfiguration> data() throws Exception {
+        return DatabaseTestUtil.loadConfigurations();
+    }
+
+    @Parameterized.Parameter
+    public DatabaseConfiguration config;
+
+    /**
+     * Initializes the database engine for the tests and creates a "USER" entity with 1 row, to serve as the primary table
+     * to be referenced in foreign keys from other tables.
+     *
+     * @throws Exception If there is a problem performing the test preparations.
+     */
+    @Before
+    public void init() throws Exception {
+        properties = new Properties() {
+            {
+                setProperty(JDBC, config.jdbc);
+                setProperty(USERNAME, config.username);
+                setProperty(PASSWORD, config.password);
+                setProperty(ENGINE, config.engine);
+                setProperty(SCHEMA_POLICY, "drop-create");
+            }
+        };
+
+        engine = DatabaseFactory.getConnection(properties);
+
+        userEntity = dbEntity()
+                .name("USER")
+                .addColumn("USER_ID", INT, DbColumnConstraint.UNIQUE)
+                .addColumn("AUTH_TYPE", STRING)
+                .pkFields("USER_ID", "AUTH_TYPE")
+                .build();
+
+        engine.addEntity(userEntity);
+        engine.persist("USER", entry().set("USER_ID", 1).set("AUTH_TYPE", "LOCAL").build());
+    }
+
+    @After
+    public void cleanup() {
+        engine.close();
+    }
+
+    /**
+     * Tests the usage of a foreign key in a 1-to-many relation.
+     *
+     * @throws Exception If something goes wrong in the test.
+     */
+    @Test
+    public void oneToNTest() throws Exception {
+        final DbEntity entity = dbEntity()
+                .name("ACCESS_LOG")
+                .addColumn("ENTRY_ID", INT, true)
+                .addColumn("USER_ID", INT)
+                .addFk(dbFk()
+                        .addColumn("USER_ID")
+                        .referencedTable("USER")
+                        .addReferencedColumn("USER_ID")
+                        .build()
+                )
+                .pkFields("ENTRY_ID")
+                .build();
+
+        checkForeignKeys(
+                entity,
+                // Next entry should fail, USER table doesn't contain ID 2
+                entry().set("USER_ID", 2).build(),
+                entry().set("USER_ID", 1).build(),
+                ImmutableList.of(userEntity)
+        );
+    }
+
+    /**
+     * Tests the usage of a foreign key in a 1-to-many relation, when that key is composed of 2 columns.
+     *
+     * @throws Exception If something goes wrong in the test.
+     */
+    @Test
+    public void multiColumnOneToNTest() throws Exception {
+        final DbEntity entity = dbEntity()
+                .name("ACCESS_LOG")
+                .addColumn("ENTRY_ID", INT, true)
+                .addColumn("USER_ID", INT)
+                .addColumn("USER_AUTH_TYPE", STRING)
+                .addFk(dbFk()
+                        .addColumn("USER_ID", "USER_AUTH_TYPE")
+                        .referencedTable("USER")
+                        .addReferencedColumn("USER_ID", "AUTH_TYPE")
+                        .build()
+                )
+                .pkFields("ENTRY_ID")
+                .build();
+
+        checkForeignKeys(
+                entity,
+                // USER table contains user 1, but with USER_AUTH_TYPE "LOCAL"; the FK references both columns, and since
+                // their compound values don't match existing values in the referenced table, the entry below should fail
+                entry().set("USER_ID", 1).set("USER_AUTH_TYPE", "EXTERNAL").build(),
+                entry().set("USER_ID", 1).set("USER_AUTH_TYPE", "LOCAL").build(),
+                ImmutableList.of(userEntity)
+        );
+    }
+
+    /**
+     * Tests the usage of a foreign key in a many-to-many relation.
+     *
+     * @throws Exception If something goes wrong in the test.
+     */
+    @Test
+    public void nToNTest() throws Exception {
+        final DbEntity roleEntity = dbEntity()
+                .name("ROLE")
+                .addColumn("ROLE_ID", INT)
+                .pkFields("ROLE_ID")
+                .build();
+
+        engine.addEntity(roleEntity);
+        engine.persist("ROLE", entry().set("ROLE_ID", 1).build());
+
+        // Here we create a table for the relation user-role:
+        // 1 user can have many roles, 1 role may be assigned to many users
+        final DbEntity userRoleEntity = dbEntity()
+                .name("USER_ROLE")
+                .addColumn("USER_ID", INT)
+                .addColumn("ROLE_ID", INT)
+                .addFk(dbFk()
+                                .addColumn("USER_ID")
+                                .referencedTable("USER")
+                                .addReferencedColumn("USER_ID")
+                                .build(),
+                        dbFk()
+                                .addColumn("ROLE_ID")
+                                .referencedTable("ROLE")
+                                .addReferencedColumn("ROLE_ID")
+                                .build()
+                )
+                .pkFields("USER_ID", "ROLE_ID")
+                .build();
+
+        checkForeignKeys(
+                userRoleEntity,
+                // USER table contains user 1, but ROLE table doesn't contain role 2, so the entry below should fail
+                entry().set("USER_ID", 1).set("ROLE_ID", 2).build(),
+                entry().set("USER_ID", 1).set("ROLE_ID", 1).build(),
+                ImmutableList.of(userEntity, roleEntity)
+        );
+    }
+
+    /**
+     * Helper method to verify the behavior of an entity with a foreign key.
+     * <p>
+     * This method performs the following actions:
+     * <ol>
+     *     <li>adds the entity with a foreign key constraint to the database (the primary entities are expected
+     *     to be there already)</li>
+     *     <li>checks that the foreign key constraint prevents the "invalid entry" from being persisted</li>
+     *     <li>persists the "valid entry"</li>
+     *     <li>checks that the foreign key constraint prevents rows referenced by the "valid entry" from being deleted
+     *     from the referenced entities</li>
+     * </ol>
+     *
+     * @param fkEntity           The entity with a foreign key constraint.
+     * @param invalidEntry       An entry to persist in the entity with a foreign key constraint, that should fail due
+     *                           to containing values that don't match any values in the referenced primary table.
+     * @param validEntry         A valid entry to persist in the entity with a foreign key constraint.
+     * @param referencedEntities A list of entities that are referenced in the foreign key constraint.
+     * @throws DatabaseEngineException If there is any problem adding an entity or persisting an entry.
+     */
+    private void checkForeignKeys(final DbEntity fkEntity,
+                                  final EntityEntry invalidEntry,
+                                  final EntityEntry validEntry,
+                                  final List<DbEntity> referencedEntities) throws DatabaseEngineException {
+        engine.addEntity(fkEntity);
+
+        assertThatCode(() -> engine.persist(fkEntity.getName(), invalidEntry))
+                .as("Persisting an entry in table '%s' should fail when the values for the columns defined" +
+                                " in the foreign key don't match an existing entry from the referenced table '%s'.",
+                        fkEntity.getName(),
+                        referencedEntities.stream().map(DbEntity::getName).collect(Collectors.joining(", ", "[", "]"))
+                )
+                .isInstanceOf(DatabaseEngineException.class);
+
+        engine.persist(fkEntity.getName(), validEntry);
+
+        for (final DbEntity referencedEntity : referencedEntities) {
+            assertThatCode(() -> engine.executeUpdate(delete(table(referencedEntity.getName()))))
+                    .as("Table '%s' contains rows referenced in a foreign key, attempting to delete them should result in an error.",
+                            referencedEntity.getName())
+                    .isInstanceOf(DatabaseEngineException.class);
+        }
+    }
+
+    /**
+     * Tests that attempting to delete a row referenced by a foreign key results in an error, until the row that
+     * references it is deleted.
+     *
+     * @throws Exception If something goes wrong in the test.
+     */
+    @Test
+    public void removeRowPreviouslyReferencedByForeignKeyTest() throws Exception {
+        final DbEntity fkEntity = dbEntity()
+                .name("ACCESS_LOG")
+                .addColumn("ENTRY_ID", INT, true)
+                .addColumn("USER_ID", INT)
+                .addFk(dbFk()
+                        .addColumn("USER_ID")
+                        .referencedTable("USER")
+                        .addReferencedColumn("USER_ID")
+                        .build()
+                )
+                .pkFields("ENTRY_ID")
+                .build();
+
+        engine.addEntity(fkEntity);
+
+        engine.persist(fkEntity.getName(), entry().set("USER_ID", 1).build());
+
+        final String userTable = userEntity.getName();
+        assertThatCode(() -> engine.executeUpdate(delete(table(userTable))))
+                .as("Table '%s' contains rows referenced in a foreign key, attempting to delete them should result in an error.",
+                        userTable)
+                .isInstanceOf(DatabaseEngineException.class);
+
+        // Remove the row that references the row to delete
+        engine.executeUpdate(delete(table(fkEntity.getName())).where(eq(column("USER_ID"), k(1))));
+
+        assertThatCode(() -> engine.executeUpdate(delete(table(userTable))))
+                .as("No rows are referencing rows from the primary table '%s', it should be possible to delete them.",
+                        userTable)
+                .doesNotThrowAnyException();
+    }
+
+    /**
+     * Tests that attempting to delete a row referenced by a foreign key results in an error, until the foreign key is
+     * removed.
+     *
+     * @throws Exception If something goes wrong in the test.
+     */
+    @Test
+    public void removeRowAfterRemovingForeignKeyTest() throws Exception {
+        DbEntity fkEntity = dbEntity()
+                .name("ACCESS_LOG")
+                .addColumn("ENTRY_ID", INT, true)
+                .addColumn("USER_ID", INT)
+                .addFk(dbFk()
+                        .addColumn("USER_ID")
+                        .referencedTable("USER")
+                        .addReferencedColumn("USER_ID")
+                        .build()
+                )
+                .pkFields("ENTRY_ID")
+                .build();
+
+        engine.addEntity(fkEntity);
+
+        engine.persist(fkEntity.getName(), entry().set("USER_ID", 1).build());
+
+        final String userTable = userEntity.getName();
+        assertThatCode(() -> engine.executeUpdate(delete(table(userTable))))
+                .as("Table '%s' contains rows referenced in a foreign key, attempting to delete them should result in an error.",
+                        userTable)
+                .isInstanceOf(DatabaseEngineException.class);
+
+        // PDB property SCHEMA_POLICY must not be drop-create, otherwise the entity
+        // will be dropped and the update of the FKs isn't properly tested.
+        engine.close();
+        properties.setProperty(SCHEMA_POLICY, "create");
+        engine = DatabaseFactory.getConnection(properties);
+
+        // Clear foreign keys from the entity
+        fkEntity = fkEntity.newBuilder().clearFks().build();
+        engine.updateEntity(fkEntity);
+
+        assertThatCode(() -> engine.executeUpdate(delete(table(userTable))))
+                .as("Foreign keys have been removed, it should be possible to delete rows from the primary table '%s'",
+                        userTable)
+                .doesNotThrowAnyException();
+
+        assertThat(engine.query(select(all()).from(table(fkEntity.getName()))))
+                .as("The table where the foreign key was previously defined should have kept its data (1 row).")
+                .hasSize(1);
+    }
+
+    /**
+     * Tests updating an entity in which the foreign key constraints are changed.
+     * <p>
+     * The test verifies the changes in foreign keys that are requested, with those keys being added/dropped only when
+     * necessary.
+     *
+     * @param <DB> The type of database engine for which to fake add/drop FK methods, so that parameters can be captured.
+     * @throws Exception If something goes wrong in the test.
+     */
+    @Test
+    public <DB extends AbstractDatabaseEngine> void updateForeignKeyTest() throws Exception {
+        final DbFk fk1 = dbFk()
+                .addColumn("USER_ID")
+                .referencedTable("USER")
+                .addReferencedColumn("USER_ID")
+                .build();
+
+        final DbFk fk2 = dbFk()
+                .addColumn("USER_ID", "USER_AUTH_TYPE")
+                .referencedTable("USER")
+                .addReferencedColumn("USER_ID", "AUTH_TYPE")
+                .build();
+
+        DbEntity fkEntity = dbEntity()
+                .name("ACCESS_LOG")
+                .addColumn("ENTRY_ID", INT, true)
+                .addColumn("USER_ID", INT)
+                .addColumn("USER_AUTH_TYPE", STRING)
+                .addFk(fk1)
+                .pkFields("ENTRY_ID")
+                .build();
+
+        engine.addEntity(fkEntity);
+
+        final LinkedList<String> fksToDrop = new LinkedList<>();
+        final LinkedList<DbFk> fksToAdd = new LinkedList<>();
+
+        new MockUp<DB>() {
+            @Mock
+            protected void dropFks(final Invocation inv, final String table, final Set<String> fks) {
+                fksToDrop.addAll(fks);
+                inv.proceed();
+            }
+
+            @Mock
+            protected void addFks(final Invocation inv, final DbEntity entity, final Set<DbFk> fks) {
+                fksToAdd.addAll(fks);
+                inv.proceed();
+            }
+        };
+
+        // Update 1: the entity has no changes, but since the schema policy is 'drop-create'
+        // the table will be created again along with foreign keys
+        engine.updateEntity(fkEntity);
+
+        assertThat(fksToDrop)
+                .as("When updating an entity with 'drop-create', it is first dropped along with its constraints, no need to drop FKs.")
+                .isEmpty();
+        assertThat(fksToAdd)
+                .as("When updating an entity with 'drop-create', it is first dropped and then created, so the FKs need to be created as well.")
+                .containsExactly(fk1);
+
+        fksToAdd.clear();
+
+        // PDB property SCHEMA_POLICY must not be drop-create, otherwise the entity
+        // will be dropped and the update of the FKs isn't properly tested.
+        engine.close();
+        properties.setProperty(SCHEMA_POLICY, "create");
+        engine = DatabaseFactory.getConnection(properties);
+
+        // Update 2: the entity has no changes, so with schema policy is 'create' nothing should be done
+        engine.updateEntity(fkEntity);
+
+        assertThat(fksToDrop)
+                .as("When updating an entity with 'create' policy, FKs shouldn't be dropped if the table already matches the entity .")
+                .isEmpty();
+        assertThat(fksToAdd)
+                .as("When updating an entity with 'create' policy, no FKs should be added if the table already matches the entity .")
+                .isEmpty();
+
+        fkEntity = fkEntity.newBuilder()
+                .clearFks()
+                .addFk(fk2)
+                .build();
+
+        // Update 3: the foreign key has been replaced in the entity, old one should be removed and the new one added
+        engine.updateEntity(fkEntity);
+
+        assertThat(fksToDrop)
+                .as("When updating an entity by replacing a FK, the old FK should be dropped.")
+                .hasSize(1);
+        assertThat(fksToAdd)
+                .as("When updating an entity by replacing a FK, the new FK should be added.")
+                .containsExactly(fk2);
+    }
+}

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/ForeignKeyTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/ForeignKeyTest.java
@@ -16,7 +16,6 @@
 
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
-import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
 import com.feedzai.commons.sql.abstraction.ddl.DbFk;
 import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
@@ -43,6 +42,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint.NOT_NULL;
+import static com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint.UNIQUE;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.INT;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.STRING;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.all;
@@ -112,7 +113,7 @@ public class ForeignKeyTest {
          */
         userEntity = dbEntity()
                 .name("USER")
-                .addColumn("USER_ID", INT, DbColumnConstraint.UNIQUE, DbColumnConstraint.NOT_NULL)
+                .addColumn("USER_ID", INT, UNIQUE, NOT_NULL)
                 .addColumn("AUTH_TYPE", STRING)
                 .pkFields("USER_ID", "AUTH_TYPE")
                 .build();


### PR DESCRIPTION
All the foreign keys were being dropped and added unnecessarily when an entity would be updated. This would result in running more DDL statements then needed.

To prevent this from happening a diff will be computed between the current entity foreign keys and the new one and only add or remove the differences.