### PR TITLE
Add a retry logic when Oracle Database removes an object from the cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,11 @@
                 <artifactId>guice</artifactId>
                 <version>5.0.1</version>
             </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>1.18.20</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -231,6 +236,11 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -296,6 +296,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
         }
 
         this.conn = DriverManager.getConnection(jdbc, props);
+        printDatabaseInformation();
 
         this.conn.setNetworkTimeout(socketTimeoutExecutor, (int) TimeUnit.SECONDS.toMillis(this.properties.getSocketTimeout()));
 
@@ -309,6 +310,21 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
         setTransactionIsolation();
 
         logger.debug("Connection successful.");
+    }
+
+    /**
+     * Helper method that prints the version of the Database.
+     */
+    public void printDatabaseInformation() {
+        try {
+            final DatabaseMetaData metaData = this.conn.getMetaData();
+
+            logger.info("Database: {}", metaData.getDatabaseProductName());
+            logger.info("Database version: {}", metaData.getDatabaseProductVersion());
+            logger.info("JDBC version: {}", metaData.getDriverVersion());
+        } catch (final SQLException ex) {
+            this.logger.error("Couldn't retrieve the database information.");
+        }
     }
 
     /**
@@ -415,7 +431,13 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
         }
     }
 
-    private synchronized void recover() throws DatabaseEngineException, NameAlreadyExistsException {
+    /**
+     * Clears entities and prepared statements cache.
+     *
+     * @throws DatabaseEngineException    If an error occurs.
+     * @throws NameAlreadyExistsException If an error occurs.
+     */
+    protected synchronized void recover() throws DatabaseEngineException, NameAlreadyExistsException {
         // Recover entities.
         final Map<String, MappedEntity> niw = new HashMap<>(entities);
         // clear the entities
@@ -862,17 +884,12 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
                                            final boolean useAutoInc) throws DatabaseEngineException {
         reconnectExceptionally(String.format("Connection error while persisting entity '%s'", name));
 
-        final MappedEntity me = entities.get(name);
-        if (me == null) {
-            throw new DatabaseEngineException(String.format("Unknown entity '%s'", name));
-        }
+        final MappedEntity me = getMappedEntityFromCache(name);
 
-        final PreparedStatement ps = getPreparedStatementForPersist(useAutoInc, me);
-
-        final int lastBindPosition = entityToPreparedStatement(me.getEntity(), ps, entry, useAutoInc);
+        final PreparedStatementWrapper preparedStatementWrapper = entityToPreparedStatement(me.getEntity(), entry, useAutoInc);
 
         try {
-            final long ret = doPersist(ps, me, useAutoInc, lastBindPosition);
+            final long ret = doPersist(preparedStatementWrapper, me, useAutoInc);
             return ret == 0 ? null : ret;
 
         } catch (final DatabaseEngineException | DatabaseEngineRuntimeException dbex) {
@@ -880,6 +897,42 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
         } catch (final Exception ex) {
             throw getQueryExceptionHandler().handleException(ex, "Something went wrong persisting the entity");
         }
+    }
+
+    /**
+     * Helper method that retrieves the {@link MappedEntity} from PDB cache.
+     *
+     * @param name The name of the {@link MappedEntity} to retrive.
+     * @return The {@link MappedEntity} from PDB cache.
+     * @throws DatabaseEngineException If the {@link MappedEntity} is not present in the cache.
+     */
+    protected MappedEntity getMappedEntityFromCache(final String name) throws DatabaseEngineException {
+        final MappedEntity me = this.entities.get(name);
+        if (me == null) {
+            throw new DatabaseEngineException(String.format("Unknown entity '%s'", name));
+        }
+        return me;
+    }
+
+    /**
+     * Helper method that gets a {@link PreparedStatement} for a specific {@link DbEntity}.
+     *
+     * @param entity     The entity name.
+     * @param useAutoInc Use or not the autoinc.
+     * @param fromBatch   Indicates if this is being requested in the context of a batch update or not.
+     * @return The {@link PreparedStatement}.
+     * @throws DatabaseEngineException If the {@link MappedEntity} is not present in the cache.
+     */
+    protected PreparedStatement getPreparedStatement(DbEntity entity, boolean useAutoInc, boolean fromBatch) throws DatabaseEngineException {
+        // Retrieve the MappedEntity from the cache.
+        final MappedEntity me = getMappedEntityFromCache(entity.getName());
+        final PreparedStatement ps;
+        if (fromBatch) {
+            ps = me.getInsert();
+        } else {
+            ps = getPreparedStatementForPersist(useAutoInc, me);
+        }
+        return ps;
     }
 
     /**
@@ -901,16 +954,14 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * @param ps               The {@link PreparedStatement} to use in the persist operation
      * @param me               The mapped entity on which to persist.
      * @param useAutoInc       Whether to use autoInc.
-     * @param lastBindPosition The position (1-based) of the last bind parameter that was filled in the prepared statement.
      * @return The ID of the auto generated value ({@code 0} if there's no auto generated value). If the table has more
      * than 1 column with auto generated values, then it will return the first column found.
      * @throws Exception if any problem occurs while persisting.
      * @since 2.5.1
      */
-    protected abstract long doPersist(final PreparedStatement ps,
+    protected abstract long doPersist(final PreparedStatementWrapper ps,
                                       final MappedEntity me,
-                                      final boolean useAutoInc,
-                                      int lastBindPosition) throws Exception;
+                                      final boolean useAutoInc) throws Exception;
 
     /**
      * Flushes the batches for all the registered entities.
@@ -1257,16 +1308,12 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
 
         try {
 
-            final MappedEntity me = entities.get(name);
+            final MappedEntity me = getMappedEntityFromCache(name);
 
-            if (me == null) {
-                throw new DatabaseEngineException(String.format("Unknown entity '%s'", name));
-            }
+            final PreparedStatementWrapper preparedStatementWrapper =
+                entityToPreparedStatementForBatch(me.getEntity(), entry, true);
 
-            PreparedStatement ps = me.getInsert();
-            entityToPreparedStatementForBatch(me.getEntity(), ps, entry, true);
-
-            ps.addBatch();
+            preparedStatementWrapper.getPreparedStatement().addBatch();
         } catch (final Exception ex) {
             throw new DatabaseEngineException("Error adding to batch", ex);
         }
@@ -1278,28 +1325,45 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
      * batch updates. This is to be overriden on engines where a distinct treatment is required
      * for these situations.
      *
-     * @param entity The entity.
-     * @param ps     The prepared statement.
-     * @param entry  The entry.
-     * @return The position (1-based) of the last bind parameter that was filled in a prepared statement.
+     * @param entity      The entity.
+     * @param entry       The entry.
+     * @param useAutoIncs True to use auto incrementation, false otherwise.
+     * @return The {@link PreparedStatementWrapper} which has the translated {@link PreparedStatement}
+     * and the position (1-based) of the last bind parameter that was filled in there.
      * @throws DatabaseEngineException if something occurs during the translation.
      *
      * @since 2.4.2
      */
-    protected int entityToPreparedStatementForBatch(final DbEntity entity, final PreparedStatement ps, final EntityEntry entry, final boolean useAutoIncs) throws DatabaseEngineException {
-        return entityToPreparedStatement(entity, ps, entry, useAutoIncs);
+    protected PreparedStatementWrapper entityToPreparedStatementForBatch(final DbEntity entity, final EntityEntry entry, final boolean useAutoIncs) throws DatabaseEngineException {
+        return entityToPreparedStatement(entity, entry, useAutoIncs, true);
     }
 
     /**
      * Translates the given entry entity to the prepared statement.
      *
-     * @param entity The entity.
-     * @param ps     The prepared statement.
-     * @param entry  The entry.
-     * @return The position (1-based) of the last bind parameter that was filled in a prepared statement.
+     * @param entity      The entity.
+     * @param entry       The entry.
+     * @param useAutoIncs True to use auto incrementation, false otherwise.
+     * @return The {@link PreparedStatementWrapper} which has the translated {@link PreparedStatement}
+     * and the position (1-based) of the last bind parameter that was filled in there.
      * @throws DatabaseEngineException if something occurs during the translation.
      */
-    protected abstract int entityToPreparedStatement(final DbEntity entity, final PreparedStatement ps, final EntityEntry entry, final boolean useAutoIncs) throws DatabaseEngineException;
+    protected PreparedStatementWrapper entityToPreparedStatement(final DbEntity entity, final EntityEntry entry, final boolean useAutoIncs) throws DatabaseEngineException {
+        return entityToPreparedStatement(entity, entry, useAutoIncs, false);
+    }
+
+    /**
+     * Translates the given entry entity to the prepared statement.
+     *
+     * @param entity      The entity.
+     * @param entry       The entry.
+     * @param useAutoIncs True to use auto incrementation, false otherwise.
+     * @param fromBatch   Indicates if this is being requested in the context of a batch update or not.
+     * @return The {@link PreparedStatementWrapper} which has the translated {@link PreparedStatement}
+     * and the position (1-based) of the last bind parameter that was filled in there.
+     * @throws DatabaseEngineException if something occurs during the translation.
+     */
+    protected abstract PreparedStatementWrapper entityToPreparedStatement(final DbEntity entity, final EntityEntry entry, final boolean useAutoIncs, final boolean fromBatch) throws DatabaseEngineException;
 
     /**
      * Executes the given query.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/PreparedStatementWrapper.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/PreparedStatementWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * The copyright of this file belongs to Feedzai. The file cannot be
+ * reproduced in whole or in part, stored in a retrieval system,
+ * transmitted in any form, or by any means electronic, mechanical,
+ * photocopying, or otherwise, without the prior permission of the owner.
+ *
+ * (c) 2021 Feedzai, Strictly Confidential
+ */
+package com.feedzai.commons.sql.abstraction.engine;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.PreparedStatement;
+
+/**
+ * Wrapper class for the {@link PreparedStatement} which adds more information
+ * like the index of the last bind parameter that was filled in the prepared statement.
+ *
+ * @author Tiago Silva (tiago.silva@feedzai.com)
+ * @since 2.8.3
+ */
+@Builder
+public class PreparedStatementWrapper {
+    /**
+     * The {@link PreparedStatement} to use in the operation.
+     */
+    @Getter
+    PreparedStatement preparedStatement;
+
+    /**
+     * The position (1-based) of the last bind parameter that was filled in the prepared statement.
+     */
+    @Getter
+    int lastBindPosition;
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -32,6 +32,7 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
+import com.feedzai.commons.sql.abstraction.engine.PreparedStatementWrapper;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
@@ -113,7 +114,9 @@ public class DB2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected int entityToPreparedStatement(final DbEntity entity, final PreparedStatement ps, final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
+    protected PreparedStatementWrapper entityToPreparedStatement(final DbEntity entity, final EntityEntry entry, final boolean useAutoInc, final boolean fromBatch) throws DatabaseEngineException {
+        final PreparedStatement ps = getPreparedStatement(entity, useAutoInc, fromBatch);
+
         int i = 1;
         for (DbColumn column : entity.getColumns()) {
             if (column.isAutoInc() && useAutoInc) {
@@ -158,7 +161,10 @@ public class DB2Engine extends AbstractDatabaseEngine {
             i++;
         }
 
-        return i - 1;
+        return PreparedStatementWrapper.builder()
+            .preparedStatement(ps)
+            .lastBindPosition(i - 1)
+            .build();
     }
 
     @Override
@@ -604,11 +610,10 @@ public class DB2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected synchronized long doPersist(final PreparedStatement ps,
+    protected synchronized long doPersist(final PreparedStatementWrapper ps,
                                           final MappedEntity me,
-                                          final boolean useAutoInc,
-                                          int lastBindPosition) throws Exception {
-        ps.execute();
+                                          final boolean useAutoInc) throws Exception {
+        ps.getPreparedStatement().execute();
 
         if (me.getAutoIncColumn() == null) {
             return 0;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -28,6 +28,7 @@ import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
+import com.feedzai.commons.sql.abstraction.engine.PreparedStatementWrapper;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
@@ -129,7 +130,8 @@ public class H2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected int entityToPreparedStatement(final DbEntity entity, final PreparedStatement ps, final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
+    protected PreparedStatementWrapper entityToPreparedStatement(final DbEntity entity, final EntityEntry entry, final boolean useAutoInc, final boolean fromBatch) throws DatabaseEngineException {
+        final PreparedStatement ps = getPreparedStatement(entity, useAutoInc, fromBatch);
 
         int i = 1;
         for (DbColumn column : entity.getColumns()) {
@@ -174,7 +176,10 @@ public class H2Engine extends AbstractDatabaseEngine {
             i++;
         }
 
-        return i - 1;
+        return PreparedStatementWrapper.builder()
+            .preparedStatement(ps)
+            .lastBindPosition(i - 1)
+            .build();
     }
 
     private DbEntity injectNotNullIfMissing(DbEntity entity) {
@@ -542,15 +547,14 @@ public class H2Engine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected synchronized long doPersist(final PreparedStatement ps,
+    protected synchronized long doPersist(final PreparedStatementWrapper ps,
                                           final MappedEntity me,
-                                          final boolean useAutoInc,
-                                          final int lastBindPosition) throws Exception {
-        ps.execute();
+                                          final boolean useAutoInc) throws Exception {
+        ps.getPreparedStatement().execute();
 
         final String autoIncColumnName = me.getAutoIncColumn();
         if (useAutoInc && autoIncColumnName != null) {
-            try (final ResultSet generatedKeys = ps.getGeneratedKeys()) {
+            try (final ResultSet generatedKeys = ps.getPreparedStatement().getGeneratedKeys()) {
                 if (generatedKeys.next()) {
                     // These generated keys belong to the primary key and might not have auto incremented values nor
                     // even have integer values.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -30,6 +30,7 @@ import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
+import com.feedzai.commons.sql.abstraction.engine.PreparedStatementWrapper;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
@@ -116,7 +117,8 @@ public class MySqlEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected int entityToPreparedStatement(final DbEntity entity, final PreparedStatement ps, final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
+    protected PreparedStatementWrapper entityToPreparedStatement(final DbEntity entity, final EntityEntry entry, final boolean useAutoInc, final boolean fromBatch) throws DatabaseEngineException {
+        final PreparedStatement ps = getPreparedStatement(entity, useAutoInc, fromBatch);
 
         int i = 1;
         for (DbColumn column : entity.getColumns()) {
@@ -172,7 +174,10 @@ public class MySqlEngine extends AbstractDatabaseEngine {
             i++;
         }
 
-        return i - 1;
+        return PreparedStatementWrapper.builder()
+            .preparedStatement(ps)
+            .lastBindPosition(i - 1)
+            .build();
     }
 
     @Override
@@ -551,14 +556,13 @@ public class MySqlEngine extends AbstractDatabaseEngine {
         return useAutoInc ? mappedEntity.getInsert() : mappedEntity.getInsertWithAutoInc();
     }
 
-    protected synchronized long doPersist(final PreparedStatement ps,
+    protected synchronized long doPersist(final PreparedStatementWrapper ps,
                                           final MappedEntity me,
-                                          final boolean useAutoInc,
-                                          int lastBindPosition) throws Exception {
-        ps.execute();
+                                          final boolean useAutoInc) throws Exception {
+        ps.getPreparedStatement().execute();
 
         if (useAutoInc) {
-            try (final ResultSet generatedKeys = ps.getGeneratedKeys()) {
+            try (final ResultSet generatedKeys = ps.getPreparedStatement().getGeneratedKeys()) {
                 if (generatedKeys.next()) {
                     return generatedKeys.getLong(1);
                 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -32,6 +32,7 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineDriver;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
 import com.feedzai.commons.sql.abstraction.engine.NameAlreadyExistsException;
+import com.feedzai.commons.sql.abstraction.engine.PreparedStatementWrapper;
 import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
@@ -88,6 +89,10 @@ public class OracleEngine extends AbstractDatabaseEngine {
      * Table can have only one primary key.
      */
     public static final String TABLE_CAN_ONLY_HAVE_ONE_PRIMARY_KEY = "ORA-02260";
+    /**
+     * Object no longer exists.
+     */
+    public static final String OBJECT_NO_LONGER_EXISTS = "ORA-08103";
     /**
      * Sequence does not exist.
      */
@@ -162,8 +167,11 @@ public class OracleEngine extends AbstractDatabaseEngine {
      * @param properties The properties for the database connection.
      * @throws DatabaseEngineException When the connection fails.
      */
-    public OracleEngine(PdbProperties properties) throws DatabaseEngineException {
+    public OracleEngine(final PdbProperties properties) throws DatabaseEngineException {
         super(ORACLE_DRIVER, properties, Dialect.ORACLE);
+
+        // Generate Trace Files on Ora Error
+        query("alter system set events '08103 trace name errorstack level 3, lifetime 10'");
     }
 
     @Override
@@ -188,6 +196,15 @@ public class OracleEngine extends AbstractDatabaseEngine {
     protected void connect() throws Exception {
         super.connect();
 
+        try {
+            // Generate Trace Files on Ora Error
+            query("alter session set events '08103 trace name errorstack level 3'");
+            logger.debug("PDB enabled Oracle trace logs for `ORA-08103` errors with success!");
+        } catch (final Exception ex) {
+            logger.debug("PDB couldn't enable Oracle trace logs for `ORA-08103` errors.\n" +
+                "If it is desired to enable the trace logs, its necessary to grant privileges for the user:\n" +
+                "grant alter session to <user>;");
+        }
         if (this.properties.isLobCachingDisabled()) {
             // need to enable this for the session in order to clean temporary segment usage when cached LOBs are freed
             // (followup for https://github.com/feedzai/pdb/issues/114)
@@ -230,113 +247,152 @@ public class OracleEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected int entityToPreparedStatementForBatch(final DbEntity entity, final PreparedStatement originalPs, final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
-        return entityToPreparedStatement(entity, originalPs, entry, useAutoInc, true);
+    protected PreparedStatementWrapper entityToPreparedStatementForBatch(final DbEntity entity, final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
+        return entityToPreparedStatement(entity, entry, useAutoInc, true);
     }
 
     @Override
-    protected int entityToPreparedStatement(final DbEntity entity, final PreparedStatement originalPs, final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
-        return entityToPreparedStatement(entity, originalPs, entry, useAutoInc, false);
+    protected PreparedStatementWrapper entityToPreparedStatement(final DbEntity entity,final EntityEntry entry, final boolean useAutoInc) throws DatabaseEngineException {
+        return entityToPreparedStatement(entity, entry, useAutoInc, false);
     }
 
     /**
      * Translates the given entry entity to the prepared statement.
      *
      * @param entity        The entity.
-     * @param originalPs    The prepared statement.
      * @param entry         The entry.
+     * @param useAutoInc    Use or not the autoinc.
      * @param fromBatch     Indicates if this is being requested in the context of a
      *                      batch update or not.
      *
-     * @return The position of the last bind parameter that was filled in a prepared statement.
+     * @return The {@link PreparedStatementWrapper} which has the translated {@link PreparedStatement}
+     * and the position (1-based) of the last bind parameter that was filled in there.
      * @throws DatabaseEngineException if something occurs during the translation.
      *
      * @since 2.4.2
      */
-    private int entityToPreparedStatement(final DbEntity entity,
-                                          final PreparedStatement originalPs,
-                                          final EntityEntry entry,
-                                          final boolean useAutoInc,
-                                          final boolean fromBatch) throws DatabaseEngineException {
-        final OraclePreparedStatement ps = (OraclePreparedStatement) originalPs;
-        int i = 1;
-        for (final DbColumn column : entity.getColumns()) {
-            if (column.isAutoInc() && useAutoInc) {
-                continue;
+    @Override
+    protected PreparedStatementWrapper entityToPreparedStatement(final DbEntity entity,
+                                                                 final EntityEntry entry,
+                                                                 final boolean useAutoInc,
+                                                                 final boolean fromBatch) throws DatabaseEngineException {
+        final int maxRetriesSQLExceptions = 3;
+
+        for (int retryCount = 0; retryCount <= maxRetriesSQLExceptions; retryCount++) {
+            // Retrieve the MappedEntity from the cache after cleaning it up and recreate all the entities.
+            final MappedEntity me = getMappedEntityFromCache(entity.getName());
+            final OraclePreparedStatement ps;
+            if (fromBatch) {
+                ps = (OraclePreparedStatement) me.getInsert();
+            } else {
+                ps = (OraclePreparedStatement) getPreparedStatementForPersist(useAutoInc, me);
             }
 
-            try {
-                final Object val;
-                if (column.isDefaultValueSet() && !entry.containsKey(column.getName())) {
-                    val = column.getDefaultValue().getConstant();
-                } else {
-                    val = entry.get(column.getName());
+
+            int i = 1;
+            boolean error = false;
+            for (final DbColumn column : entity.getColumns()) {
+                if (column.isAutoInc() && useAutoInc) {
+                    continue;
                 }
-                switch (column.getDbColumnType()) {
-                    case BLOB:
-                        final byte[] valArray = objectToArray(val);
-                        if (fromBatch && valArray.length > MIN_SIZE_FOR_BLOB) {
-                            // Use a blob for columns greater than 4K when inside a batch
-                            // update because the Oracle driver creates one and only releases
-                            // it when the PreparedStatement is closed. This will be closed
-                            // explicitly when the batch is flushed.
-                            final Blob blob = ps.getConnection().createBlob();
-                            blob.setBytes(1, valArray);
-                            ps.setBlob(i, blob);
-                            postFlushActions.add(blob::free);
-                        } else {
-                            ps.setBytesForBlob(i, valArray);
-                        }
-                        break;
-                    case JSON:
-                    case CLOB:
-                        if (val == null) {
-                            ps.setNull(i, Types.CLOB);
-                            break;
-                        }
-                        if (val instanceof String) {
-                            final String valString = (String) val;
-                            if (fromBatch && valString.length() > MIN_SIZE_FOR_CLOB) {
-                                // Use a clob for columns greater than 35K when inside a batch
+
+                try {
+                    final Object val;
+                    if (column.isDefaultValueSet() && !entry.containsKey(column.getName())) {
+                        val = column.getDefaultValue().getConstant();
+                    } else {
+                        val = entry.get(column.getName());
+                    }
+                    switch (column.getDbColumnType()) {
+                        case BLOB:
+                            final byte[] valArray = objectToArray(val);
+                            if (fromBatch && valArray.length > MIN_SIZE_FOR_BLOB) {
+                                // Use a blob for columns greater than 4K when inside a batch
                                 // update because the Oracle driver creates one and only releases
                                 // it when the PreparedStatement is closed. This will be closed
                                 // explicitly when the batch is flushed.
-                                final Clob clob = ps.getConnection().createClob();
-                                clob.setString(1, valString);
-                                ps.setClob(i, clob);
-                                postFlushActions.add(clob::free);
+                                final Blob blob = ps.getConnection().createBlob();
+                                blob.setBytes(1, valArray);
+                                ps.setBlob(i, blob);
+                                this.postFlushActions.add(blob::free);
                             } else {
-                                ps.setStringForClob(i, valString);
+                                ps.setBytesForBlob(i, valArray);
                             }
-                        } else {
-                            throw new DatabaseEngineException("Cannot convert " + val.getClass().getSimpleName() + " to String. CLOB columns only accept Strings.");
-                        }
-                        break;
-                    case BOOLEAN:
-                        Boolean b = (Boolean) val;
-                        if (b == null) {
-                            ps.setObject(i, null);
-                        } else if (b) {
-                            ps.setObject(i, "1");
-                        } else {
-                            ps.setObject(i, "0");
-                        }
+                            break;
+                        case JSON:
+                        case CLOB:
+                            if (val == null) {
+                                ps.setNull(i, Types.CLOB);
+                                break;
+                            }
+                            if (val instanceof String) {
+                                final String valString = (String) val;
+                                if (fromBatch && valString.length() > MIN_SIZE_FOR_CLOB) {
+                                    // Use a clob for columns greater than 35K when inside a batch
+                                    // update because the Oracle driver creates one and only releases
+                                    // it when the PreparedStatement is closed. This will be closed
+                                    // explicitly when the batch is flushed.
+                                    final Clob clob = ps.getConnection().createClob();
+                                    clob.setString(1, valString);
+                                    ps.setClob(i, clob);
+                                    this.postFlushActions.add(clob::free);
+                                } else {
+                                    ps.setStringForClob(i, valString);
+                                }
+                            } else {
+                                throw new DatabaseEngineException("Cannot convert " + val.getClass().getSimpleName() + " to String. CLOB columns only accept Strings.");
+                            }
+                            break;
+                        case BOOLEAN:
+                            Boolean b = (Boolean) val;
+                            if (b == null) {
+                                ps.setObject(i, null);
+                            } else if (b) {
+                                ps.setObject(i, "1");
+                            } else {
+                                ps.setObject(i, "0");
+                            }
 
+                            break;
+                        case DOUBLE:
+                            setParameterValues(ps, i, val);
+                            break;
+                        default:
+                            ps.setObject(i, ensureNoUnderflow(val));
+                    }
+                    i++;
+                } catch (final SQLException ex) {
+                    error = true;
+                    this.logger.debug("Something went wrong persisting the entity '{}'", entity.getName());
+                    printDatabaseInformation();
+                    if (ex.getMessage().startsWith(OBJECT_NO_LONGER_EXISTS)) {
+                        if (retryCount >= maxRetriesSQLExceptions) {
+                            throw new DatabaseEngineException(ex.getMessage(), ex);
+                        }
+                        this.logger.debug("Will clear PDB entities and prepared statements cache and will try again.");
+                        try {
+                            // If Oracle fails with an `SQLException`.
+                            // Clear the cache and recreate all PreparedStatements and MappedEntities.
+                            recover();
+                        } catch (final NameAlreadyExistsException ex2) {
+                            final String msg = String.format("Something went wrong persisting the entity '%s'", entity.getName());
+                            throw getQueryExceptionHandler().handleException(ex2, msg);
+                        }
                         break;
-                    case DOUBLE:
-                        setParameterValues(ps, i, val);
-                        break;
-                    default:
-                        ps.setObject(i, ensureNoUnderflow(val));
+                    } else {
+                        throw new DatabaseEngineException("Error while mapping variables to database", ex);
+                    }
+                } catch (final Exception ex) {
+                    throw new DatabaseEngineException("Error while mapping variables to database", ex);
                 }
-            } catch (final Exception ex) {
-                throw new DatabaseEngineException("Error while mapping variables to database", ex);
-            }
 
-            i++;
+            }
+            if (!error) {
+                return PreparedStatementWrapper.builder().preparedStatement(ps).lastBindPosition(i - 1).build();
+            }
         }
 
-        return i - 1;
+        throw new DatabaseEngineException("Error while mapping variables to database");
     }
 
     @Override
@@ -886,13 +942,12 @@ public class OracleEngine extends AbstractDatabaseEngine {
     }
 
     @Override
-    protected synchronized long doPersist(final PreparedStatement ps,
+    protected synchronized long doPersist(final PreparedStatementWrapper ps,
                                           final MappedEntity me,
-                                          final boolean useAutoInc,
-                                          int lastBindPosition) throws Exception {
-        final OraclePreparedStatement oraclePs = ps.unwrap(OraclePreparedStatement.class);
+                                          final boolean useAutoInc) throws Exception {
+        final OraclePreparedStatement oraclePs = ps.getPreparedStatement().unwrap(OraclePreparedStatement.class);
         if (useAutoInc) {
-            oraclePs.registerReturnParameter(lastBindPosition + 1, OracleTypes.NUMBER);
+            oraclePs.registerReturnParameter(ps.getLastBindPosition() + 1, OracleTypes.NUMBER);
         }
 
         oraclePs.execute();


### PR DESCRIPTION
This commit improves the resilience of setting up PreparedStatements for
Oracle databases.
It adds a retry mechanism when the Oracle JDBC driver gives an exception when
the database deletes references for some of the objects, like the
PreparedStatements or temporary objects like temporary CLobs used when
preparing the statements.