### PR TITLE
Removes error logging for UPSERT command when creating an entity

### DIFF
--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -444,7 +444,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                         .setUpsert(psUpsert);
 
         } catch (final IllegalArgumentException e) {
-            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.info("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -469,9 +469,8 @@ public class DB2Engine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created because the entity "
-                                                             + "'%s' has no primary keys. Skipping statement creation.",
-                                                             entity.getName()));
+            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created for the entity "
+                                                             + "'%s'.", entity.getName()));
         }
 
         final List<String> merge = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -445,7 +445,6 @@ public class DB2Engine extends AbstractDatabaseEngine {
 
         } catch (final IllegalArgumentException e) {
             logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
-            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -494,7 +494,6 @@ public class H2Engine extends AbstractDatabaseEngine {
 
         } catch (final IllegalArgumentException e) {
             logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
-            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -493,7 +493,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                         .setUpsert(psMerge);
 
         } catch (final IllegalArgumentException e) {
-            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.info("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -517,9 +517,8 @@ public class H2Engine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created because the entity "
-                                                             + "'%s' has no primary keys. Skipping statement creation.",
-                                                             entity.getName()));
+            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created for the entity "
+                                                             + "'%s'.", entity.getName()));
         }
 
         final List<String> mergeInto = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -408,7 +408,7 @@ public class MySqlEngine extends AbstractDatabaseEngine {
                         .setUpsert(psUpsert);
 
         } catch (final IllegalArgumentException e) {
-            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.info("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -432,9 +432,7 @@ public class MySqlEngine extends AbstractDatabaseEngine {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
             throw new IllegalArgumentException(String.format("The 'INSERT INTO (...) ON DUPLICATE KEY UPDATE' prepared statement was "
-                                                             + "not created because the entity '%s' has no primary keys. "
-                                                             + "Skipping statement creation.",
-                                                             entity.getName()));
+                                                             + "not created for entity '%s.", entity.getName()));
         }
 
         List<String> insertIntoIgnoring = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -409,7 +409,6 @@ public class MySqlEngine extends AbstractDatabaseEngine {
 
         } catch (final IllegalArgumentException e) {
             logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
-            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -413,7 +413,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                         .setAutoIncColumn(returning);
 
         } catch (final IllegalArgumentException e) {
-            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.info("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -437,10 +437,8 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException(String.format("The 'INSERT INTO (...) ON CONFLICT DO UPDATE' prepared statement was not "
-                                                             + "created because the entity '%s' has no primary keys. "
-                                                             + "Skipping statement creation.",
-                                                             entity.getName()));
+            throw new IllegalArgumentException(String.format("The 'INSERT INTO (...) ON CONFLICT DO UPDATE' prepared "
+                                                             + "statement was not created for entity '%s'.", entity.getName()));
         }
 
         List<String> insertIntoIgnoring = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -414,7 +414,6 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
 
         } catch (final IllegalArgumentException e) {
             logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
-            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)


### PR DESCRIPTION
This commit removes an unnecessary stack trace logging when an entity is created on pdb and it has no primary keys.