### PR TITLE
Fix jgitver configuration

### DIFF
--- a/.mvn/jgitver.config.xml
+++ b/.mvn/jgitver.config.xml
@@ -17,7 +17,7 @@
 <configuration xmlns="http://jgitver.github.io/maven/configuration/1.0.0-beta"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.0.0-beta https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_0_0-beta.xsd ">
-    <regexVersionTag>(^[0-9]+\.[0-9]+\.[0-9]$)</regexVersionTag>
+    <regexVersionTag>(^[0-9]+\.[0-9]+\.[0-9]+$)</regexVersionTag>
     <mavenLike>true</mavenLike>
     <branchPolicies>
         <branchPolicy>


### PR DESCRIPTION
There is a problem with jgitver configuration, which does not consider patches greater than 9 (it is configured to process the version only if the patch is one-digit only).