### PR TITLE
Add Support to Upsert/Insert Ignore on PDB

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -966,12 +966,11 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
          */
 
         try {
-            final List<MappedEntity> upsertableEntities = entities.values()
-                                                                  .stream()
-                                                                  .filter(entity -> entity.getUpsert() != null)
-                                                                  .collect(Collectors.toList());
-            for (MappedEntity me : upsertableEntities) {
-                me.getUpsert().executeBatch();
+            for (MappedEntity me : entities.values()) {
+                final PreparedStatement upsert = me.getUpsert();
+                if (upsert != null) {
+                    upsert.executeBatch();
+                }
             }
         } catch (final Exception ex) {
             throw getQueryExceptionHandler().handleException(ex, "Something went wrong while flushing");

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -444,7 +444,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                         .setUpsert(psUpsert);
 
         } catch (final IllegalArgumentException e) {
-            logger.error("Returning entity without an UPSERT/MERGE prepared statement.", e);
+            logger.error("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -469,7 +469,9 @@ public class DB2Engine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
+            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created because the entity "
+                                                             + "'%s' has no primary keys. Skipping statement creation.",
+                                                             entity.getName()));
         }
 
         final List<String> merge = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -444,7 +444,8 @@ public class DB2Engine extends AbstractDatabaseEngine {
                         .setUpsert(psUpsert);
 
         } catch (final IllegalArgumentException e) {
-            logger.error("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -493,7 +493,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                         .setUpsert(psMerge);
 
         } catch (final IllegalArgumentException e) {
-            logger.error("Returning entity without an UPSERT/MERGE prepared statement.", e);
+            logger.error("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -517,7 +517,9 @@ public class H2Engine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
+            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created because the entity "
+                                                             + "'%s' has no primary keys. Skipping statement creation.",
+                                                             entity.getName()));
         }
 
         final List<String> mergeInto = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -493,7 +493,8 @@ public class H2Engine extends AbstractDatabaseEngine {
                         .setUpsert(psMerge);
 
         } catch (final IllegalArgumentException e) {
-            logger.error("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -408,7 +408,8 @@ public class MySqlEngine extends AbstractDatabaseEngine {
                         .setUpsert(psUpsert);
 
         } catch (final IllegalArgumentException e) {
-            logger.error("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -408,7 +408,7 @@ public class MySqlEngine extends AbstractDatabaseEngine {
                         .setUpsert(psUpsert);
 
         } catch (final IllegalArgumentException e) {
-            logger.error("Returning entity without an UPSERT/MERGE prepared statement.", e);
+            logger.error("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -431,7 +431,10 @@ public class MySqlEngine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
+            throw new IllegalArgumentException(String.format("The 'INSERT INTO (...) ON DUPLICATE KEY UPDATE' prepared statement was "
+                                                             + "not created because the entity '%s' has no primary keys. "
+                                                             + "Skipping statement creation.",
+                                                             entity.getName()));
         }
 
         List<String> insertIntoIgnoring = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -429,7 +429,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                         .setAutoIncColumn(returning);
 
         } catch (final IllegalArgumentException e) {
-            logger.error("Returning entity without an UPSERT/MERGE prepared statement.", e);
+            logger.error("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -453,7 +453,10 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
+            throw new IllegalArgumentException(String.format("The 'INSERT INTO (...) ON CONFLICT DO UPDATE' prepared statement was not "
+                                                             + "created because the entity '%s' has no primary keys. "
+                                                             + "Skipping statement creation.",
+                                                             entity.getName()));
         }
 
         List<String> insertIntoIgnoring = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -429,7 +429,8 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                         .setAutoIncColumn(returning);
 
         } catch (final IllegalArgumentException e) {
-            logger.error("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -821,12 +821,12 @@ public class BatchUpdateTest {
     }
 
     /**
-     * Tests if a batch with entries having duplicate ignores when there is an error.
+     * Tests if a batch with entries having duplicate upserts the entry when flushing.
      *
      * @throws Exception if any operations on the batch fail.
      */
     @Test
-    public void batchInsertOnIgnoreDuplicateFlushTest() throws Exception {
+    public void batchUpsertDuplicateFlushTest() throws Exception {
         assumeTrue(ImmutableList.of("postresql", "mysql", "cockroach", "db2").contains(dbConfig.vendor) && dbConfig.vendor.startsWith("h2"));
         final TestBatchListener batchListener = new TestBatchListener();
         final int numTestEntries = 2;
@@ -834,13 +834,12 @@ public class BatchUpdateTest {
         addTestEntityWithPrimaryKey();
 
         final DefaultBatch batch = engine.createBatch(DefaultBatchConfig.builder()
-                                                             .withName("batchInsertOnIgnoreDuplicateFlushTest")
-                                                             .withBatchSize(numTestEntries + 1)
-                                                             .withBatchTimeout(Duration.ofSeconds(100))
-                                                             .withMaxAwaitTimeShutdown(Duration.ofSeconds(1000))
-                                                             .withBatchListener(batchListener)
-                                                             .build()
-        );
+                                                                        .withName("batchUpsertDuplicateFlushTest")
+                                                                        .withBatchSize(numTestEntries + 1)
+                                                                        .withBatchTimeout(Duration.ofSeconds(100))
+                                                                        .withMaxAwaitTimeShutdown(Duration.ofSeconds(1000))
+                                                                        .withBatchListener(batchListener)
+                                                                        .build());
 
         // Add entries to batch, no flush should take place because numTestEntries < batch size and batch timeout is huge
         final int idx = 0;


### PR DESCRIPTION
This commit fixes the a `NullPointerException` thrown when trying to execute the batches of a MappedEntity. It also addressses a missing part of the implementation where the opearation of clearing the batch parameters was not performed when doing a rollback.

This commit also improves the logging information and the method names and its documentation when applicable. 

