### PR TITLE
Bump JMockit to 1.49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
     <properties>
         <project.source>1.8</project.source>
 
+        <default.test.cmdArgs>
+            -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+        </default.test.cmdArgs>
+
         <jmockit.version>1.49</jmockit.version>
 
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
@@ -320,9 +324,7 @@
                     <systemProperties>
                         <instances>h2</instances>
                     </systemProperties>
-                    <argLine>
-                        -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
-                    </argLine>
+                    <argLine>${default.test.cmdArgs}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -692,7 +694,7 @@
                              The following line is a workaround for "ORA-01882: timezone region not found"
                              that occurs when the Oracle DB server doesn't have the system timezone
                              -->
-                            <argLine>-Doracle.jdbc.timezoneAsRegion=false</argLine>
+                            <argLine>${default.test.cmdArgs} -Doracle.jdbc.timezoneAsRegion=false</argLine>
                             <systemProperties>
                                 <instances>oracle</instances>
                             </systemProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
     <properties>
         <project.source>1.8</project.source>
 
+        <jmockit.version>1.49</jmockit.version>
+
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
@@ -84,7 +86,7 @@
             <dependency>
                 <groupId>org.jmockit</groupId>
                 <artifactId>jmockit</artifactId>
-                <version>1.35</version>
+                <version>${jmockit.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -318,6 +320,9 @@
                     <systemProperties>
                         <instances>h2</instances>
                     </systemProperties>
+                    <argLine>
+                        -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -1532,7 +1532,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * @return The current schema name or <code>null</code> if there is none.
      * @throws DatabaseEngineException If a database access error occurs or this method is called on a closed connection.
      */
-    protected String getSchema() throws DatabaseEngineException {
+    public String getSchema() throws DatabaseEngineException {
         try {
             return this.conn.getSchema();
         } catch (final Exception e) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -866,7 +866,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected String getSchema() throws DatabaseEngineException {
+    public String getSchema() throws DatabaseEngineException {
         try (final Statement stmt = conn.createStatement();
              final ResultSet resultSet = stmt.executeQuery("VALUES(CURRENT SCHEMA)")) {
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -618,7 +618,7 @@ public class H2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected String getSchema() throws DatabaseEngineException {
+    public String getSchema() throws DatabaseEngineException {
         try {
             return this.conn.getSchema();
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -751,7 +751,7 @@ public class MySqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected String getSchema() throws DatabaseEngineException {
+    public String getSchema() throws DatabaseEngineException {
         try {
             return this.conn.getCatalog();
         } catch (final Exception e) {

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
@@ -19,6 +19,7 @@ import com.feedzai.commons.sql.abstraction.ddl.DbColumnType;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntityType;
 import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
+import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.ConnectionResetException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
@@ -29,7 +30,6 @@ import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import com.google.common.collect.Sets;
-import mockit.Deencapsulation;
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.data.MapEntry;
 import org.junit.Before;
@@ -683,8 +683,9 @@ public abstract class AbstractEngineSchemaTest {
                 // this second entry is needed because MySQL returns tables as SYSTEM_TABLEs (when they are created in default schema)
                 MapEntry.entry(name, DbEntityType.SYSTEM_TABLE)
         };
-        final String originalSchema = Deencapsulation.getField(originalEngine, "currentSchema");
-        final String otherSchema = Deencapsulation.getField(otherEngine, "currentSchema");
+
+        final String originalSchema = ((AbstractDatabaseEngine) originalEngine).getSchema();
+        final String otherSchema = ((AbstractDatabaseEngine) otherEngine).getSchema();
 
         // check metadata in the schema of the "original engine"
         final MapAssert<String, DbColumnType> originalMetadataAssert = assertThat(originalEngine.getMetadata(name))

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -4118,17 +4118,17 @@ public class EngineGeneralTest {
     }
 
     /**
-     * Tests that creating a {@link DatabaseEngine} using try-with-resources will close the engine once the block is
-     * exited from.
+     * Tests that creating a {@link DatabaseEngine} using try-with-resources will close the engine
+     * (and thus the underlying connection to the database) once the block is exited from.
      *
-     * @since 2.1.12
      * @throws Exception if something goes wrong while checking if the connection of the engine is closed.
+     * @since 2.1.12
      */
     @Test
     public void tryWithResourcesClosesEngine() throws Exception {
         final AtomicReference<Connection> connReference = new AtomicReference<>();
 
-        try(final DatabaseEngine tryEngine = this.engine) {
+        try (final DatabaseEngine tryEngine = this.engine) {
             connReference.set(tryEngine.getConnection());
             assertFalse("close() method should not be called within the try-with-resources block, for an existing DatabaseEngine",
                     connReference.get().isClosed());
@@ -4137,7 +4137,7 @@ public class EngineGeneralTest {
         assertTrue("close() method should be called after exiting try-with-resources block, for an existing DatabaseEngine",
                 connReference.get().isClosed());
 
-        try(final DatabaseEngine tryEngine = DatabaseFactory.getConnection(properties)) {
+        try (final DatabaseEngine tryEngine = DatabaseFactory.getConnection(properties)) {
             connReference.set(tryEngine.getConnection());
             assertFalse("close() method should not be called within the try-with-resources block, for a DatabaseEngine created in the block",
                     connReference.get().isClosed());

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -76,7 +76,6 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint.NOT_NULL;
@@ -4114,36 +4113,6 @@ public class EngineGeneralTest {
                 .build();
 
         assertEquals("entry's hashCode() matches map's hashCode()", map.hashCode(), entry.hashCode());
-    }
-
-    /**
-     * Tests that creating a {@link DatabaseEngine} using try-with-resources will close the engine once the block is
-     * exited from.
-     *
-     * @since 2.1.12
-     */
-    @Test
-    public void tryWithResourcesClosesEngine() {
-        final AtomicInteger closeCallCount = new AtomicInteger(0);
-
-        try(final DatabaseEngine ignored = new MockUp<DatabaseEngine>() {
-            @Mock
-            void close() {
-                closeCallCount.incrementAndGet();
-            }
-        }.getMockInstance()) {
-            assertEquals(
-                    "DatabaseEngine#close method should not be called within the try-with-resources block",
-                    0,
-                    closeCallCount.get()
-            );
-        }
-
-        assertEquals(
-                "DatabaseEngine#close method should be called after exiting try-with-resources block",
-                1,
-                closeCallCount.get()
-        );
     }
 
     /**


### PR DESCRIPTION
Summary:
Bumps JMockit version in preparation for Java 11 and beyond.