### PR TITLE
Update javadoc plugin and add tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
 
         <jmockit.version>1.49</jmockit.version>
 
-        <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     </properties>
@@ -290,7 +289,27 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>${maven-javadoc-plugin.version}</version>
+                    <version>3.4.0</version>
+                    <configuration>
+                        <tags>
+                            <tag>
+                                <name>apiNote</name>
+                                <placement>a</placement>
+                                <head>API Note:</head>
+                            </tag>
+                            <tag>
+                                <name>implSpec</name>
+                                <placement>a</placement>
+                                <head>Implementation Requirements:</head>
+                            </tag>
+                            <tag>
+                                <name>implNote</name>
+                                <placement>a</placement>
+                                <head>Implementation Note:</head>
+                            </tag>
+                        </tags>
+                    </configuration>
+
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -449,7 +449,7 @@ public abstract class AbstractBatch extends AbstractPdbBatch implements Runnable
     /**
      * Flushes the pending batches.
      *
-     * @implSpec Same as {@link #flush(boolean)} with {@link false}.
+     * @implSpec Same as {@link #flush(boolean)} with {@code false}.
      */
     public void flush() {
         this.metricsListener.onFlushTriggered();


### PR DESCRIPTION
Summary:
- Updates the version of maven-javadoc-plugin to the newest available.
- Adds @apiNote, @implSpec and @implNote as custom tags, singe they aren't supported by the plugin yet.