### PR TITLE
Disable the activation by default of Java 11 and 17 profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -786,9 +786,6 @@
         <!-- Profile to compile and run tests with JDK 11 -->
         <profile>
             <id>java-11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
             <properties>
                 <project.source>11</project.source>
             </properties>
@@ -808,9 +805,6 @@
         <!-- Profile to compile and run tests with JDK 17 -->
         <profile>
             <id>java-17</id>
-            <activation>
-                <jdk>17</jdk>
-            </activation>
             <properties>
                 <project.source>17</project.source>
             </properties>


### PR DESCRIPTION
This commit disables by default the activation of Java 11 and 17 profiles.
This is useful to avoid maven automatically activate Java 11 or 17 profile when the JDK detected is 11 or 17 and thus when compiling it produces an artifact that is not compatible with Java 8 anymore.