### PR TITLE
Remove usage of Guava `Preconditions` due to conflict of versions

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -20,7 +20,6 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
@@ -31,6 +30,7 @@ import org.slf4j.MarkerFactory;
 import javax.annotation.Nullable;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -170,7 +170,7 @@ public abstract class AbstractBatch implements Runnable {
         @Nullable final BatchListener batchListener,
         final int maxFlushRetries,
         final long flushRetryDelay) {
-        Preconditions.checkNotNull(de, "The provided database engine is null.");
+        Objects.requireNonNull(de, "The provided database engine is null.");
 
         this.de = de;
         this.batchSize = batchSize;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/ddl/DbFk.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/ddl/DbFk.java
@@ -15,7 +15,6 @@
  */
 package com.feedzai.commons.sql.abstraction.ddl;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.io.Serializable;
@@ -258,11 +257,17 @@ public class DbFk implements Serializable {
 
         @Override
         public DbFk build() {
-            Preconditions.checkNotNull(referencedTable, "The referenced table can't be null.");
-            Preconditions.checkArgument(localColumns.size() == referencedColumns.size(),
-                    "The number of local columns and referenced columns must be the same. local: %s ; referenced: %s",
-                    localColumns, referencedColumns
-            );
+            Objects.requireNonNull(this.referencedTable, "The referenced table can't be null");
+
+            if (this.localColumns.size() != this.referencedColumns.size()) {
+                throw new IllegalArgumentException (
+                    String.format("The number of local columns and referenced columns must be the same. local: %s ; referenced: %s",
+                        this.localColumns,
+                        this.referencedColumns
+                    )
+                );
+            }
+
             return new DbFk(this);
         }
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -37,7 +37,6 @@ import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.engine.impl.oracle.OracleQueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OraclePreparedStatement;
@@ -1151,7 +1150,7 @@ public class OracleEngine extends AbstractDatabaseEngine {
 
     private DbColumnType toPdbType(String type) {
         // We want to override the default mappings depending on number precision.
-        Preconditions.checkNotNull(type, "Type cannot be null.");
+        Objects.requireNonNull(type, "Type cannot be null.");
 
         switch (type) {
             case "NUMBER":


### PR DESCRIPTION
This commit removes the usage of Guava Preconditions due to conflict of versions that caused the `checkArgument` method not being found at runtime.