### PR TITLE
Enable more tests

### DIFF
--- a/.github/workflows/test-h2remote.yml
+++ b/.github/workflows/test-h2remote.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: PDB tests with H2v2 embedded
+name: PDB tests with H2 remote
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Test H2V2 PDB Java ${{ matrix.java-version }}
+    name: Test H2 remote PDB Java ${{ matrix.java-version }}
 
     strategy:
       matrix:
@@ -32,5 +32,5 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2-java${{ matrix.java-version }}
 
-    - name: Test with H2v2
-      run: mvn -B clean test -Ph2v2
+    - name: Test with H2 remote
+      run: mvn -B clean test -Ph2remote

--- a/.github/workflows/test-h2v2remote.yml
+++ b/.github/workflows/test-h2v2remote.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: PDB tests with H2v2 embedded
+name: PDB tests with H2v2 remote
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Test H2V2 PDB Java ${{ matrix.java-version }}
+    name: Test H2V2 remote PDB Java ${{ matrix.java-version }}
 
     strategy:
       matrix:
@@ -32,5 +32,5 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2-java${{ matrix.java-version }}
 
-    - name: Test with H2v2
-      run: mvn -B clean test -Ph2v2
+    - name: Test with H2v2 remote
+      run: mvn -B clean test -Ph2v2remote

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,11 @@
                     <version>2.22.2</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>${maven-source-plugin.version}</version>
@@ -349,6 +354,10 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
@@ -376,7 +385,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -390,7 +398,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
                     <doclint>none</doclint>
                 </configuration>
@@ -407,7 +414,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>${maven-gpg-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -445,13 +451,6 @@
     <profiles>
         <profile>
             <id>h2remote</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.h2database</groupId>
-                    <artifactId>h2</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
@@ -467,7 +466,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.0.0</version>
                         <executions>
                             <execution>
                                 <phase>test-compile</phase>
@@ -478,6 +476,8 @@
                         </executions>
                         <configuration>
                             <executable>java</executable>
+                            <!-- add test artifacts (UDFs) to server classpath -->
+                            <classpathScope>test</classpathScope>
                             <arguments>
                                 <argument>-classpath</argument>
                                 <!-- automatically creates the classpath using all project dependencies,
@@ -501,14 +501,24 @@
         </profile>
 
         <profile>
-            <id>h2v2remote</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.h2database</groupId>
-                    <artifactId>h2</artifactId>
-                </dependency>
-            </dependencies>
+            <id>h2v2</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <instances>h2v2</instances>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
+        <profile>
+            <id>h2v2remote</id>
             <build>
                 <plugins>
                     <plugin>
@@ -524,7 +534,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.0.0</version>
                         <executions>
                             <execution>
                                 <phase>test-compile</phase>
@@ -535,6 +544,8 @@
                         </executions>
                         <configuration>
                             <executable>java</executable>
+                            <!-- add test artifacts (UDFs) to server classpath -->
+                            <classpathScope>test</classpathScope>
                             <arguments>
                                 <argument>-classpath</argument>
                                 <!-- automatically creates the classpath using all project dependencies,
@@ -543,6 +554,9 @@
                                 <argument>org.h2.tools.Server</argument>
                                 <!-- make db available via tcp -->
                                 <argument>-tcp</argument>
+                                <!-- use port 9093, different from the one used in h2remote profile (the default 9092) -->
+                                <argument>-tcpPort</argument>
+                                <argument>9093</argument>
                                 <!-- set local file inside test output directory -->
                                 <argument>-baseDir</argument>
                                 <argument>${project.build.testOutputDirectory}/pdb-h2v2-remote</argument>
@@ -713,7 +727,7 @@
         <profile>
             <id>cockroach</id>
             <properties>
-                <image.cockroach>cockroachdb/cockroach:v19.2.0</image.cockroach>
+                <image.cockroach>cockroachdb/cockroach:v21.2.5</image.cockroach>
             </properties>
             <build>
                 <plugins>
@@ -743,7 +757,7 @@
                                             <port>8080:8080</port>
                                             <port>26257:26257</port>
                                         </ports>
-                                        <cmd>start --insecure</cmd>
+                                        <cmd>start-single-node --insecure</cmd>
                                         <wait>
                                             <time>40000</time>
                                             <log>CockroachDB node starting</log>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultColumn.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/result/ResultColumn.java
@@ -111,6 +111,10 @@ public abstract class ResultColumn implements Serializable {
             return null;
         }
 
+        if (val instanceof Number) {
+            return ((Number) val).doubleValue();
+        }
+
         return Double.parseDouble(val.toString());
     }
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
@@ -140,7 +140,7 @@ public abstract class AbstractEngineSchemaTest {
 
 
     /**
-     * Gets the test schema to be used in tests that need a schema other then the default/configured.
+     * Gets the test schema to be used in tests that need a schema other than the default/configured.
      *
      * @return The test schema.
      * @since 2.1.13
@@ -811,8 +811,7 @@ public abstract class AbstractEngineSchemaTest {
      * @param engine The database engine.
      * @throws DatabaseEngineException If anything goes wrong creating the UDF.
      */
-    protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
-    }
+    protected abstract void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException;
 
     /**
      * Defines the UDF "TimesTwo" in the database engine.
@@ -822,8 +821,7 @@ public abstract class AbstractEngineSchemaTest {
      * @param engine The database engine.
      * @throws DatabaseEngineException If anything goes wrong creating the UDF.
      */
-    protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
-    }
+    protected abstract void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException;
 
     /**
      * Creates the {@link #getTestSchema() test schema} in the database, dropping it first if necessary.

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/cockroach/CockroachDBEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/cockroach/CockroachDBEngineSchemaTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.feedzai.commons.sql.abstraction.engine.impl.cockroach;
+
+import com.feedzai.commons.sql.abstraction.engine.impl.postgresql.PostgreSqlEngineSchemaTest;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+/**
+ * Schema related tests for CockroachDB.
+ *
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ */
+@RunWith(Parameterized.class)
+public class CockroachDBEngineSchemaTest extends PostgreSqlEngineSchemaTest {
+
+    @Parameterized.Parameters
+    public static Collection<DatabaseConfiguration> data() throws Exception {
+        return DatabaseTestUtil.loadConfigurations("cockroach");
+    }
+
+    @Override
+    @Test
+    @Ignore("CockroachDB doesn't support stored procedures; see https://github.com/cockroachdb/cockroach/issues/17511")
+    public void udfGetOneTest() {
+    }
+
+    @Override
+    @Test
+    @Ignore("CockroachDB doesn't support stored procedures; see https://github.com/cockroachdb/cockroach/issues/17511")
+    public void udfTimesTwoTest() {
+    }
+}

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/db2/DB2EngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/db2/DB2EngineSchemaTest.java
@@ -44,24 +44,24 @@ public class DB2EngineSchemaTest extends AbstractEngineSchemaTest {
     @Override
     protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate(
-            "CREATE OR REPLACE FUNCTION GETONE () " +
-            "    RETURNS INTEGER " +
-            "    NO EXTERNAL ACTION " +
-            "F1: BEGIN ATOMIC " +
-                "RETURN 1; " +
-            "END"
+                "CREATE OR REPLACE FUNCTION GETONE()" +
+                        " RETURNS INTEGER" +
+                        " NO EXTERNAL ACTION" +
+                        " F1: BEGIN ATOMIC" +
+                        "    RETURN 1;" +
+                        " END"
         );
     }
 
     @Override
     protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate(
-            "CREATE OR REPLACE FUNCTION \"" + getTestSchema() + "\".TimesTwo (VARNAME VARCHAR(128)) " +
-            "    RETURNS INTEGER " +
-            "    NO EXTERNAL ACTION " +
-            "F1: BEGIN ATOMIC " +
-            "    RETURN VARNAME * 2; " +
-            "END"
+            "CREATE OR REPLACE FUNCTION \"" + getTestSchema() + "\".TimesTwo(N VARCHAR(128))" +
+                    " RETURNS INTEGER" +
+                    " NO EXTERNAL ACTION" +
+                    " F1: BEGIN ATOMIC" +
+                    "    RETURN N * 2;" +
+                    " END"
         );
     }
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/H2EngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/H2EngineSchemaTest.java
@@ -27,7 +27,6 @@ import org.junit.runners.Parameterized;
 import java.util.Collection;
 
 import static com.feedzai.commons.sql.abstraction.engine.impl.abs.AbstractEngineSchemaTest.Ieee754Support.SUPPORTED_STRINGS;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * @author Joao Silva (joao.silva@feedzai.com)

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/H2EngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/h2/H2EngineSchemaTest.java
@@ -46,53 +46,17 @@ public class H2EngineSchemaTest extends AbstractEngineSchemaTest {
         return SUPPORTED_STRINGS;
     }
 
-    /**
-     * This test overrides the superclass in order to check if the H2 engine is local or remote; if it is remote
-     * the test is skipped.
-     *
-     * This was done because the UDF is defined by static methods in this class, which needs to be available (compiled)
-     * to the H2 engine. This is already assumed when H2 is embedded, but making the class available in remote H2
-     * would require copying this to the location of the remote server.
-     * Since this is already being tested with H2 embedded, we just skip the test when the server is remote.
-     *
-     * @throws Exception If something goes wrong with the test.
-     * @see AbstractEngineSchemaTest#udfGetOneTest()
-     */
-    @Override
-    public void udfGetOneTest() throws Exception {
-        assumeTrue("Test not supported when using H2 remote - skipped", checkIsLocalH2());
-        super.udfGetOneTest();
-    }
-
-    /**
-     * This test overrides the superclass in order to check if the H2 engine is local or remote; if it is remote
-     * the test is skipped.
-     *
-     * This was done because the UDF is defined by static methods in this class, which needs to be available (compiled)
-     * to the H2 engine. This is already assumed when H2 is embedded, but making the class available in remote H2
-     * would require copying this to the location of the remote server.
-     * Since this is already being tested with H2 embedded, we just skip the test when the server is remote.
-     *
-     * @throws Exception If something goes wrong with the test.
-     * @see AbstractEngineSchemaTest#udfTimesTwoTest()
-     */
-    @Override
-    public void udfTimesTwoTest() throws Exception {
-        assumeTrue("Test not supported when using H2 remote - skipped", checkIsLocalH2());
-        super.udfTimesTwoTest();
-    }
-
     @Override
     protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
-        engine.executeUpdate(
-            "CREATE ALIAS IF NOT EXISTS GetOne FOR \"com.feedzai.commons.sql.abstraction.engine.impl.h2.H2EngineSchemaTest.GetOne\";"
-        );
+        engine.executeUpdate("DROP ALIAS IF EXISTS GetOne");
+        engine.executeUpdate("CREATE ALIAS IF NOT EXISTS GetOne FOR \"" + this.getClass().getName() + ".GetOne\"");
     }
 
     @Override
     protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
+        engine.executeUpdate("DROP ALIAS IF EXISTS \"" + getTestSchema() + "\".TimesTwo");
         engine.executeUpdate(
-            "CREATE ALIAS IF NOT EXISTS \"" + getTestSchema() + "\".TimesTwo FOR \"com.feedzai.commons.sql.abstraction.engine.impl.h2.H2EngineSchemaTest.TimesTwo\";"
+                "CREATE ALIAS IF NOT EXISTS \"" + getTestSchema() + "\".TimesTwo FOR \"" + this.getClass().getName() + ".TimesTwo\""
         );
     }
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/mysql/MySqlEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/mysql/MySqlEngineSchemaTest.java
@@ -41,9 +41,9 @@ public class MySqlEngineSchemaTest extends AbstractEngineSchemaTest {
     protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate("DROP FUNCTION IF EXISTS GetOne");
         engine.executeUpdate(
-            "CREATE FUNCTION GetOne() " +
-            "RETURNS INTEGER " +
-            "RETURN 1;"
+                "CREATE FUNCTION GetOne()" +
+                        " RETURNS INTEGER DETERMINISTIC" +
+                        " RETURN 1;"
         );
     }
 
@@ -51,9 +51,9 @@ public class MySqlEngineSchemaTest extends AbstractEngineSchemaTest {
     protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate("DROP FUNCTION IF EXISTS " + getTestSchema() + ".TimesTwo");
         engine.executeUpdate(
-            "CREATE FUNCTION " + getTestSchema() + ".TimesTwo(number INT) " +
-            "RETURNS INTEGER " +
-            "RETURN number * 2;"
+                "CREATE FUNCTION " + getTestSchema() + ".TimesTwo(number INT)" +
+                        " RETURNS INTEGER DETERMINISTIC" +
+                        " RETURN number * 2;"
         );
     }
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/oracle/OracleEngineSchemaTest.java
@@ -85,24 +85,22 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
     @Override
     protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate(
-            "CREATE OR REPLACE FUNCTION GetOne " +
-            "RETURN INTEGER " +
-            "AS " +
-            "BEGIN " +
-            "    RETURN 1;" +
-            "END GetOne;"
+                "CREATE OR REPLACE FUNCTION GetOne" +
+                        " RETURN INTEGER AS" +
+                        " BEGIN" +
+                        "    RETURN 1;" +
+                        " END;"
         );
     }
 
     @Override
     protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate(
-            "CREATE OR REPLACE FUNCTION " + getTestSchema() + ".TimesTwo (n IN INTEGER) " +
-            "RETURN INTEGER " +
-            "AS " +
-            "BEGIN " +
-            "    RETURN n * 2;" +
-            "END TimesTwo;"
+                "CREATE OR REPLACE FUNCTION " + getTestSchema() + ".TimesTwo(n IN INTEGER)" +
+                        " RETURN INTEGER AS" +
+                        " BEGIN" +
+                        "    RETURN n * 2;" +
+                        " END;"
         );
     }
 
@@ -111,8 +109,8 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
         // create user (=schema) with all privileges granted
         // schema needs to be quotized to have proper case; assume it already is if it starts with double quote
         engine.executeUpdate(
-            "GRANT ALL PRIVILEGES TO " + (schema.startsWith("\"") ? schema : quotize(schema))
-                + " IDENTIFIED BY " + engine.getProperties().getPassword() + " WITH ADMIN OPTION"
+                "GRANT ALL PRIVILEGES TO " + (schema.startsWith("\"") ? schema : quotize(schema))
+                        + " IDENTIFIED BY " + engine.getProperties().getPassword() + " WITH ADMIN OPTION"
         );
     }
 
@@ -121,13 +119,13 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
         // schema needs to be quotized to have proper case; assume it already is if it starts with double quote
         engine.executeUpdate(
                 "DECLARE\n" +
-                "   not_exists EXCEPTION;" +
-                "   PRAGMA EXCEPTION_INIT(not_exists, -01918);" +
-                "BEGIN\n" +
-                "   EXECUTE IMMEDIATE 'DROP USER " + (schema.startsWith("\"") ? schema : quotize(schema)) + " CASCADE';" +
-                "EXCEPTION\n" +
-                "   WHEN not_exists THEN null; -- ignore the error\n" +
-                "END;"
+                        "   not_exists EXCEPTION;" +
+                        "   PRAGMA EXCEPTION_INIT(not_exists, -01918);" +
+                        "BEGIN\n" +
+                        "   EXECUTE IMMEDIATE 'DROP USER " + (schema.startsWith("\"") ? schema : quotize(schema)) + " CASCADE';" +
+                        "EXCEPTION\n" +
+                        "   WHEN not_exists THEN null; -- ignore the error\n" +
+                        "END;"
         );
     }
 
@@ -208,7 +206,7 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
 
         final List<Map<String, ResultColumn>> results = engine.query(query);
 
-        assertEquals("Check that two lines are returned",2, results.size());
+        assertEquals("Check that two lines are returned", 2, results.size());
 
         for (final Map<String, ResultColumn> result : results) {
             assertEquals("Check that compression is defined as MEDIUM", result.get(compression).toString(), "MEDIUM");
@@ -347,7 +345,7 @@ public class OracleEngineSchemaTest extends AbstractEngineSchemaTest {
      * @param tablespace the name of the tablespace
      * @param user       the user for which its default tablespace will be assigned
      * @param engine     the database engine used to create the tablespace
-     * @throws DatabaseEngineException  if there is a problem when executing the update tablespace query
+     * @throws DatabaseEngineException if there is a problem when executing the update tablespace query
      */
     private void createUserTablespace(final String tablespace,
                                       final String user,

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/postgresql/PostgreSqlEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/postgresql/PostgreSqlEngineSchemaTest.java
@@ -47,26 +47,26 @@ public class PostgreSqlEngineSchemaTest extends AbstractEngineSchemaTest {
     @Override
     protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate(
-            "CREATE OR REPLACE FUNCTION GetOne() " +
-            "RETURNS INTEGER " +
-            "AS 'SELECT 1;' " +
-            "LANGUAGE SQL;"
+                "CREATE OR REPLACE FUNCTION GetOne()" +
+                        " RETURNS INTEGER" +
+                        " AS 'SELECT 1;'" +
+                        " LANGUAGE SQL;"
         );
     }
 
     @Override
     protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate(
-            "CREATE OR REPLACE FUNCTION \"" + getTestSchema() + "\".TimesTwo(INTEGER) " +
-            "RETURNS INTEGER " +
-            "AS 'SELECT $1 * 2;' " +
-            "LANGUAGE SQL;"
+                "CREATE OR REPLACE FUNCTION " + getTestSchema() + ".TimesTwo(INTEGER) " +
+                        " RETURNS INTEGER" +
+                        " AS 'SELECT $1 * 2;'" +
+                        " LANGUAGE SQL;"
         );
     }
 
     @Override
     protected void createSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
-        engine.executeUpdate("CREATE SCHEMA IF NOT EXISTS \"" + schema + "\"");
+        engine.executeUpdate("CREATE SCHEMA \"" + schema + "\"");
 
     }
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/sqlserver/SqlServerEngineSchemaTest.java
@@ -53,38 +53,24 @@ public class SqlServerEngineSchemaTest extends AbstractEngineSchemaTest {
     }
 
     @Override
-    protected void defineUDFGetOne(DatabaseEngine engine) throws DatabaseEngineException {
+    protected void defineUDFGetOne(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate(
-            "IF OBJECT_ID (N'GetOne', N'FN') IS NOT NULL " +
-            "    DROP FUNCTION GetOne"
-        );
-
-        engine.executeUpdate(
-            "CREATE FUNCTION GetOne() " +
-            "RETURNS INTEGER " +
-            "AS " +
-            "BEGIN " +
-            "    RETURN(1) " +
-            "END"
+                "CREATE OR ALTER FUNCTION GetOne() " +
+                        " RETURNS INTEGER AS" +
+                        " BEGIN" +
+                        "    RETURN(1)" +
+                        " END"
         );
     }
 
     @Override
-    protected void defineUDFTimesTwo(DatabaseEngine engine) throws DatabaseEngineException {
+    protected void defineUDFTimesTwo(final DatabaseEngine engine) throws DatabaseEngineException {
         engine.executeUpdate(
-            "IF OBJECT_ID (N'" + getTestSchema() + ".TimesTwo', N'FN') IS NOT NULL " +
-            "BEGIN " +
-            "    DROP FUNCTION " + getTestSchema() + ".TimesTwo;" +
-            "END"
-        );
-
-        engine.executeUpdate(
-            "CREATE FUNCTION " + getTestSchema() + ".TimesTwo(@number INTEGER) " +
-            "RETURNS INTEGER " +
-            "AS " +
-            "BEGIN " +
-            "    RETURN(@number * 2) " +
-            "END"
+                "CREATE OR ALTER FUNCTION " + getTestSchema() + ".TimesTwo(@number INTEGER) " +
+                        " RETURNS INTEGER AS" +
+                        " BEGIN" +
+                        "    RETURN(@number * 2) " +
+                        " END"
         );
     }
 
@@ -95,6 +81,6 @@ public class SqlServerEngineSchemaTest extends AbstractEngineSchemaTest {
 
     @Override
     protected void dropSchema(final DatabaseEngine engine, final String schema) throws DatabaseEngineException {
-        engine.executeUpdate("DROP SCHEMA " + schema);
+        engine.executeUpdate("DROP SCHEMA IF EXISTS " + schema);
     }
 }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/testconfig/DatabaseTestUtil.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/testconfig/DatabaseTestUtil.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -66,8 +67,8 @@ public class DatabaseTestUtil {
 
     /**
      * Filters the instances given by {@code vendor}.
-     * <p/>
-     * The match is performed by contains, i.e. oracle matches oracle11 and oracle12.
+     * <p>
+     * The match is performed by the start of vendor name, i.e. h2 matches h2, h2remote, h2v2 and h2v2remote.
      *
      * @param vendors The list of instances to test.
      * @return The filtered instances to test.
@@ -75,16 +76,8 @@ public class DatabaseTestUtil {
      */
     public static Collection<DatabaseConfiguration> loadConfigurations(final String... vendors) throws Exception {
         return loadConfigurations().stream()
-            .filter(dbConfig -> {
-                for (String vendor : vendors) {
-                    if (dbConfig.vendor.contains(vendor)) {
-                        return true;
-                    }
-                }
-
-                return false;
-            })
-            .collect(Collectors.toList());
+                .filter(dbConfig -> Arrays.stream(vendors).anyMatch(dbConfig.vendor::startsWith))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/test/resources/connections.properties
+++ b/src/test/resources/connections.properties
@@ -6,7 +6,7 @@
 ###############################################################################################
 
 h2.engine=com.feedzai.commons.sql.abstraction.engine.impl.H2Engine
-h2.jdbc=jdbc:h2:./target/pdb;AUTO_SERVER=FALSE
+h2.jdbc=jdbc:h2:./target/pdb_h2;AUTO_SERVER=FALSE
 h2.username=pdb
 h2.password=pdb
 
@@ -16,18 +16,19 @@ h2remote.username=sa
 h2remote.password=sa
 
 h2v2.engine=com.feedzai.commons.sql.abstraction.engine.impl.H2EngineV2
-h2v2.jdbc=jdbc:h2:./target/pdb;AUTO_SERVER=FALSE
+h2v2.jdbc=jdbc:h2:./target/pdb_h2v2;AUTO_SERVER=FALSE
 h2v2.username=pdb
 h2v2.password=pdb
 
 h2v2remote.engine=com.feedzai.commons.sql.abstraction.engine.impl.H2EngineV2
-h2v2remote.jdbc=jdbc:h2:tcp://localhost:9092/public
+h2v2remote.jdbc=jdbc:h2:tcp://localhost:9093/public
 h2v2remote.username=sa
 h2v2remote.password=sa
 
 mysql.engine=com.feedzai.commons.sql.abstraction.engine.impl.MySqlEngine
-mysql.jdbc=jdbc:mysql://localhost:3306/mysql?useSSL=false
+mysql.jdbc=jdbc:mysql://localhost:3306/mysql?useSSL=false&allowPublicKeyRetrieval=true
 # appended "useSSL=false" to jdbc url to avoid a warning about not using SSL;
+# appended "allowPublicKeyRetrieval=true" to jdbc url to avoid "key retrieval not allowed" error in newer MySQL versions
 # for mysql, schema and database is the same thing
 # default database/schema: none, it must be specified either in jdbc url or in schema property
 # example when used in jdbc url: jdbc:mysql://localhost:3306/mysql


### PR DESCRIPTION
* Create missing profiles for H2, in pom and github workflows
* Add test classpath for H2 remote, so that UDF tests can run
* Make each H2 test config use different directories/ports
* Enable CockroachDB engine schema tests (required upgrading Docker image version, due to a bug https://github.com/cockroachdb/cockroach/issues/62601)
* Add flag to MySQL test configs to allow connecting to newer versions of the server
* Other improvements and cleanups