### PR TITLE
Make MetricsListener AutoCloseable

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -385,6 +385,7 @@ public abstract class AbstractBatch extends AbstractPdbBatch implements Runnable
     @Override
     public void close() throws Exception {
         destroy();
+        this.metricsListener.close();
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/impl/MultithreadedBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/impl/MultithreadedBatch.java
@@ -241,6 +241,12 @@ public class MultithreadedBatch extends AbstractPdbBatch implements PdbBatch {
         remainingTimeout = Math.max(this.maxAwaitTimeShutdownMs - (System.currentTimeMillis() - start), 1);
         orderlyShutdownExecutor(flusher, remainingTimeout);
 
+        try {
+            this.metricsListener.close();
+        } catch (final Exception e) {
+            // ignore, continue closing DB connections
+        }
+
         logger.trace("Closing internal database connections");
         dbEnginesMap.values().forEach(DatabaseEngine::close);
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/listeners/MetricsListener.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/listeners/MetricsListener.java
@@ -22,7 +22,7 @@ package com.feedzai.commons.sql.abstraction.listeners;
  * @author José Fidalgo (jose.fidalgo@feedzai.com)
  * @implSpec The method calls on the listener should not block nor throw any exceptions.
  */
-public interface MetricsListener {
+public interface MetricsListener extends AutoCloseable {
 
     /**
      * Called when an entry is added to the batch.
@@ -60,4 +60,9 @@ public interface MetricsListener {
      * @param failedEntriesCount     The number of entries that failed to be flushed.
      */
     void onFlushFinished(long elapsed, int successfulEntriesCount, int failedEntriesCount);
+
+    @Override
+    default void close() throws Exception {
+        // do nothing by default
+    }
 }


### PR DESCRIPTION
Make MetricsListener AutoCloseable so that the implementation knows when the batch is closed and can act upon it (e.g. unregister metrics).