### PR TITLE
Add Support to Upsert/Insert Ignore on PDB

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -190,9 +190,14 @@ public interface DatabaseEngine extends AutoCloseable {
     /**
      * Flushes the batches for all the registered entities upserting duplicated entries.
      *
+     * @implNote The default implementation of this method throws an {@link UnsupportedOperationException}
+     * for backward-compatibility reasons. If this method is supposed to be called, it must be explicitly overridden.
+     *
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
-    void flushUpsert() throws DatabaseEngineException;
+    default void flushUpsert() throws DatabaseEngineException {
+        throw new UnsupportedOperationException("This method needs to be explicitly implemented ");
+    }
 
     /**
      * Commits the current transaction. You should only call this method if you've previously called
@@ -394,12 +399,18 @@ public interface DatabaseEngine extends AutoCloseable {
 
     /**
      * Adds an entry to the batch upserting duplicate entries.
-     *
+
      * @param name  The entity name.
      * @param entry The entry to persist.
+     *
+     * @implNote The default implementation of this method throws an {@link UnsupportedOperationException}
+     * for backward-compatibility reasons. If this method is supposed to be called, it must be explicitly overridden.
+     *
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
-    void addBatchUpsert(final String name, final EntityEntry entry) throws DatabaseEngineException;
+    default void addBatchUpsert(final String name, final EntityEntry entry) throws DatabaseEngineException {
+        throw new UnsupportedOperationException("This method needs to be explicitly implemented ");
+    }
 
     /**
      * Executes the given query.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -196,7 +196,7 @@ public interface DatabaseEngine extends AutoCloseable {
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
     default void flushUpsert() throws DatabaseEngineException {
-        throw new UnsupportedOperationException("This method needs to be explicitly implemented ");
+        throw new UnsupportedOperationException("Method not implemented.");
     }
 
     /**
@@ -399,7 +399,7 @@ public interface DatabaseEngine extends AutoCloseable {
 
     /**
      * Adds an entry to the batch upserting duplicate entries.
-
+     *
      * @param name  The entity name.
      * @param entry The entry to persist.
      *
@@ -409,7 +409,7 @@ public interface DatabaseEngine extends AutoCloseable {
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
     default void addBatchUpsert(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        throw new UnsupportedOperationException("This method needs to be explicitly implemented ");
+        throw new UnsupportedOperationException("Method not implemented.");
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -37,6 +37,7 @@ import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.util.Constants;
 import com.feedzai.commons.sql.abstraction.util.PreparedStatementCapsule;
 import com.ibm.db2.jcc.am.SqlSyntaxErrorException;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
@@ -425,17 +426,92 @@ public class DB2Engine extends AbstractDatabaseEngine {
         logger.trace(insertStatement);
         logger.trace(insertReturnStatement);
 
-        PreparedStatement ps, psReturn, psWithAutoInc;
+        PreparedStatement ps = null, psReturn = null, psWithAutoInc = null, psUpsert;
         try {
 
             ps = conn.prepareStatement(insertStatement);
             psReturn = conn.prepareStatement(insertReturnStatement);
             psWithAutoInc = conn.prepareStatement(insertWithAutoInc);
 
-            return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc).setAutoIncColumn(returning);
+            final String upsert = buildUpsertStatement(entity, columns, values);
+            psUpsert = conn.prepareStatement(upsert);
+
+            return new MappedEntity()
+                        .setInsert(ps)
+                        .setInsertReturning(psReturn)
+                        .setInsertWithAutoInc(psWithAutoInc)
+                        .setAutoIncColumn(returning)
+                        .setUpsert(psUpsert);
+
+        } catch (final IllegalArgumentException e) {
+            logger.trace("Returning entity without an UPSERT/MERGE prepared statement.");
+            return new MappedEntity()
+                        .setInsert(ps)
+                        .setInsertReturning(psReturn)
+                        .setInsertWithAutoInc(psWithAutoInc)
+                        .setAutoIncColumn(returning);
+
         } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }
+
+    }
+
+    /**
+     * Helper method to create an upsert statement for this engine.
+     *
+     * @param entity    The entity.
+     * @param columns   The columns of this entity.
+     * @param values    The values of the entity.
+     *
+     * @return          An upsert statement.
+     */
+    private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
+
+        if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
+            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
+        }
+
+        List<String> merge = new ArrayList<>();
+        merge.add("MERGE INTO " + quotize(entity.getName()) + " AS dest");
+
+        merge.add("USING (VALUES(" + join(values, ", ") + ")) AS src (" + join(columns, ", ") + ")");
+
+        final List<String> primaryKeys = entity.getPkFields()
+                                               .stream()
+                                               .map(com.feedzai.commons.sql.abstraction.util.StringUtils::quotize)
+                                               .collect(Collectors.toList());
+
+        final List<String> primaryKeysOnClause = primaryKeys
+                                                    .stream()
+                                                    .map(pk -> String.format("dest.%s = src.%s", pk, pk))
+                                                    .collect(Collectors.toList());
+
+        merge.add("ON ( " + join(primaryKeysOnClause, " AND ") + " )");
+
+        merge.add("WHEN MATCHED THEN");
+        merge.add("UPDATE");
+
+        final List<String> columnsWithoutPKs = new ArrayList<>(columns);
+        columnsWithoutPKs.removeAll(primaryKeys);
+
+        final String columnsToUpdate = columnsWithoutPKs
+                                        .stream()
+                                        .map(column -> String.format("%s = src.%s", column, column))
+                                        .collect(Collectors.joining(", "));
+
+        merge.add("SET " + columnsToUpdate);
+
+        merge.add("WHEN NOT MATCHED THEN");
+
+        final String insertColumns = columns.stream().map(column -> String.format("%s", column)).collect(Collectors.joining(", "));
+        merge.add("INSERT (" + insertColumns + ")");
+
+        final String insertColumnValues = columns.stream().map(value -> String.format("src.%s", value)).collect(Collectors.joining(", "));
+        merge.add("VALUES (" + insertColumnValues + ")");
+
+        return join(merge, " ");
+
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -463,8 +463,6 @@ public class H2Engine extends AbstractDatabaseEngine {
         insertIntoWithAutoInc.add("(" + join(columnsWithAutoInc, ", ") + ")");
         insertIntoWithAutoInc.add("VALUES (" + join(valuesWithAutoInc, ", ") + ")");
 
-        final String statementWithMerge = buildUpsertStatement(entity, columns, values);
-
         final String statement = join(insertInto, " ");
         // The H2 DB doesn't implement INSERT RETURNING. Therefore, we just create a dummy statement, which will
         // never be invoked by this implementation.
@@ -473,23 +471,34 @@ public class H2Engine extends AbstractDatabaseEngine {
         logger.trace(statement);
 
 
-        final PreparedStatement ps, psReturn, psWithAutoInc, psMerge;
+        PreparedStatement ps = null, psReturn = null, psWithAutoInc = null, psMerge;
         try {
 
             // Generate keys when the table has at least 1 column with auto generate value.
-            final int generateKeys = columnWithAutoIncName != null? Statement.RETURN_GENERATED_KEYS : Statement.NO_GENERATED_KEYS;
+            final int generateKeys = columnWithAutoIncName != null ? Statement.RETURN_GENERATED_KEYS : Statement.NO_GENERATED_KEYS;
             ps = this.conn.prepareStatement(statement, generateKeys);
             psReturn = this.conn.prepareStatement(insertReturnStatement, generateKeys);
             psWithAutoInc = this.conn.prepareStatement(statementWithAutoInt, generateKeys);
+
+            final String statementWithMerge = buildUpsertStatement(entity, columns, values);
             psMerge = this.conn.prepareStatement(statementWithMerge, generateKeys);
+
             return new MappedEntity()
-                .setInsert(ps)
-                .setInsertReturning(psReturn)
-                .setInsertWithAutoInc(psWithAutoInc)
-                // The auto incremented column must be set, so when persisting a row, it's possible to retrieve its value
-                // by consulting the column name from this MappedEntity.
-                .setAutoIncColumn(columnWithAutoIncName)
-                .setUpsert(psMerge);
+                        .setInsert(ps)
+                        .setInsertReturning(psReturn)
+                        .setInsertWithAutoInc(psWithAutoInc)
+                        // The auto incremented column must be set, so when persisting a row, it's possible to retrieve its value
+                        // by consulting the column name from this MappedEntity.
+                        .setAutoIncColumn(columnWithAutoIncName)
+                        .setUpsert(psMerge);
+
+        } catch (final IllegalArgumentException e) {
+            logger.trace("Returning entity without an UPSERT/MERGE prepared statement.");
+            return new MappedEntity()
+                        .setInsert(ps)
+                        .setInsertReturning(psReturn)
+                        .setInsertWithAutoInc(psWithAutoInc);
+
         } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -35,6 +35,7 @@ import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.engine.impl.postgresql.PostgresSqlQueryExceptionHandler;
+import com.feedzai.commons.sql.abstraction.util.StringUtils;
 
 import java.util.stream.Collectors;
 import org.postgresql.Driver;
@@ -406,39 +407,53 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         final String insertStatement = join(insertInto, " ");
         final String insertReturnStatement = join(insertIntoReturn, " ");
         final String statementWithAutoInt = join(insertIntoWithAutoInc, " ");
-        final String upsert = buildUpsertStatement(entity, columns, values);
 
         logger.trace(insertStatement);
         logger.trace(insertReturnStatement);
-        logger.trace(upsert);
 
-        PreparedStatement ps, psReturn, psWithAutoInc, psUpsert;
+        PreparedStatement ps = null, psReturn = null, psWithAutoInc = null, psUpsert;
         try {
 
             ps = conn.prepareStatement(insertStatement);
             psReturn = conn.prepareStatement(insertReturnStatement);
             psWithAutoInc = conn.prepareStatement(statementWithAutoInt);
+
+            final String upsert = buildUpsertStatement(entity, columns, values);
             psUpsert = conn.prepareStatement(upsert);
 
-            return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc).setUpsert(psUpsert).setAutoIncColumn(returning);
+            return new MappedEntity()
+                        .setInsert(ps)
+                        .setInsertReturning(psReturn)
+                        .setInsertWithAutoInc(psWithAutoInc)
+                        .setUpsert(psUpsert)
+                        .setAutoIncColumn(returning);
+
+        } catch (final IllegalArgumentException e) {
+            logger.trace("Returning entity without an UPSERT/MERGE prepared statement.");
+            return new MappedEntity()
+                        .setInsert(ps)
+                        .setInsertReturning(psReturn)
+                        .setInsertWithAutoInc(psWithAutoInc)
+                        .setAutoIncColumn(returning);
+
         } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }
     }
 
     /**
-     * Helper method to create a insert on conflict statement that updates for this engine.
+     * Helper method to create an insert statement on duplicate key conflict for this engine.
      *
      * @param entity    The entity.
      * @param columns   The columns of this entity.
      * @param values    The values of the entity.
      *
-     * @return          A insert on conflict statement.
+     * @return          An insert statement on duplicate key conflict.
      */
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            return "";
+            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
         }
 
         List<String> insertIntoIgnoring = new ArrayList<>();
@@ -448,7 +463,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         insertIntoIgnoring.add("(" + join(columns, ", ") + ")");
         insertIntoIgnoring.add("VALUES (" + join(values, ", ") + ")");
 
-        final List<String> primaryKeys = entity.getPkFields().stream().map(pk -> quotize(pk)).collect(Collectors.toList());
+        final List<String> primaryKeys = entity.getPkFields().stream().map(StringUtils::quotize).collect(Collectors.toList());
         insertIntoIgnoring.add("ON CONFLICT (" + join(primaryKeys, ", ") + ")");
 
         insertIntoIgnoring.add("DO UPDATE");

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -827,7 +827,7 @@ public class BatchUpdateTest {
      */
     @Test
     public void batchInsertOnIgnoreDuplicateFlushTest() throws Exception {
-        assumeTrue(ImmutableList.of("h2", "postresql").contains(dbConfig.vendor));
+        assumeTrue(ImmutableList.of("postresql", "mysql", "cockroach", "db2").contains(dbConfig.vendor) && dbConfig.vendor.startsWith("h2"));
         final TestBatchListener batchListener = new TestBatchListener();
         final int numTestEntries = 2;
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
@@ -123,7 +123,7 @@ public class EngineCloseTest {
     @Test
     public void closingAnEngineShouldFlushAndCloseInsertPSsAndCloseCachedPSs(@Capturing final Statement preparedStatementMock)
             throws DatabaseEngineException, SQLException, NameAlreadyExistsException {
-        assumeTrue(!ImmutableList.of("postgresql", "cockroach").contains(config.vendor) && !config.vendor.startsWith("h2"));
+        assumeTrue(!ImmutableList.of("postgresql", "cockroach", "mysql", "db2").contains(config.vendor) && !config.vendor.startsWith("h2"));
 
         engine.addEntity(buildEntity("ENTITY-1"));
         engine.addEntity(buildEntity("ENTITY-2"));


### PR DESCRIPTION
- Adds support for the following engines: MySQL, DB2.
- Adds an exception to being thrown when a merge is not possible and use a `MappedEntity` without an `UPSERT` statement.