### PR TITLE
Fix JDK 17 downloads from workflows

### DIFF
--- a/.github/workflows/build-pdb.yml
+++ b/.github/workflows/build-pdb.yml
@@ -60,16 +60,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/test-cockroach.yml
+++ b/.github/workflows/test-cockroach.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/test-db2.yml
+++ b/.github/workflows/test-db2.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/test-h2.yml
+++ b/.github/workflows/test-h2.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/test-oracle.yml
+++ b/.github/workflows/test-oracle.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages

--- a/.github/workflows/tests-sqlserver.yml
+++ b/.github/workflows/tests-sqlserver.yml
@@ -57,16 +57,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Download JDK 17
-        run: |
-          download_url="https://download.java.net/java/early_access/jdk17/28/GPL/openjdk-17-ea+28_linux-x64_bin.tar.gz"
-          wget -O ${{ runner.temp }}/java_package.tar.gz $download_url
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2.1.0
         with:
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-          java-version: '17.ea.28'
-          architecture: x64
+          java-version: 17
           distribution: zulu
 
       - name: Cache Maven packages


### PR DESCRIPTION
The JDK 17 downloads are not working. This fix points the workflow actions to the correct JDK 17 URL.