### PR TITLE
Add support to provide logger to batch

### DIFF
--- a/.github/workflows/build-pdb.yml
+++ b/.github/workflows/build-pdb.yml
@@ -60,16 +60,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/test-cockroach.yml
+++ b/.github/workflows/test-cockroach.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/test-db2.yml
+++ b/.github/workflows/test-db2.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/test-h2.yml
+++ b/.github/workflows/test-h2.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/test-oracle.yml
+++ b/.github/workflows/test-oracle.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/tests-sqlserver.yml
+++ b/.github/workflows/tests-sqlserver.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -38,6 +38,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static java.util.Objects.isNull;
+
 /**
  * A Batch that periodically flushes pending insertions to the database.
  * <p/>
@@ -51,7 +53,7 @@ public abstract class AbstractBatch implements Runnable {
     /**
      * The logger.
      */
-    protected final Logger logger = LoggerFactory.getLogger(AbstractBatch.class);
+    protected final Logger logger;
 
     /**
      * Constant representing that no retries should be attempted on batch flush failures.
@@ -158,8 +160,9 @@ public abstract class AbstractBatch implements Runnable {
      * @param maxFlushRetries      The number of times to retry a batch flush upon failure. When set to 0, no retries
      *                             will be attempted.
      * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries.
+     * @param logger               The logger.
      *
-     * @since 2.8.1
+     * @since 2.8.8
      */
     protected AbstractBatch(
         final DatabaseEngine de,
@@ -169,7 +172,8 @@ public abstract class AbstractBatch implements Runnable {
         final long maxAwaitTimeShutdown,
         @Nullable final BatchListener batchListener,
         final int maxFlushRetries,
-        final long flushRetryDelay) {
+        final long flushRetryDelay,
+        @Nullable final Logger logger) {
         Objects.requireNonNull(de, "The provided database engine is null.");
 
         this.de = de;
@@ -182,6 +186,34 @@ public abstract class AbstractBatch implements Runnable {
         this.batchListener = Optional.ofNullable(batchListener);
         this.maxFlushRetries = maxFlushRetries;
         this.flushRetryDelay = flushRetryDelay;
+        this.logger = isNull(logger) ? LoggerFactory.getLogger(AbstractBatch.class) : logger;
+    }
+
+    /**
+     * Creates a new instance of {@link AbstractBatch} with a {@link BatchListener}.
+     *
+     * @param de                   The database engine.
+     * @param name                 The batch name (null or empty names are allowed, falling back to "Anonymous Batch").
+     * @param batchSize            The batch size.
+     * @param batchTimeout         The batch timeout.
+     * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
+     * @param batchListener        The listener that will be invoked whenever some batch operation fail or succeeds to persist.
+     * @param maxFlushRetries      The number of times to retry a batch flush upon failure. When set to 0, no retries
+     *                             will be attempted.
+     * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries.
+     *
+     * @since 2.8.1
+     */
+    protected AbstractBatch(
+            final DatabaseEngine de,
+            final String name,
+            final int batchSize,
+            final long batchTimeout,
+            final long maxAwaitTimeShutdown,
+            @Nullable final BatchListener batchListener,
+            final int maxFlushRetries,
+            final long flushRetryDelay) {
+        this(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, batchListener, maxFlushRetries, flushRetryDelay, null);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/DefaultBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/DefaultBatch.java
@@ -18,12 +18,13 @@ package com.feedzai.commons.sql.abstraction.batch;
 import com.feedzai.commons.sql.abstraction.FailureListener;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
+import org.slf4j.Logger;
 
 /**
  * The default batch implementation.
  * <p/>
  * Behind the scenes, it will periodically flush pending statements. It has auto recovery
- * and will never thrown any exception.
+ * and will never throw any exception.
  *
  * @author Rui Vilao (rui.vilao@feedzai.com)
  * @see AbstractBatch
@@ -55,10 +56,18 @@ public class DefaultBatch extends AbstractBatch {
      * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
      * @param listener             The listener that will be invoked when batch fails or succeeds to persist at least
      *                             one data row.
+     * @param maxFlushRetries      The number of times to retry a batch flush upon failure. Defaults to
+     *                             {@value NO_RETRY}. When set to 0, no retries will be attempted.
+     * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries. Defaults to
+     *                             {@value DEFAULT_RETRY_INTERVAL}.
+     * @param logger               The logger.
+     *
+     * @since 2.8.8
      */
     protected DefaultBatch(final DatabaseEngine de, final String name, final int batchSize, final long batchTimeout,
-                           final long maxAwaitTimeShutdown, final BatchListener listener) {
-        super(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener);
+                           final long maxAwaitTimeShutdown, final BatchListener listener, final int maxFlushRetries,
+                           final long flushRetryDelay, final Logger logger) {
+        super(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener, maxFlushRetries, flushRetryDelay, logger);
     }
 
     /**
@@ -97,10 +106,7 @@ public class DefaultBatch extends AbstractBatch {
      */
     public static DefaultBatch create(final DatabaseEngine de, final String name, final int batchSize,
                                       final long batchTimeout, final long maxAwaitTimeShutdown) {
-        final DefaultBatch b = new DefaultBatch(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown);
-        b.start();
-
-        return b;
+        return create(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, (BatchListener) null);
     }
 
     /**
@@ -171,10 +177,7 @@ public class DefaultBatch extends AbstractBatch {
                                       final long batchTimeout,
                                       final long maxAwaitTimeShutdown,
                                       final BatchListener listener) {
-        final DefaultBatch b = new DefaultBatch(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener);
-        b.start();
-
-        return b;
+        return create(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener, NO_RETRY, DEFAULT_RETRY_INTERVAL);
     }
 
     /**
@@ -203,15 +206,72 @@ public class DefaultBatch extends AbstractBatch {
                                       final BatchListener listener,
                                       final int maxFlushRetries,
                                       final long flushRetryDelay) {
+        return create(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener, maxFlushRetries, flushRetryDelay, null);
+    }
+
+    /**
+     * <p>Creates a new instance of {@link DefaultBatch} with a {@link BatchListener} and a {@link Logger}.</p>
+     * <p>Starts the timertask.</p>
+     *
+     * @param de                   The database engine.
+     * @param name                 The batch name.
+     * @param batchSize            The batch size.
+     * @param batchTimeout         The batch timeout.
+     * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
+     * @param listener             The listener that will be invoked when batch fails to persist at least one data row.
+     *                             {@value DEFAULT_RETRY_INTERVAL}.
+     * @param logger               The logger.
+     * @return The Batch.
+     *
+     * @since 2.8.8
+     */
+    public static DefaultBatch create(final DatabaseEngine de,
+                                      final String name,
+                                      final int batchSize,
+                                      final long batchTimeout,
+                                      final long maxAwaitTimeShutdown,
+                                      final BatchListener listener,
+                                      final Logger logger) {
+        return create(de, name, batchSize, batchTimeout, maxAwaitTimeShutdown, listener, NO_RETRY, DEFAULT_RETRY_INTERVAL, logger);
+    }
+
+    /**
+     * <p>Creates a new instance of {@link DefaultBatch} with a {@link BatchListener}.</p>
+     * <p>Starts the timertask.</p>
+     *
+     * @param de                   The database engine.
+     * @param name                 The batch name.
+     * @param batchSize            The batch size.
+     * @param batchTimeout         The batch timeout.
+     * @param maxAwaitTimeShutdown The maximum await time for the batch to shutdown.
+     * @param listener             The listener that will be invoked when batch fails to persist at least one data row.
+     * @param maxFlushRetries      The number of times to retry a batch flush upon failure. Defaults to
+     *                             {@value NO_RETRY}. When set to 0, no retries will be attempted.
+     * @param flushRetryDelay      The time interval (milliseconds) to wait between batch flush retries. Defaults to
+     *                             {@value DEFAULT_RETRY_INTERVAL}.
+     * @return The Batch.
+     *
+     * @since 2.8.1
+     */
+    public static DefaultBatch create(final DatabaseEngine de,
+                                     final String name,
+                                     final int batchSize,
+                                     final long batchTimeout,
+                                     final long maxAwaitTimeShutdown,
+                                     final BatchListener listener,
+                                     final int maxFlushRetries,
+                                     final long flushRetryDelay,
+                                     final Logger logger) {
         final DefaultBatch b = new DefaultBatch(
-            de,
-            name,
-            batchSize,
-            batchTimeout,
-            maxAwaitTimeShutdown,
-            listener,
-            maxFlushRetries,
-            flushRetryDelay
+                de,
+                name,
+                batchSize,
+                batchTimeout,
+                maxAwaitTimeShutdown,
+                listener,
+                maxFlushRetries,
+                flushRetryDelay,
+                logger
         );
         b.start();
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -80,6 +80,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static com.feedzai.commons.sql.abstraction.batch.AbstractBatch.DEFAULT_RETRY_INTERVAL;
+import static com.feedzai.commons.sql.abstraction.batch.AbstractBatch.NO_RETRY;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENCRYPTED_PASSWORD;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENCRYPTED_USERNAME;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.JDBC;
@@ -1102,7 +1104,12 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
 
     @Override
     public AbstractBatch createBatch(int batchSize, long batchTimeout, String batchName, @Nullable final BatchListener batchListener) {
-        return DefaultBatch.create(this, batchName, batchSize, batchTimeout, properties.getMaximumAwaitTimeBatchShutdown(), batchListener);
+        return createBatch(batchSize, batchTimeout, batchName, batchListener, null);
+    }
+
+    @Override
+    public AbstractBatch createBatch(int batchSize, long batchTimeout, String batchName, @Nullable BatchListener batchListener, @Nullable Logger logger) {
+        return DefaultBatch.create(this, batchName, batchSize, batchTimeout, properties.getMaximumAwaitTimeBatchShutdown(), batchListener, NO_RETRY, DEFAULT_RETRY_INTERVAL, logger);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -28,6 +28,7 @@ import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.ExceptionHandler;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
+import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import java.sql.Connection;
@@ -264,6 +265,21 @@ public interface DatabaseEngine extends AutoCloseable {
      * @return The batch.
      */
     AbstractBatch createBatch(final int batchSize, final long batchTimeout, final String batchName);
+
+    /**
+     * Creates a new batch that periodically flushes a batch. A flush will also occur when the maximum number of
+     * statements in the batch is reached.
+     * <p/>
+     * Please be sure to call {@link AbstractBatch#destroy() } before closing the session with the database.
+     *
+     * @param batchSize     The batch size.
+     * @param batchTimeout  If inserts do not occur after the specified time, a flush will be performed.
+     * @param batchName     The batch name.
+     * @param batchListener Batch listener to execute custom behavior when the batch fails or succeeds to persist.
+     * @param logger        The logger.
+     * @return The batch.
+     */
+    AbstractBatch createBatch(final int batchSize, final long batchTimeout, final String batchName, final BatchListener batchListener, final Logger logger);
 
     /**
      * Creates a new batch that periodically flushes a batch. A flush will also occur when the maximum number of


### PR DESCRIPTION
This update allows the batcher to optionally receive a `Logger` object as parameter. A use case scenario for this would be providing a confidential logger, to prevent the batcher to dump confidential information to its logger.