### PR TITLE
Add more SQL functions (#377)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -624,7 +624,17 @@
                                         <env>
                                             <MYSQL_ROOT_PASSWORD>AaBb12.#</MYSQL_ROOT_PASSWORD>
                                         </env>
-                                        <cmd>--max-allowed-packet=16000000 --innodb-log-file-size=160000000</cmd>
+                                        <!--
+                                         For some tests to work (e.g. sending large values to LOB columns) we need
+                                          packet size and log file size increased from the default.
+                                         To be able to correctly obtain the length and a substring of a string with
+                                          some special characters, full UTF-8 support is needed, so the default
+                                          character set needs to be defined as "utf8mb4", instead of the default utf8
+                                          which is "utf8mb3".
+                                         To be able to distinguish strings with same characters but different case, a
+                                          case-sensitive collation is needed, hence utf8mb4_bin is used.
+                                        -->
+                                        <cmd>--character-set-server=utf8mb4 --collation-server=utf8mb4_bin --max-allowed-packet=32000000 --innodb-log-file-size=160000000</cmd>
                                         <wait>
                                             <time>40000</time>
                                             <log>MySQL init process done. Ready for start up.</log>
@@ -683,8 +693,13 @@
                                                  isolation level) and ALLOW_SNAPSHOT_ISOLATION enabled to allow using the
                                                  TRANSACTION_SNAPSHOT level (equivalent to SERIALIZABLE in Oracle).
                                                 A new database needs to be used because the flags can't be enabled on "master" database.
+                                                This new database will also have a default collation that is case-sensitive
+                                                 and supports extended characters, so that tests that verify string length
+                                                 functions work correctly, and to be able to distinguish strings with same
+                                                 characters but different case. In particular, the selected collation supports:
+                                                 case-sensitive, accent-sensitive, kanatype-sensitive, width-sensitive, supplementary characters, UTF8.
                                                 -->
-                                                <postStart>/opt/mssql-tools/bin/sqlcmd -l 45 -U sa -P AaBb12.# -Q CREATE\ DATABASE\ pdb;\ ALTER\ DATABASE\ pdb\ SET\ READ_COMMITTED_SNAPSHOT\ ON;\ ALTER\ DATABASE\ pdb\ SET\ ALLOW_SNAPSHOT_ISOLATION\ ON</postStart>
+                                                <postStart>/opt/mssql-tools/bin/sqlcmd -l 45 -U sa -P AaBb12.# -Q CREATE\ DATABASE\ pdb\ COLLATE\ Latin1_General_100_CS_AS_KS_WS_SC_UTF8;\ ALTER\ DATABASE\ pdb\ SET\ READ_COMMITTED_SNAPSHOT\ ON;\ ALTER\ DATABASE\ pdb\ SET\ ALLOW_SNAPSHOT_ISOLATION\ ON</postStart>
                                             </exec>
                                         </wait>
                                     </run>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
@@ -44,9 +44,15 @@ public class Function extends Expression {
      */
     public static final String COUNT = "COUNT";
     /**
-     * The STDDEV function.
+     * The STDDEV function (sample standard deviation).
      */
     public static final String STDDEV = "STDDEV";
+
+    /**
+     * The STDDEV_POP function (population standard deviation).
+     */
+    public static final String STDDEV_POP = "STDDEV_POP";
+
     /**
      * The SUM function.
      */
@@ -67,6 +73,12 @@ public class Function extends Expression {
      * The CEILING function.
      */
     public static final String CEILING = "CEIL";
+
+    /**
+     * The ASCII function.
+     */
+    public static final String ASCII = "ASCII";
+
     /**
      * The list of functions.
      */
@@ -79,22 +91,24 @@ public class Function extends Expression {
                 .add(AVG)
                 .add(COUNT)
                 .add(STDDEV)
+                .add(STDDEV_POP)
                 .add(SUM)
                 .add(UPPER)
                 .add(LOWER)
                 .add(FLOOR)
                 .add(CEILING)
+                .add(ASCII)
                 .build();
     }
 
     /**
      * The function.
      */
-    private String function;
+    private final String function;
     /**
      * The expression enclosed in the function.
      */
-    private Expression exp;
+    private final Expression exp;
 
     /**
      * Creates a new instance of {@link Function}.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/Function.java
@@ -75,9 +75,14 @@ public class Function extends Expression {
     public static final String CEILING = "CEIL";
 
     /**
-     * The ASCII function.
+     * The ASCII SQL function (returns the ASCII code of the first character of the provided string).
      */
     public static final String ASCII = "ASCII";
+
+    /**
+     * The CHAR_LENGTH SQL function (returns the length of the provided string in number of characters).
+     */
+    public static final String CHAR_LENGTH = "CHAR_LENGTH";
 
     /**
      * The list of functions.
@@ -98,6 +103,7 @@ public class Function extends Expression {
                 .add(FLOOR)
                 .add(CEILING)
                 .add(ASCII)
+                .add(CHAR_LENGTH)
                 .build();
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
@@ -47,6 +47,7 @@ import com.feedzai.commons.sql.abstraction.dml.Update;
 import com.feedzai.commons.sql.abstraction.dml.Values;
 import com.feedzai.commons.sql.abstraction.dml.View;
 import com.feedzai.commons.sql.abstraction.dml.With;
+import com.feedzai.commons.sql.abstraction.dml.functions.SubString;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 
 import java.util.Arrays;
@@ -565,13 +566,49 @@ public final class SqlBuilder {
     }
 
     /**
-     * The ASCII function (returns the ASCII value of the first character in the string value from the expression).
+     * The ASCII SQL function (returns the ASCII code of the first character in the string value from the expression).
      *
      * @param column The expression inside the operator.
      * @return The ASCII function.
      */
     public static Function ascii(final Expression column) {
         return new Function(Function.ASCII, column);
+    }
+
+    /**
+     * The CHAR_LENGTH SQL function (returns the length of string value from the expression, in number of characters).
+     *
+     * @param column The expression inside the operator.
+     * @return The ASCII function.
+     */
+    public static Function length(final Expression column) {
+        return new Function(Function.CHAR_LENGTH, column);
+    }
+
+    /**
+     * The SUBSTRING SQL function (returns a substring of the string value from the expression).
+     *
+     * @param column The expression referring to the column for which to obtain a substring (the expression should
+     *               return a string, can be a constant).
+     * @param start  The start position. The first position in string is 1.
+     * @param length The number of characters to extract. Must be a positive number.
+     * @return The SUBSTRING function.
+     */
+    public static SubString subString(final Expression column, final int start, final int length) {
+        return subString(column, k(start), k(length));
+    }
+
+    /**
+     * The SUBSTRING SQL function (returns a substring of the string value from the expression).
+     *
+     * @param column The expression referring to the column for which to obtain a substring (the expression should
+     *               return a string, can be a constant).
+     * @param start  The expression for getting the start position. The first position in string is 1.
+     * @param length The expression for getting the number of characters to extract. Must be a positive number.
+     * @return The SUBSTRING function.
+     */
+    public static SubString subString(final Expression column, final Expression start, final Expression length) {
+        return new SubString(column, start, length);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/dialect/SqlBuilder.java
@@ -62,7 +62,6 @@ import static com.feedzai.commons.sql.abstraction.dml.Function.FLOOR;
 import static com.feedzai.commons.sql.abstraction.dml.Function.LOWER;
 import static com.feedzai.commons.sql.abstraction.dml.Function.MAX;
 import static com.feedzai.commons.sql.abstraction.dml.Function.MIN;
-import static com.feedzai.commons.sql.abstraction.dml.Function.STDDEV;
 import static com.feedzai.commons.sql.abstraction.dml.Function.SUM;
 import static com.feedzai.commons.sql.abstraction.dml.Function.UPPER;
 import static com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter.AND;
@@ -455,13 +454,23 @@ public final class SqlBuilder {
     }
 
     /**
-     * The STDDEV operator.
+     * The STDDEV operator (sample standard deviation).
      *
      * @param exp The expression.
      * @return The STDDEV representation.
      */
     public static Expression stddev(final Expression exp) {
-        return new Function(STDDEV, exp);
+        return new Function(Function.STDDEV, exp);
+    }
+
+    /**
+     * The STDDEV_POP operator (population standard deviation).
+     *
+     * @param exp The expression.
+     * @return The STDDEV_POP representation.
+     */
+    public static Function stddevp(final Expression exp) {
+        return new Function(Function.STDDEV_POP, exp);
     }
 
     /**
@@ -553,6 +562,16 @@ public final class SqlBuilder {
      */
     public static StringAgg stringAgg(final Expression column) {
         return StringAgg.stringAgg(column);
+    }
+
+    /**
+     * The ASCII function (returns the ASCII value of the first character in the string value from the expression).
+     *
+     * @param column The expression inside the operator.
+     * @return The ASCII function.
+     */
+    public static Function ascii(final Expression column) {
+        return new Function(Function.ASCII, column);
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/dml/functions/SubString.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/dml/functions/SubString.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 Feedzai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.feedzai.commons.sql.abstraction.dml.functions;
+
+import com.feedzai.commons.sql.abstraction.dml.Expression;
+
+/**
+ * SQL function "SUBSTRING", which returns a string that is a substring of the string in the colum expression.
+ *
+ * @author José Fidalgo (jose.fidalgo@feedzai.com)
+ */
+public class SubString extends Expression {
+
+    /**
+     * @see #getColumn()
+     */
+    public final Expression column;
+
+    /**
+     * @see #getStart()
+     */
+    private final Expression start;
+
+    /**
+     * @see #getLength()
+     */
+    private final Expression length;
+
+    /**
+     * Constructor for a {@link SubString} SQL expression, which returns a substring of the string in the colum
+     * expression.
+     *
+     * @param column The column for which to obtain a substring.
+     * @param start  The start position. The first position in string is 1.
+     * @param length The number of characters to extract. Must be a positive number.
+     */
+    public SubString(final Expression column, final Expression start, final Expression length) {
+        this.column = column;
+        this.start = start;
+        this.length = length;
+    }
+
+    /**
+     * Returns the column expression for which to obtain a substring.
+     *
+     * @return The column for which to obtain a substring.
+     */
+    public Expression getColumn() {
+        return column;
+    }
+
+    /**
+     * Returns The start position of the substring in the original string. The first position is 1.
+     *
+     * @return The start position.
+     */
+    public Expression getStart() {
+        return start;
+    }
+
+    /**
+     * Returns the length of the substring, which is the number of characters to extract from the original string.
+     * Must be a positive number.
+     *
+     * @return The number of characters to extract.
+     */
+    public Expression getLength() {
+        return length;
+    }
+
+    @Override
+    public String translate() {
+        return translator.translate(this);
+    }
+}

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractTranslator.java
@@ -660,7 +660,19 @@ public abstract class AbstractTranslator {
      * @param f The object to translate.
      * @return The string representation of the given object.
      */
-    public abstract String translate(Function f);
+    public String translate(final Function f) {
+        final String function = f.getFunction();
+        final Expression exp = f.getExp();
+        inject(exp);
+
+        String expTranslated = "";
+
+        if (exp != null) {
+            expTranslated = exp.translate();
+        }
+
+        return function + "(" + expTranslated + ")";
+    }
 
     /**
      * Translates {@link Modulo}.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -25,7 +25,6 @@ import com.feedzai.commons.sql.abstraction.dml.Concat;
 import com.feedzai.commons.sql.abstraction.dml.Expression;
 import com.feedzai.commons.sql.abstraction.dml.Function;
 import com.feedzai.commons.sql.abstraction.dml.Join;
-import com.feedzai.commons.sql.abstraction.dml.Modulo;
 import com.feedzai.commons.sql.abstraction.dml.Name;
 import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
@@ -133,15 +132,6 @@ public class DB2Translator extends AbstractTranslator {
         } else {
             return function + "(" + expTranslated + ")";
         }
-    }
-
-    @Override
-    public String translate(Modulo m) {
-        final Expression dividend = m.getDividend();
-        final Expression divisor = m.getDivisor();
-        inject(dividend, divisor);
-
-        return String.format("MOD(%s, %s)", dividend.translate(), divisor.translate());
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Translator.java
@@ -106,9 +106,9 @@ public class DB2Translator extends AbstractTranslator {
     }
 
     @Override
-    public String translate(Function f) {
+    public String translate(final Function f) {
         final Expression exp = f.getExp();
-        final String function = f.getFunction();
+        String function = f.getFunction();
         inject(exp);
 
 
@@ -118,14 +118,13 @@ public class DB2Translator extends AbstractTranslator {
             expTranslated = exp.translate();
         }
 
-        if (Function.STDDEV.equalsIgnoreCase(function)) {
-            /* DB2 STDDEV divides VARIANCE by N instead of N-1 (why IBM??? why?), this fixes it */
-            return "SQRT(VARIANCE(" + expTranslated + ")*COUNT(1)/(COUNT(1)-1))";
-
-        }
-        if (Function.AVG.equalsIgnoreCase(function)) {
-           /* DB2 AVG is type sensitive - avg of int returns int (why IBM???)*/
-            return "AVG(" + expTranslated + "+0.0)";
+        switch (function.toUpperCase()) {
+            case Function.STDDEV:
+                function = "STDDEV_SAMP";
+                break;
+            case Function.AVG:
+                /* DB2 AVG is type sensitive - avg of int returns int (why IBM???)*/
+                return "AVG(CAST(" + expTranslated + " AS DOUBLE PRECISION))";
         }
 
         // if it is a user-defined function

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
@@ -24,7 +24,6 @@ import com.feedzai.commons.sql.abstraction.dml.Cast;
 import com.feedzai.commons.sql.abstraction.dml.Expression;
 import com.feedzai.commons.sql.abstraction.dml.Function;
 import com.feedzai.commons.sql.abstraction.dml.Join;
-import com.feedzai.commons.sql.abstraction.dml.Modulo;
 import com.feedzai.commons.sql.abstraction.dml.Name;
 import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
@@ -100,15 +99,6 @@ public class H2Translator extends AbstractTranslator {
         }
 
         return function + "(" + expTranslated + ")";
-    }
-
-    @Override
-    public String translate(Modulo m) {
-        final Expression dividend = m.getDividend();
-        final Expression divisor = m.getDivisor();
-        inject(dividend, divisor);
-
-        return String.format("MOD(%s, %s)", dividend.translate(), divisor.translate());
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Translator.java
@@ -15,8 +15,21 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl;
 
-import com.feedzai.commons.sql.abstraction.ddl.*;
-import com.feedzai.commons.sql.abstraction.dml.*;
+import com.feedzai.commons.sql.abstraction.ddl.AlterColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
+import com.feedzai.commons.sql.abstraction.ddl.DropPrimaryKey;
+import com.feedzai.commons.sql.abstraction.ddl.Rename;
+import com.feedzai.commons.sql.abstraction.dml.Cast;
+import com.feedzai.commons.sql.abstraction.dml.Expression;
+import com.feedzai.commons.sql.abstraction.dml.Function;
+import com.feedzai.commons.sql.abstraction.dml.Join;
+import com.feedzai.commons.sql.abstraction.dml.Modulo;
+import com.feedzai.commons.sql.abstraction.dml.Name;
+import com.feedzai.commons.sql.abstraction.dml.Query;
+import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
+import com.feedzai.commons.sql.abstraction.dml.StringAgg;
+import com.feedzai.commons.sql.abstraction.dml.View;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 import com.feedzai.commons.sql.abstraction.engine.OperationNotSupportedRuntimeException;
@@ -71,7 +84,7 @@ public class H2Translator extends AbstractTranslator {
     }
 
     @Override
-    public String translate(Function f) {
+    public String translate(final Function f) {
         final Expression exp = f.getExp();
         final String function = f.getFunction();
         inject(exp);
@@ -82,8 +95,8 @@ public class H2Translator extends AbstractTranslator {
             expTranslated = exp.translate();
         }
 
-        if (Function.AVG.equals(function)) {
-            expTranslated = String.format("CONVERT(%s, DOUBLE PRECISION)", expTranslated);
+        if (Function.AVG.equalsIgnoreCase(function)) {
+            expTranslated = format("CONVERT(%s, DOUBLE PRECISION)", expTranslated);
         }
 
         return function + "(" + expTranslated + ")";

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
@@ -15,8 +15,24 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl;
 
-import com.feedzai.commons.sql.abstraction.ddl.*;
-import com.feedzai.commons.sql.abstraction.dml.*;
+import com.feedzai.commons.sql.abstraction.ddl.AlterColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
+import com.feedzai.commons.sql.abstraction.ddl.DropPrimaryKey;
+import com.feedzai.commons.sql.abstraction.ddl.Rename;
+import com.feedzai.commons.sql.abstraction.dml.Cast;
+import com.feedzai.commons.sql.abstraction.dml.Expression;
+import com.feedzai.commons.sql.abstraction.dml.Function;
+import com.feedzai.commons.sql.abstraction.dml.Join;
+import com.feedzai.commons.sql.abstraction.dml.Modulo;
+import com.feedzai.commons.sql.abstraction.dml.Name;
+import com.feedzai.commons.sql.abstraction.dml.Query;
+import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
+import com.feedzai.commons.sql.abstraction.dml.StringAgg;
+import com.feedzai.commons.sql.abstraction.dml.Union;
+import com.feedzai.commons.sql.abstraction.dml.Update;
+import com.feedzai.commons.sql.abstraction.dml.View;
+import com.feedzai.commons.sql.abstraction.dml.With;
 import com.feedzai.commons.sql.abstraction.engine.AbstractTranslator;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
 import com.feedzai.commons.sql.abstraction.engine.OperationNotSupportedRuntimeException;
@@ -75,7 +91,7 @@ public class MySqlTranslator extends AbstractTranslator {
     }
 
     @Override
-    public String translate(com.feedzai.commons.sql.abstraction.dml.Function f) {
+    public String translate(final Function f) {
         String function = f.getFunction();
         final Expression exp = f.getExp();
         inject(exp);
@@ -86,7 +102,7 @@ public class MySqlTranslator extends AbstractTranslator {
             expTranslated = exp.translate();
         }
 
-        if (Function.STDDEV.equals(function)) {
+        if (Function.STDDEV.equalsIgnoreCase(function)) {
             function = "STDDEV_SAMP";
         }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlTranslator.java
@@ -24,7 +24,6 @@ import com.feedzai.commons.sql.abstraction.dml.Cast;
 import com.feedzai.commons.sql.abstraction.dml.Expression;
 import com.feedzai.commons.sql.abstraction.dml.Function;
 import com.feedzai.commons.sql.abstraction.dml.Join;
-import com.feedzai.commons.sql.abstraction.dml.Modulo;
 import com.feedzai.commons.sql.abstraction.dml.Name;
 import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
@@ -107,16 +106,6 @@ public class MySqlTranslator extends AbstractTranslator {
         }
 
         return function + "(" + expTranslated + ")";
-    }
-
-    @Override
-    public String translate(Modulo m) {
-        final Expression dividend = m.getDividend();
-        final Expression divisor = m.getDivisor();
-        inject(dividend, divisor);
-
-        return String.format("MOD(%s, %s)", dividend.translate(), divisor.translate());
-
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleTranslator.java
@@ -23,7 +23,6 @@ import com.feedzai.commons.sql.abstraction.ddl.Rename;
 import com.feedzai.commons.sql.abstraction.dml.Cast;
 import com.feedzai.commons.sql.abstraction.dml.Concat;
 import com.feedzai.commons.sql.abstraction.dml.Expression;
-import com.feedzai.commons.sql.abstraction.dml.Function;
 import com.feedzai.commons.sql.abstraction.dml.Join;
 import com.feedzai.commons.sql.abstraction.dml.Modulo;
 import com.feedzai.commons.sql.abstraction.dml.Name;
@@ -101,21 +100,6 @@ public class OracleTranslator extends AbstractTranslator {
         final String pkName = StringUtils.md5(format("PK_%s", tableName), properties.getMaxIdentifierSize());
 
         return String.format("ALTER TABLE %s DROP CONSTRAINT %s", table.translate(), StringUtils.quotize(pkName));
-    }
-
-    @Override
-    public String translate(Function f) {
-        final String function = f.getFunction();
-        final Expression exp = f.getExp();
-        inject(exp);
-
-        String expTranslated = "";
-
-        if (exp != null) {
-            expTranslated = exp.translate();
-        }
-
-        return function + "(" + expTranslated + ")";
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
@@ -22,7 +22,6 @@ import com.feedzai.commons.sql.abstraction.ddl.DropPrimaryKey;
 import com.feedzai.commons.sql.abstraction.ddl.Rename;
 import com.feedzai.commons.sql.abstraction.dml.Cast;
 import com.feedzai.commons.sql.abstraction.dml.Expression;
-import com.feedzai.commons.sql.abstraction.dml.Function;
 import com.feedzai.commons.sql.abstraction.dml.Join;
 import com.feedzai.commons.sql.abstraction.dml.Modulo;
 import com.feedzai.commons.sql.abstraction.dml.Name;
@@ -101,21 +100,6 @@ public class PostgreSqlTranslator extends AbstractTranslator {
         final String pkName = StringUtils.md5(format("PK_%s", tableName), properties.getMaxIdentifierSize());
 
         return String.format("ALTER TABLE %s DROP CONSTRAINT %s", table.translate(), quotize(pkName));
-    }
-
-    @Override
-    public String translate(Function f) {
-        final Expression exp = f.getExp();
-        final String function = f.getFunction();
-        inject(exp);
-
-        String expTranslated = "";
-
-        if (exp != null) {
-            expTranslated = exp.translate();
-        }
-
-        return function + "(" + expTranslated + ")";
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlTranslator.java
@@ -22,8 +22,8 @@ import com.feedzai.commons.sql.abstraction.ddl.DropPrimaryKey;
 import com.feedzai.commons.sql.abstraction.ddl.Rename;
 import com.feedzai.commons.sql.abstraction.dml.Cast;
 import com.feedzai.commons.sql.abstraction.dml.Expression;
+import com.feedzai.commons.sql.abstraction.dml.Function;
 import com.feedzai.commons.sql.abstraction.dml.Join;
-import com.feedzai.commons.sql.abstraction.dml.Modulo;
 import com.feedzai.commons.sql.abstraction.dml.Name;
 import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.RepeatDelimiter;
@@ -103,12 +103,18 @@ public class PostgreSqlTranslator extends AbstractTranslator {
     }
 
     @Override
-    public String translate(Modulo m) {
-        final Expression dividend = m.getDividend();
-        final Expression divisor = m.getDivisor();
-        inject(dividend, divisor);
+    public String translate(Function f) {
+        final Expression exp = f.getExp();
+        final String function = f.getFunction();
+        inject(exp);
 
-        return String.format("MOD(%s, %s)", dividend.translate(), divisor.translate());
+        String expTranslated = "";
+
+        if (exp != null) {
+            expTranslated = exp.translate();
+        }
+
+        return function + "(" + expTranslated + ")";
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -117,6 +117,9 @@ public class SqlServerTranslator extends AbstractTranslator {
             case Function.CEILING:
                 function = "CEILING";
                 break;
+            case Function.CHAR_LENGTH:
+                // LEN function in SQL counts the characters after trimming trailing spaces
+                return "(LEN(" + expTranslated + " + '1') - 1)";
         }
 
         // if it is a user-defined function
@@ -480,10 +483,13 @@ public class SqlServerTranslator extends AbstractTranslator {
             if (environment != null && !environment.isEmpty()) {
                 final Expression parsedColumn = column(columnName.getName());
                 inject(parsedColumn);
-                if (column.getOrdering().equals("DESC")) {
-                    parsedColumn.desc();
-                } else {
-                    parsedColumn.asc();
+                switch (column.getOrdering()) {
+                    case "DESC":
+                        parsedColumn.desc();
+                        break;
+                    default:
+                        parsedColumn.asc();
+                        break;
                 }
 
                 return parsedColumn;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerTranslator.java
@@ -93,7 +93,7 @@ public class SqlServerTranslator extends AbstractTranslator {
     }
 
     @Override
-    public String translate(Function f) {
+    public String translate(final Function f) {
         String function = f.getFunction();
         final Expression exp = f.getExp();
         inject(exp);
@@ -104,16 +104,19 @@ public class SqlServerTranslator extends AbstractTranslator {
             expTranslated = exp.translate();
         }
 
-        if (Function.STDDEV.equals(function)) {
-            function = "STDEV";
-        }
-
-        if (Function.AVG.equals(function)) {
-            expTranslated = String.format("CONVERT(DOUBLE PRECISION, %s)", expTranslated);
-        }
-
-        if (Function.CEILING.equals(function)) {
-            function = "CEILING";
+        switch (function.toUpperCase()) {
+            case Function.STDDEV:
+                function = "STDEV";
+                break;
+            case Function.STDDEV_POP:
+                function = "STDEVP";
+                break;
+            case Function.AVG:
+                expTranslated = String.format("CONVERT(DOUBLE PRECISION, %s)", expTranslated);
+                break;
+            case Function.CEILING:
+                function = "CEILING";
+                break;
         }
 
         // if it is a user-defined function
@@ -477,13 +480,10 @@ public class SqlServerTranslator extends AbstractTranslator {
             if (environment != null && !environment.isEmpty()) {
                 final Expression parsedColumn = column(columnName.getName());
                 inject(parsedColumn);
-                switch (column.getOrdering()) {
-                    case "DESC":
-                        parsedColumn.desc();
-                        break;
-                    default:
-                        parsedColumn.asc();
-                        break;
+                if (column.getOrdering().equals("DESC")) {
+                    parsedColumn.desc();
+                } else {
+                    parsedColumn.asc();
                 }
 
                 return parsedColumn;

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -22,7 +22,9 @@ import com.feedzai.commons.sql.abstraction.ddl.DbColumnType;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
 import com.feedzai.commons.sql.abstraction.ddl.Rename;
 import com.feedzai.commons.sql.abstraction.dml.Expression;
+import com.feedzai.commons.sql.abstraction.dml.Function;
 import com.feedzai.commons.sql.abstraction.dml.K;
+import com.feedzai.commons.sql.abstraction.dml.Name;
 import com.feedzai.commons.sql.abstraction.dml.Query;
 import com.feedzai.commons.sql.abstraction.dml.Truncate;
 import com.feedzai.commons.sql.abstraction.dml.Update;
@@ -54,6 +56,9 @@ import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Verifications;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.data.Offset;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,6 +73,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.IntSummaryStatistics;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,8 +93,18 @@ import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.DOUBLE;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.INT;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.LONG;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.STRING;
+import static com.feedzai.commons.sql.abstraction.dml.Function.AVG;
+import static com.feedzai.commons.sql.abstraction.dml.Function.CEILING;
+import static com.feedzai.commons.sql.abstraction.dml.Function.COUNT;
+import static com.feedzai.commons.sql.abstraction.dml.Function.FLOOR;
+import static com.feedzai.commons.sql.abstraction.dml.Function.MAX;
+import static com.feedzai.commons.sql.abstraction.dml.Function.MIN;
+import static com.feedzai.commons.sql.abstraction.dml.Function.STDDEV;
+import static com.feedzai.commons.sql.abstraction.dml.Function.STDDEV_POP;
+import static com.feedzai.commons.sql.abstraction.dml.Function.SUM;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.L;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.all;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.ascii;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.avg;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.between;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.caseWhen;
@@ -123,6 +139,7 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.notIn;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.or;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.select;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.stddev;
+import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.stddevp;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.stringAgg;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.sum;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.table;
@@ -158,8 +175,7 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class EngineGeneralTest {
 
-
-    private static final double DELTA = 1e-7;
+    private static final Offset<Double> DELTA = Assertions.offset(1e-7);
 
     protected DatabaseEngine engine;
     protected Properties properties;
@@ -1072,136 +1088,32 @@ public class EngineGeneralTest {
     }
 
     @Test
-    public void stddevTest() throws DatabaseEngineException {
+    public void statsTest() throws DatabaseEngineException {
         create5ColumnsEntity();
 
-        EntityEntry.Builder entry = entry()
-                .set("COL1", 2)
-                .set("COL2", false)
-                .set("COL3", 2D)
-                .set("COL4", 3L)
-                .set("COL5", "ADEUS");
+        class FullStats extends IntSummaryStatistics {
+            private double sumQ = 0.0;
 
-        for (int i = 0; i < 10; i++) {
-            entry.set("COL1", i);
-            engine.persist("TEST", entry
-                    .build());
+            @Override
+            public void accept(final int value) {
+                final double prevSumQ = this.sumQ;
+                final double prevAvg = getAverage();
+                super.accept(value);
+                this.sumQ = prevSumQ + (value - prevAvg) * (value - getAverage());
+            }
+
+            public double getStdevSample() {
+                return Math.sqrt(this.sumQ / (getCount() - 1));
+            }
+
+            public double getStdevPop() {
+                return Math.sqrt(this.sumQ / getCount());
+            }
         }
-        List<Map<String, ResultColumn>> query = engine.query(select(stddev(column("COL1")).alias("STDDEV")).from(table("TEST")));
 
-        assertEquals("result ok?", 3.0276503540974917D, query.get(0).get("STDDEV").toDouble(), 0.0001D);
-    }
+        final FullStats stats = new FullStats();
 
-    @Test
-    public void sumTest() throws DatabaseEngineException {
-        create5ColumnsEntity();
-
-        EntityEntry.Builder entry = entry()
-                .set("COL1", 2)
-                .set("COL2", false)
-                .set("COL3", 2D)
-                .set("COL4", 3L)
-                .set("COL5", "ADEUS");
-
-        for (int i = 0; i < 10; i++) {
-            entry.set("COL1", i);
-            engine.persist("TEST", entry
-                    .build());
-        }
-        List<Map<String, ResultColumn>> query = engine.query(select(sum(column("COL1")).alias("SUM")).from(table("TEST")));
-
-        assertEquals("result ok?", 45, (int) query.get(0).get("SUM").toInt());
-    }
-
-    @Test
-    public void countTest() throws DatabaseEngineException {
-        create5ColumnsEntity();
-
-        EntityEntry.Builder entry = entry()
-                .set("COL1", 2)
-                .set("COL2", false)
-                .set("COL3", 2D)
-                .set("COL4", 3L)
-                .set("COL5", "ADEUS");
-
-        for (int i = 0; i < 10; i++) {
-            entry.set("COL1", i);
-            engine.persist("TEST", entry
-                    .build());
-        }
-        List<Map<String, ResultColumn>> query = engine.query(select(count(column("COL1")).alias("COUNT")).from(table("TEST")));
-
-        assertEquals("result ok?", 10, (int) query.get(0).get("COUNT").toInt());
-    }
-
-    @Test
-    public void avgTest() throws DatabaseEngineException {
-        create5ColumnsEntity();
-
-        EntityEntry.Builder entry = entry()
-                .set("COL1", 2)
-                .set("COL2", false)
-                .set("COL3", 2D)
-                .set("COL4", 3L)
-                .set("COL5", "ADEUS");
-
-        for (int i = 0; i < 10; i++) {
-            entry.set("COL1", i);
-            engine.persist("TEST", entry
-                    .build());
-        }
-        List<Map<String, ResultColumn>> query = engine.query(select(avg(column("COL1")).alias("AVG")).from(table("TEST")));
-
-        assertEquals("result ok?", 4.5D, query.get(0).get("AVG").toDouble(), 0);
-    }
-
-    @Test
-    public void maxTest() throws DatabaseEngineException {
-        create5ColumnsEntity();
-
-        EntityEntry.Builder entry = entry()
-                .set("COL1", 2)
-                .set("COL2", false)
-                .set("COL3", 2D)
-                .set("COL4", 3L)
-                .set("COL5", "ADEUS");
-
-        for (int i = 0; i < 10; i++) {
-            entry.set("COL1", i);
-            engine.persist("TEST", entry
-                    .build());
-        }
-        List<Map<String, ResultColumn>> query = engine.query(select(max(column("COL1")).alias("MAX")).from(table("TEST")));
-
-        assertEquals("result ok?", 9, (int) query.get(0).get("MAX").toInt());
-    }
-
-    @Test
-    public void minTest() throws DatabaseEngineException {
-        create5ColumnsEntity();
-
-        EntityEntry.Builder entry = entry()
-                .set("COL1", 2)
-                .set("COL2", false)
-                .set("COL3", 2D)
-                .set("COL4", 3L)
-                .set("COL5", "ADEUS");
-
-        for (int i = 0; i < 10; i++) {
-            entry.set("COL1", i);
-            engine.persist("TEST", entry
-                    .build());
-        }
-        List<Map<String, ResultColumn>> query = engine.query(select(min(column("COL1")).alias("MIN")).from(table("TEST")));
-
-        assertEquals("result ok?", 0, (int) query.get(0).get("MIN").toInt());
-    }
-
-    @Test
-    public void floorTest() throws DatabaseEngineException {
-        create5ColumnsEntity();
-
-        EntityEntry.Builder entry = entry()
+        final EntityEntry.Builder entry = entry()
                 .set("COL1", 2)
                 .set("COL2", false)
                 .set("COL3", 2.5D)
@@ -1210,35 +1122,60 @@ public class EngineGeneralTest {
 
         for (int i = 0; i < 10; i++) {
             entry.set("COL1", i);
-            engine.persist("TEST", entry
-                    .build());
+            engine.persist("TEST", entry.build());
+            stats.accept(i);
         }
 
-        List<Map<String, ResultColumn>> query = engine.query(select(floor(column("COL3")).alias("FLOOR")).from(table("TEST")));
+        final Name col1 = column("COL1");
+        final List<Map<String, ResultColumn>> result = engine.query(select(
+                count(col1).alias(COUNT),
+                sum(col1).alias(SUM),
+                avg(col1).alias(AVG),
+                stddev(col1).alias(STDDEV),
+                stddevp(col1).alias(STDDEV_POP),
+                min(col1).alias(MIN),
+                max(col1).alias(MAX)
+        )
+                .from(table("TEST")));
 
-        assertEquals("result ok?", 2.0, query.get(0).get("FLOOR").toDouble(), DELTA);
+        assertThat(result).hasSize(1);
+
+        final Map<String, ResultColumn> statsResult = result.get(0);
+
+        final SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(statsResult.get(COUNT).toInt()).as(COUNT).isEqualTo(stats.getCount());
+        softly.assertThat(statsResult.get(SUM).toInt()).as(SUM).isEqualTo(stats.getSum());
+        softly.assertThat(statsResult.get(AVG).toDouble()).as(AVG).isEqualTo(stats.getAverage(), DELTA);
+        softly.assertThat(statsResult.get(STDDEV).toDouble()).as(STDDEV).isEqualTo(stats.getStdevSample(), DELTA);
+        softly.assertThat(statsResult.get(STDDEV_POP).toDouble()).as(STDDEV_POP).isEqualTo(stats.getStdevPop(), DELTA);
+        softly.assertThat(statsResult.get(MIN).toInt()).as(MIN).isEqualTo(stats.getMin());
+        softly.assertThat(statsResult.get(MAX).toInt()).as(MAX).isEqualTo(stats.getMax());
+        softly.assertAll();
     }
 
     @Test
-    public void ceilingTest() throws DatabaseEngineException {
+    public void roundingTest() throws DatabaseEngineException {
         create5ColumnsEntity();
 
-        EntityEntry.Builder entry = entry()
+        engine.persist("TEST", entry()
                 .set("COL1", 2)
                 .set("COL2", false)
                 .set("COL3", 2.5D)
                 .set("COL4", 3L)
-                .set("COL5", "ADEUS");
+                .set("COL5", "ADEUS")
+                .build());
 
-        for (int i = 0; i < 10; i++) {
-            entry.set("COL1", i);
-            engine.persist("TEST", entry
-                    .build());
-        }
+        final Map<String, ResultColumn> result = engine.query(select(
+                floor(column("COL3")).alias(FLOOR),
+                ceiling(column("COL3")).alias(CEILING)
+        )
+                .from(table("TEST")))
+                .get(0);
 
-        List<Map<String, ResultColumn>> query = engine.query(select(ceiling(column("COL3")).alias("CEILING")).from(table("TEST")));
-
-        assertEquals("result ok?", 3.0, query.get(0).get("CEILING").toDouble(), DELTA);
+        final SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(result.get(FLOOR).toDouble()).as(FLOOR).isEqualTo(2, DELTA);
+        softly.assertThat(result.get(CEILING).toDouble()).as(CEILING).isEqualTo(3, DELTA);
+        softly.assertAll();
     }
 
     @Test
@@ -4083,17 +4020,37 @@ public class EngineGeneralTest {
     }
 
     @Test
-    public void upperTest() throws DatabaseEngineException {
+    public void stringFunctionsTest() throws DatabaseEngineException {
         create5ColumnsEntity();
-        engine.persist("TEST", entry().set("COL5", "ola").build());
-        assertEquals("text is uppercase", "OLA", engine.query(select(upper(column("COL5")).alias("RES")).from(table("TEST"))).get(0).get("RES").toString());
-    }
+        final String testString = "oLaZaO";
 
-    @Test
-    public void lowerTest() throws DatabaseEngineException {
-        create5ColumnsEntity();
-        engine.persist("TEST", entry().set("COL5", "OLA").build());
-        assertEquals("text is lowercase", "ola", engine.query(select(lower(column("COL5")).alias("RES")).from(table("TEST"))).get(0).get("RES").toString());
+        engine.persist("TEST", entry().set("COL5", testString).build());
+
+        final Name col5 = column("COL5");
+        final Map<String, ResultColumn> queryResult = engine.query(
+                        select(
+                                upper(col5).alias(Function.UPPER),
+                                lower(col5).alias(Function.LOWER),
+                                ascii(col5).alias(Function.ASCII)
+                        )
+                                .from(table("TEST")))
+                .get(0);
+
+        final SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(queryResult.get(Function.UPPER).toString())
+                .as("text is uppercase")
+                .isEqualTo(testString.toUpperCase());
+
+        softly.assertThat(queryResult.get(Function.LOWER).toString())
+                .as("text is lowercase")
+                .isEqualTo(testString.toLowerCase());
+
+        final char asciiVal = testString.charAt(0);
+        softly.assertThat(queryResult.get(Function.ASCII).toInt())
+                .as("ascii for '%s' in '%s' is %d", asciiVal, testString, (int) asciiVal)
+                .isEqualTo(asciiVal);
+
+        softly.assertAll();
     }
 
     @Test


### PR DESCRIPTION
Summary:

Adds SQL functions:
- STDDEV_POP (standard deviation of a population), mainly to disambiguate with STDDEV (standard deviation of a sample);
- ASCII (returns the ASCII code of the first character in a string);
- CHAR_LENGTH (returns the length of a string, in number of characters);
- SUBSTRING (returns a substring of a string).
These functions are useful and all DBs support it.

For example in PostresSQL documentation:
https://www.postgresql.org/docs/9.6/functions-aggregate.html
https://www.postgresql.org/docs/9.6/functions-string.html

This commit also improves the translation of functions in general.
The new functions are tested in EngineGeneralTest, where some tests that performed the same actions on related functions were merged, to reduce the number of lines.