### PR TITLE
Fix batch creation with Guice v4

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -1101,7 +1101,6 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
                 new AbstractModule() {
                     @Override
                     protected void configure() {
-                        super.configure();
                         bind(PdbProperties.class).toProvider(Providers.of(AbstractDatabaseEngine.this.properties));
                         bind(AbstractTranslator.class).toProvider(Providers.of(AbstractDatabaseEngine.this.translator));
                         bind(DatabaseEngine.class).toProvider(Providers.of(AbstractDatabaseEngine.this));


### PR DESCRIPTION
Summary:
On Guice v4 AbstractModule.configure() is abstract, super.configure() can't be called.
This commit removes that call to super on the anonymous module for batch creation.