### PR TITLE
Update dependency versions and do some cleanups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,12 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.5.0</version>
+                <version>42.6.0</version>
             </dependency>
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>
-                <version>21.9.0.0</version>
+                <version>23.2.0.0</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.2.11</version>
+                <version>1.2.12</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -681,7 +681,7 @@
                                                 Prepare a new "pdb" database for tests with READ_COMMITTED_SNAPSHOT enabled
                                                  (required for SQL server to have the same behavior as other DBs in READ_COMMITTED
                                                  isolation level) and ALLOW_SNAPSHOT_ISOLATION enabled to allow using the
-                                                 TRANSACTION_SNAPSHOT level (equivalent to SERIALIZABLE in PostgreSQL and Oracle).
+                                                 TRANSACTION_SNAPSHOT level (equivalent to SERIALIZABLE in Oracle).
                                                 A new database needs to be used because the flags can't be enabled on "master" database.
                                                 -->
                                                 <postStart>/opt/mssql-tools/bin/sqlcmd -l 45 -U sa -P AaBb12.# -Q CREATE\ DATABASE\ pdb;\ ALTER\ DATABASE\ pdb\ SET\ READ_COMMITTED_SNAPSHOT\ ON;\ ALTER\ DATABASE\ pdb\ SET\ ALLOW_SNAPSHOT_ISOLATION\ ON</postStart>
@@ -746,7 +746,7 @@
         <profile>
             <id>cockroach</id>
             <properties>
-                <image.cockroach>cockroachdb/cockroach:v21.2.5</image.cockroach>
+                <image.cockroach>cockroachdb/cockroach:v22.2.7</image.cockroach>
             </properties>
             <build>
                 <plugins>

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -669,7 +669,7 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
             final String sString = format(
                     "SELECT T1.TABLE_NAME, CONSTRAINT_NAME "
                             + "FROM INFORMATION_SCHEMA.CONSTRAINT_TABLE_USAGE AS T1 "
-                            + "JOIN SYS.FOREIGN_KEYS AS F "
+                            + "JOIN sys.foreign_keys AS F "
                             + "ON (F.parent_object_id = OBJECT_ID(N'%s') OR "
                             + "F.referenced_object_id = OBJECT_ID(N'%s')) AND "
                             + "T1.CONSTRAINT_NAME = OBJECT_NAME(F.object_id) AND "

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -15,8 +15,6 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import com.feedzai.commons.sql.abstraction.batch.AbstractBatch;
 import com.feedzai.commons.sql.abstraction.batch.AbstractBatchConfig;
 import com.feedzai.commons.sql.abstraction.batch.BatchEntry;
@@ -47,11 +45,9 @@ import mockit.MockUp;
 import org.assertj.core.api.ObjectAssert;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -137,11 +133,6 @@ public class BatchUpdateTest {
 
     @Parameterized.Parameter(1)
     public Supplier<AbstractBatchConfig.Builder<?, ?, ?>> batchConfigBuilderSupplier;
-
-    @BeforeClass
-    public static void initStatic() {
-        ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.TRACE);
-    }
 
     @Before
     public void init() throws DatabaseFactoryException {

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
@@ -15,8 +15,6 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
 import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
@@ -32,11 +30,9 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Verifications;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -52,10 +48,9 @@ import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProper
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
 
-
 /**
  * Tests closing a {@link DatabaseEngine} to make sure all resources are cleaned up correctly.
- *
+ * <p>
  * It tests with each schema policy.
  *
  * @author David Fialho (david.fialho@feedzai.com)
@@ -97,11 +92,6 @@ public class EngineCloseTest {
         this.schemaPolicy = schemaPolicy;
     }
 
-    @BeforeClass
-    public static void initStatic() {
-        ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.TRACE);
-    }
-
     @Before
     public void setUp() throws DatabaseFactoryException {
         properties = new Properties() {{
@@ -118,7 +108,7 @@ public class EngineCloseTest {
     /**
      * Test that closing a database engine with multiple entities closes all insert statements associated with each
      * entity, regardless of the schema policy used.
-     *
+     * <p>
      * Each entity is associated with 3 prepared statements. This test ensures that 3 PSs per entity are closed.
      *
      * @param preparedStatementMock       The mock to check number of closed prepared statements.

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -15,8 +15,6 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import com.feedzai.commons.sql.abstraction.ddl.AlterColumn;
 import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
 import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
@@ -39,7 +37,6 @@ import com.feedzai.commons.sql.abstraction.engine.ConnectionResetException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
-import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineUniqueConstraintViolationException;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.MappedEntity;
@@ -50,8 +47,8 @@ import com.feedzai.commons.sql.abstraction.engine.testconfig.BlobTest;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineUniqueConstraintViolationException;
 import com.google.common.collect.ImmutableSet;
-import java.sql.SQLException;
 import mockit.Expectations;
 import mockit.Invocation;
 import mockit.Mock;
@@ -59,16 +56,15 @@ import mockit.MockUp;
 import mockit.Verifications;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -175,11 +171,6 @@ public class EngineGeneralTest {
 
     @Parameterized.Parameter
     public DatabaseConfiguration config;
-
-    @BeforeClass
-    public static void initStatic() {
-        ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.TRACE);
-    }
 
     @Before
     public void init() throws DatabaseFactoryException {
@@ -683,7 +674,7 @@ public class EngineGeneralTest {
 
     /**
      * Tests that on a rollback situation, the prepared statement batches are cleared.
-     *
+     * <p>
      * The steps performed on this test are:
      * <ol>
      *     <li>Add batch to transaction and purposely fail to flush</li>
@@ -4162,7 +4153,7 @@ public class EngineGeneralTest {
     /**
      * Test that closing a database engine a 'create-drop' policy with multiple entities closes all insert statements
      * associated with each entity, regardless of the schema policy used.
-     *
+     * <p>
      * Each entity is associated with 3 prepared statements. This test ensures that 3 PSs per entity are closed.
      *
      * @throws DatabaseEngineException  If something goes wrong while adding an entity to the engine.
@@ -4257,7 +4248,7 @@ public class EngineGeneralTest {
 
     /**
      * Tests that when inserting duplicated entries in a table the right exception is returned.
-     *
+     * <p>
      * The steps performed on this test are:
      * <ol>
      *     <li>Add duplicated entries in a transaction and fail to persist</li>
@@ -4289,7 +4280,7 @@ public class EngineGeneralTest {
 
     /**
      * Tests that on a duplicated batch entry situation the right exception is returned.
-     *
+     * <p>
      * The steps performed on this test are:
      * <ol>
      *     <li>Add duplicated batch entries to transaction and fail to flush</li>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <configuration>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <level>INFO</level>
+    <level>TRACE</level>
     <layout class="ch.qos.logback.classic.PatternLayout">
       <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
     </layout>
@@ -10,7 +10,7 @@
   <logger name="com.feedzai.commons.sql.abstraction" level="trace"/>
   <logger name="com.feedzai.commons.sql.abstraction.engine.impl" level="trace"/>
 
-  <root level="DEBUG">
+  <root level="TRACE">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
Summary:
- Updated some driver dependencies because of CVEs and to support newest database versions (still can't update MySQL driver, which also has CVE, because v8 isn't supported yet in PDB).
- Updated CockrachDB Docker image, with bugfixes and support for more SQL functions.
- Some tests were setting logger level to TRACE on BeforeClass, using Logback classes. Not only was this using Logback specific code (instead of SLF4J API), thus making updates more difficult, but the new log level would also affect other tests (since it is static). This commit removes that specific code and sets TRACE log level on the logback config file instead.