### PR TITLE
PDB-384: Make BLOB accept null values on all database engines

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -56,6 +56,7 @@ import java.util.Set;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
+import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.join;
 
 /**
@@ -124,6 +125,11 @@ public class DB2Engine extends AbstractDatabaseEngine {
             case JSON:
             case CLOB:
             case BLOB:
+                if (isNull(value)) {
+                    ps.setBytes(index, null);
+                    break;
+                }
+
                 ps.setBytes(index, objectToArray(value));
 
                 break;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
+import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.join;
 
 /**
@@ -122,6 +123,11 @@ public class MySqlEngine extends AbstractDatabaseEngine {
                                              final boolean fromBatch) throws Exception {
         switch (dbColumn.getDbColumnType()) {
             case BLOB:
+                if (isNull(value)) {
+                    ps.setBytes(index, null);
+                    break;
+                }
+
                 ps.setBytes(index, objectToArray(value));
 
                 break;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/OracleEngine.java
@@ -63,6 +63,7 @@ import java.util.concurrent.TimeUnit;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
+import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.join;
 
@@ -235,6 +236,11 @@ public class OracleEngine extends AbstractDatabaseEngine {
                                              final boolean fromBatch) throws Exception {
         switch (dbColumn.getDbColumnType()) {
             case BLOB:
+                if (isNull(value)) {
+                    ps.setBytes(index, null);
+                    break;
+                }
+
                 final byte[] valArray = objectToArray(value);
                 if (fromBatch && valArray.length > MIN_SIZE_FOR_BLOB) {
                     // Use a blob for columns greater than 4K when inside a batch

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -58,6 +58,7 @@ import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.table;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
+import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.join;
 
 /**
@@ -143,6 +144,11 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                                              final boolean fromBatch) throws Exception {
         switch (dbColumn.getDbColumnType()) {
             case BLOB:
+                if (isNull(value)) {
+                    ps.setBytes(index, null);
+                    break;
+                }
+
                 ps.setBytes(index, objectToArray(value));
                 break;
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/SqlServerEngine.java
@@ -51,6 +51,7 @@ import java.util.regex.Pattern;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
 import static java.lang.String.format;
+import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.join;
 
 /**
@@ -149,6 +150,11 @@ public class SqlServerEngine extends AbstractDatabaseEngine {
                                              final boolean fromBatch) throws Exception {
         switch (dbColumn.getDbColumnType()) {
             case BLOB:
+                if (isNull(value)) {
+                    ps.setBytes(index, null);
+                    break;
+                }
+
                 ps.setBytes(index, objectToArray(value));
                 break;
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/AbstractEngineSchemaTest.java
@@ -15,6 +15,7 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
+import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
 import com.feedzai.commons.sql.abstraction.ddl.DbColumnType;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntityType;
@@ -32,6 +33,7 @@ import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import com.google.common.collect.Sets;
+import java.sql.PreparedStatement;
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.data.MapEntry;
 import org.junit.Before;

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineGeneralTest.java
@@ -2788,6 +2788,27 @@ public class EngineGeneralTest {
         assertEquals(updBlob, result.get(0).get("COL2").<BlobTest>toBlob());
     }
 
+    /**
+     * Tests that persisting a null value to a BLOB type column persists a null value.
+     *
+     * @throws Exception If anything goes wrong on engine-related operations, namely adding an entity, persisting an
+     *                   entry and querying an entry.
+     */
+    @Test
+    public void testBlobPersistNull() throws Exception {
+        DbEntity entity = dbEntity().name("TEST").addColumn("COL1", STRING).addColumn("COL2", BLOB)
+                                    .build();
+        engine.addEntity(entity);
+        EntityEntry entry = entry().set("COL1", "CENINHAS").set("COL2", null)
+                                   .build();
+
+        engine.persist("TEST", entry);
+
+        List<Map<String, ResultColumn>> result = engine.query(select(all()).from(table("TEST")));
+        assertEquals("CENINHAS", result.get(0).get("COL1").toString());
+        assertNull(result.get(0).get("COL2").toObject());
+    }
+
     @Test
     public void testBlobSettingWithIndexTest() throws Exception {
         DbEntity entity = dbEntity().name("TEST").addColumn("COL1", STRING).addColumn("COL2", BLOB)


### PR DESCRIPTION
Summary:

Blob values, added to prepared statement value slots on a given index, are done so by creating a byte array stream of the value and passing the byte array to the value to be inserted. Without a null check, when persisting a null value what will actually end up on the column is a **small byte array representation of null**, and thus **the column will not actually be null** and hold a small value. The only current db system in which this does not happen is H2 because it already has a null check.

This commit adds a null check to each affected DB engine class and a general engine unit test with a scenario that goes through the affected codepath for any given engine type.

See more [here](https://github.com/feedzai/pdb/issues/384)