### PR TITLE
Create Batch Listener and deprecate Failure Listener

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/DefaultBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/DefaultBatch.java
@@ -17,6 +17,7 @@ package com.feedzai.commons.sql.abstraction.batch;
 
 import com.feedzai.commons.sql.abstraction.FailureListener;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
 
 /**
  * The default batch implementation.
@@ -52,10 +53,11 @@ public class DefaultBatch extends AbstractBatch {
      * @param batchSize            The batch size.
      * @param batchTimeout         The timeout.
      * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
-     * @param listener             The listener that will be invoked when batch fails to persist at least one data row.
+     * @param listener             The listener that will be invoked when batch fails or succeeds to persist at least
+     *                             one data row.
      */
     protected DefaultBatch(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout,
-                           final long maxAwaitTimeShutdown, final FailureListener listener) {
+                           final long maxAwaitTimeShutdown, final BatchListener listener) {
         super(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener);
     }
 
@@ -67,7 +69,8 @@ public class DefaultBatch extends AbstractBatch {
      * @param batchSize            The batch size.
      * @param batchTimeout         The timeout.
      * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
-     * @param listener             The listener that will be invoked when batch fails to persist at least one data row.
+     * @param listener             The listener that will be invoked when batch fails or succeeds to persist at least
+     *                             one data row.
      * @param maxFlushRetries      The number of times to retry a batch flush upon failure. Defaults to
      *                             {@value NO_RETRY}. When set to 0, no retries will be attempted.
      * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries. Defaults to
@@ -76,7 +79,7 @@ public class DefaultBatch extends AbstractBatch {
      * @since 2.1.12
      */
     protected DefaultBatch(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout,
-                           final long maxAwaitTimeShutdown, final FailureListener listener, final int maxFlushRetries,
+                           final long maxAwaitTimeShutdown, final BatchListener listener, final int maxFlushRetries,
                            final long flushRetryDelay) {
         super(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener, maxFlushRetries, flushRetryDelay);
     }
@@ -113,13 +116,12 @@ public class DefaultBatch extends AbstractBatch {
      * @return The Batch.
      *
      * @since 2.1.11
+     * @deprecated Use {@link #create(DatabaseEngine, String, int, long, long, BatchListener)} instead.
      */
+    @Deprecated
     public static DefaultBatch create(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout,
                                       final long maxAwaitTimeShutdown, final FailureListener listener) {
-        final DefaultBatch b = new DefaultBatch(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener);
-        b.start();
-
-        return b;
+        return create(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, convertToBatchListener(listener));
     }
 
     /**
@@ -139,20 +141,77 @@ public class DefaultBatch extends AbstractBatch {
      * @return The Batch.
      *
      * @since 2.1.12
+     * @deprecated Use {@link #create(DatabaseEngine, String, int, long, long, BatchListener, int, long)} intead.
      */
+    @Deprecated
     public static DefaultBatch create(final DatabaseEngine de, final String name, final int batchSize,
                                       final long batchTimeout, final long maxAwaitTimeShutdown,
                                       final FailureListener listener, final int maxFlushRetries,
                                       final long flushRetryDelay) {
+        return create(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, convertToBatchListener(listener), maxFlushRetries, flushRetryDelay);
+    }
+
+    /**
+     * <p>Creates a new instance of {@link DefaultBatch} with a {@link BatchListener}.</p>
+     * <p>Starts the timertask.</p>
+     *
+     * @param de                   The database engine.
+     * @param name                 The batch name.
+     * @param batchSize            The batch size.
+     * @param batchTimeout         The batch timeout.
+     * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
+     * @param listener             The listener that will be invoked when batch fails to persist at least one data row.
+     * @return The Batch.
+     *
+     * @since 2.8.1
+     */
+    public static DefaultBatch create(final DatabaseEngine de,
+                                      final String name,
+                                      final int batchSize,
+                                      final long batchTimeout,
+                                      final long maxAwaitTimeShutdown,
+                                      final BatchListener listener) {
+        final DefaultBatch b = new DefaultBatch(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener);
+        b.start();
+
+        return b;
+    }
+
+    /**
+     * <p>Creates a new instance of {@link DefaultBatch} with a {@link BatchListener}.</p>
+     * <p>Starts the timertask.</p>
+     *
+     * @param de                   The database engine.
+     * @param name                 The batch name.
+     * @param batchSize            The batch size.
+     * @param batchTimeout         The batch timeout.
+     * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
+     * @param listener             The listener that will be invoked when batch fails to persist at least one data row.
+     * @param maxFlushRetries      The number of times to retry a batch flush upon failure. Defaults to
+     *                             {@value NO_RETRY}. When set to 0, no retries will be attempted.
+     * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries. Defaults to
+     *                             {@value DEFAULT_RETRY_INTERVAL}.
+     * @return The Batch.
+     *
+     * @since 2.8.1
+     */
+    public static DefaultBatch create(final DatabaseEngine de,
+                                      final String name,
+                                      final int batchSize,
+                                      final long batchTimeout,
+                                      final long maxAwaitTimeShutdown,
+                                      final BatchListener listener,
+                                      final int maxFlushRetries,
+                                      final long flushRetryDelay) {
         final DefaultBatch b = new DefaultBatch(
-                de,
-                name,
-                batchSize,
-                batchTimeout,
-                maxAwaitTimeShutdown,
-                listener,
-                maxFlushRetries,
-                flushRetryDelay
+            de,
+            name,
+            batchSize,
+            batchTimeout,
+            maxAwaitTimeShutdown,
+            listener,
+            maxFlushRetries,
+            flushRetryDelay
         );
         b.start();
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -35,6 +35,7 @@ import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableException;
 import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableRuntimeException;
+import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
 import com.feedzai.commons.sql.abstraction.util.AESHelper;
 import com.feedzai.commons.sql.abstraction.util.Constants;
 import com.feedzai.commons.sql.abstraction.util.InitiallyReusableByteArrayOutputStream;
@@ -48,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
+import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -1008,12 +1010,17 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
 
     @Override
     public AbstractBatch createBatch(final int batchSize, final long batchTimeout, final String batchName) {
-        return createBatch(batchSize, batchTimeout, batchName, AbstractBatch.NO_OP);
+        return createBatch(batchSize, batchTimeout, batchName, (BatchListener) null);
     }
 
     @Override
     public AbstractBatch createBatch(int batchSize, long batchTimeout, String batchName, final FailureListener failureListener) {
-        return DefaultBatch.create(this, batchName, batchSize, batchTimeout, properties.getMaximumAwaitTimeBatchShutdown(), failureListener);
+        return createBatch(batchSize, batchTimeout, batchName, AbstractBatch.convertToBatchListener(failureListener));
+    }
+
+    @Override
+    public AbstractBatch createBatch(int batchSize, long batchTimeout, String batchName, @Nullable final BatchListener batchListener) {
+        return DefaultBatch.create(this, batchName, batchSize, batchTimeout, properties.getMaximumAwaitTimeBatchShutdown(), batchListener);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/listeners/BatchListener.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/listeners/BatchListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Feedzai
+ * Copyright 2021 Feedzai
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.feedzai.commons.sql.abstraction;
+package com.feedzai.commons.sql.abstraction.listeners;
 
 import com.feedzai.commons.sql.abstraction.batch.BatchEntry;
 
 /**
- * Listener interface to add behavior when there is some failure executing batch
+ * Listener interface to add behavior after executing batch
  * operations on databases (e.g. write rows to file).
  *
- * @author Helder Martins (helder.martins@feedzai.com).
- * @since 2.1.11
- * @deprecated Use {@link com.feedzai.commons.sql.abstraction.listeners.BatchListener} instead.
+ * @author João Fernandes (joao.fernandes@feedzai.com)
+ * @since 2.8.1
  */
-@Deprecated
-@FunctionalInterface
-public interface FailureListener {
+public interface BatchListener {
 
     /**
      * Callback indicating that one or more rows have failed to be persisted.
@@ -35,4 +32,11 @@ public interface FailureListener {
      * @param rowsFailed An array of {@link BatchEntry entries} with the row or rows that failed to be persisted.
      */
     void onFailure(BatchEntry[] rowsFailed);
+
+    /**
+     * Callback indicating that one or more rows have succeeded to be persisted.
+     *
+     * @param rowsSucceeded An array of {@link BatchEntry entries} with the row or rows that succeeded to be persisted.
+     */
+    void onSuccess(BatchEntry[] rowsSucceeded);
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/listeners/package-info.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/listeners/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The listeners interfaces for the pdb.
+ *
+ * @since 2.8.1
+ */
+package com.feedzai.commons.sql.abstraction.listeners;


### PR DESCRIPTION
This commit replaces the old Failure Listener for batch operations by a Batch Listener that allows to not just listen the failed batch entries but also the ones that succeeded.