### PR TITLE
Reverts the Support to Upsert/Insert Ignore on PDB

### DIFF
--- a/.github/workflows/test-oracle.yml
+++ b/.github/workflows/test-oracle.yml
@@ -15,7 +15,6 @@ jobs:
     name: Test Oracle PDB Java ${{ matrix.java-version }}
 
     strategy:
-      max-parallel: 1
       matrix:
         java-version: [ 8, 11, 17 ]
     steps:

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -15,22 +15,7 @@
  */
 package com.feedzai.commons.sql.abstraction.batch;
 
-import com.feedzai.commons.sql.abstraction.FailureListener;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
-import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
-import com.feedzai.commons.sql.abstraction.listeners.MetricsListener;
-import com.feedzai.commons.sql.abstraction.listeners.impl.NoopBatchListener;
-import com.feedzai.commons.sql.abstraction.listeners.impl.NoopMetricsListener;
 import com.google.common.base.Strings;
-import org.apache.commons.lang3.time.DurationFormatUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
-
-import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -42,6 +27,21 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+import com.feedzai.commons.sql.abstraction.FailureListener;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
+import com.feedzai.commons.sql.abstraction.listeners.MetricsListener;
+import com.feedzai.commons.sql.abstraction.listeners.impl.NoopBatchListener;
+import com.feedzai.commons.sql.abstraction.listeners.impl.NoopMetricsListener;
 
 /**
  * A Batch that periodically flushes pending insertions to the database.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -470,7 +470,7 @@ public abstract class AbstractBatch extends AbstractPdbBatch implements Runnable
     /**
      * Flushes the pending batches ignoring duplicate entries.
      */
-    public void flushUpsert() {
+    public void flushIgnore() {
         logger.trace("Start batch flushing ignoring duplicated entries.");
         flush((this::processBatchIgnoring));
     }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -471,8 +471,8 @@ public abstract class AbstractBatch extends AbstractPdbBatch implements Runnable
      * Flushes the pending batches ignoring duplicate entries.
      */
     public void flushUpsert() {
-        logger.trace("Start batch flushing upserting duplicated entries.");
-        flush((this::processBatchUpsert));
+        logger.trace("Start batch flushing ignoring duplicated entries.");
+        flush((this::processBatchIgnoring));
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -15,7 +15,22 @@
  */
 package com.feedzai.commons.sql.abstraction.batch;
 
+import com.feedzai.commons.sql.abstraction.FailureListener;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
+import com.feedzai.commons.sql.abstraction.listeners.MetricsListener;
+import com.feedzai.commons.sql.abstraction.listeners.impl.NoopBatchListener;
+import com.feedzai.commons.sql.abstraction.listeners.impl.NoopMetricsListener;
 import com.google.common.base.Strings;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -27,21 +42,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import javax.annotation.Nullable;
-import org.apache.commons.lang3.time.DurationFormatUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
-
-import com.feedzai.commons.sql.abstraction.FailureListener;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
-import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
-import com.feedzai.commons.sql.abstraction.listeners.MetricsListener;
-import com.feedzai.commons.sql.abstraction.listeners.impl.NoopBatchListener;
-import com.feedzai.commons.sql.abstraction.listeners.impl.NoopMetricsListener;
 
 /**
  * A Batch that periodically flushes pending insertions to the database.
@@ -366,17 +366,6 @@ public abstract class AbstractBatch extends AbstractPdbBatch implements Runnable
     }
 
     /**
-     * A functional interface to represent a {@link java.util.function.BiConsumer} that throws an exception.
-     *
-     * @param <T> the type of the first argument to the operation.
-     * @param <R> the type of the second argument to the operation.
-     */
-    @FunctionalInterface
-    public interface ThrowingBiConsumer<T, R> {
-        void accept(T t, R r) throws Exception;
-    }
-
-    /**
      * Starts the timer task.
      */
     protected void start() {
@@ -463,24 +452,6 @@ public abstract class AbstractBatch extends AbstractPdbBatch implements Runnable
      * @implSpec Same as {@link #flush(boolean)} with {@code false}.
      */
     public void flush() {
-        logger.trace("Start batch flushing entries.");
-        flush(this::processBatch);
-    }
-
-    /**
-     * Flushes the pending batches ignoring duplicate entries.
-     */
-    public void flushIgnore() {
-        logger.trace("Start batch flushing ignoring duplicated entries.");
-        flush((this::processBatchIgnoring));
-    }
-
-    /**
-     * Flushes the pending batches given a processing callback function.
-     *
-     * @param processBatch A (throwing) BiConsumer to process the batch entries.
-     */
-    private void flush(final ThrowingBiConsumer<DatabaseEngine, List<BatchEntry>> processBatch) {
         this.metricsListener.onFlushTriggered();
         final long flushTriggeredMs = System.currentTimeMillis();
         List<BatchEntry> temp;
@@ -514,7 +485,7 @@ public abstract class AbstractBatch extends AbstractPdbBatch implements Runnable
             this.metricsListener.onFlushStarted(flushTriggeredMs, temp.size());
             start = System.currentTimeMillis();
 
-            processBatch.accept(de, temp);
+            processBatch(de, temp);
 
             onFlushFinished(flushTriggeredMs, temp, Collections.emptyList());
             logger.trace("[{}] Batch flushed. Took {} ms, {} rows.", name, System.currentTimeMillis() - start, temp.size());

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractBatch.java
@@ -372,8 +372,8 @@ public abstract class AbstractBatch extends AbstractPdbBatch implements Runnable
      * @param <R> the type of the second argument to the operation.
      */
     @FunctionalInterface
-    private interface FlushConsumer<T, R> {
-        void accept(T t, R r) throws DatabaseEngineException;
+    public interface ThrowingBiConsumer<T, R> {
+        void accept(T t, R r) throws Exception;
     }
 
     /**
@@ -480,7 +480,7 @@ public abstract class AbstractBatch extends AbstractPdbBatch implements Runnable
      *
      * @param processBatch A (throwing) BiConsumer to process the batch entries.
      */
-    private void flush(final FlushConsumer<DatabaseEngine, List<BatchEntry>> processBatch) {
+    private void flush(final ThrowingBiConsumer<DatabaseEngine, List<BatchEntry>> processBatch) {
         this.metricsListener.onFlushTriggered();
         final long flushTriggeredMs = System.currentTimeMillis();
         List<BatchEntry> temp;
@@ -539,7 +539,7 @@ public abstract class AbstractBatch extends AbstractPdbBatch implements Runnable
                         de.rollback();
                     }
 
-                    processBatch.accept(de, temp);
+                    processBatch(de, temp);
 
                     success = true;
                 } catch (final InterruptedException ex) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractPdbBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractPdbBatch.java
@@ -82,7 +82,7 @@ public abstract class AbstractPdbBatch implements PdbBatch {
      * @param batchEntries              The list of batch entries to be flushed.
      * @throws DatabaseEngineException  If the operation failed.
      */
-    protected void processBatchUpsert(final DatabaseEngine de, final List<BatchEntry> batchEntries) throws DatabaseEngineException {
+    protected void processBatchIgnoring(final DatabaseEngine de, final List<BatchEntry> batchEntries) throws DatabaseEngineException {
         /*
          Begin transaction before the addBatch calls, in order to force the retry of the connection if it was lost during
          or since the last batch. Otherwise, the addBatch call that uses a prepared statement will fail.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractPdbBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractPdbBatch.java
@@ -16,12 +16,12 @@
 
 package com.feedzai.commons.sql.abstraction.batch;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * A abstract {@link PdbBatch} with useful default base methods for concrete implementations.
@@ -72,29 +72,4 @@ public abstract class AbstractPdbBatch implements PdbBatch {
         de.flush();
         de.commit();
     }
-
-    /**
-     * Processes all batch entries ignoring duplicate entries.
-     *
-     * @implSpec Same as {@link #processBatch(DatabaseEngine, List)}}.
-     *
-     * @param de                        The {@link DatabaseEngine} on which to perform the flush.
-     * @param batchEntries              The list of batch entries to be flushed.
-     * @throws DatabaseEngineException  If the operation failed.
-     */
-    protected void processBatchIgnoring(final DatabaseEngine de, final List<BatchEntry> batchEntries) throws DatabaseEngineException {
-        /*
-         Begin transaction before the addBatch calls, in order to force the retry of the connection if it was lost during
-         or since the last batch. Otherwise, the addBatch call that uses a prepared statement will fail.
-         */
-        de.beginTransaction();
-
-        for (final BatchEntry entry : batchEntries) {
-            de.addBatchIgnore(entry.getTableName(), entry.getEntityEntry());
-        }
-
-        de.flushIgnore();
-        de.commit();
-    }
-
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractPdbBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractPdbBatch.java
@@ -90,10 +90,10 @@ public abstract class AbstractPdbBatch implements PdbBatch {
         de.beginTransaction();
 
         for (final BatchEntry entry : batchEntries) {
-            de.addBatchUpsert(entry.getTableName(), entry.getEntityEntry());
+            de.addBatchIgnore(entry.getTableName(), entry.getEntityEntry());
         }
 
-        de.flushUpsert();
+        de.flushIgnore();
         de.commit();
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractPdbBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/AbstractPdbBatch.java
@@ -16,12 +16,12 @@
 
 package com.feedzai.commons.sql.abstraction.batch;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * A abstract {@link PdbBatch} with useful default base methods for concrete implementations.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/PdbBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/PdbBatch.java
@@ -62,10 +62,10 @@ public interface PdbBatch extends AutoCloseable {
     CompletableFuture<Void> flushAsync() throws Exception;
 
     /**
-     * Flushes the pending batches upserting entries to avoid duplicated key violations.
+     * Flushes the pending batches ignoring duplicated key violations.
      *
      * @throws Exception If an error occurs while flushing.
      */
-    void flushUpsert() throws Exception;
+    void flushIgnore() throws Exception;
 
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/PdbBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/PdbBatch.java
@@ -16,9 +16,9 @@
 
 package com.feedzai.commons.sql.abstraction.batch;
 
-import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-
 import java.util.concurrent.CompletableFuture;
+
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 
 /**
  * Interface specifying a batch that periodically flushes pending insertions to the database.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/PdbBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/PdbBatch.java
@@ -16,9 +16,9 @@
 
 package com.feedzai.commons.sql.abstraction.batch;
 
-import java.util.concurrent.CompletableFuture;
-
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Interface specifying a batch that periodically flushes pending insertions to the database.
@@ -60,12 +60,4 @@ public interface PdbBatch extends AutoCloseable {
      * @return A void {@link CompletableFuture} that completes when the flush action finishes.
      */
     CompletableFuture<Void> flushAsync() throws Exception;
-
-    /**
-     * Flushes the pending batches ignoring duplicated key violations.
-     *
-     * @throws Exception If an error occurs while flushing.
-     */
-    void flushIgnore() throws Exception;
-
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/impl/MultithreadedBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/impl/MultithreadedBatch.java
@@ -16,21 +16,7 @@
 
 package com.feedzai.commons.sql.abstraction.batch.impl;
 
-import com.feedzai.commons.sql.abstraction.batch.AbstractPdbBatch;
-import com.feedzai.commons.sql.abstraction.batch.BatchEntry;
-import com.feedzai.commons.sql.abstraction.batch.PdbBatch;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
-import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
-import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
-import com.feedzai.commons.sql.abstraction.listeners.MetricsListener;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.commons.lang3.time.DurationFormatUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
-
-import javax.inject.Inject;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -52,6 +38,20 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import javax.inject.Inject;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+import com.feedzai.commons.sql.abstraction.batch.AbstractPdbBatch;
+import com.feedzai.commons.sql.abstraction.batch.BatchEntry;
+import com.feedzai.commons.sql.abstraction.batch.PdbBatch;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
+import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
+import com.feedzai.commons.sql.abstraction.listeners.MetricsListener;
 
 /**
  * A Batch that periodically flushes pending insertions to the database using multiple threads/connections.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/impl/MultithreadedBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/impl/MultithreadedBatch.java
@@ -16,7 +16,21 @@
 
 package com.feedzai.commons.sql.abstraction.batch.impl;
 
+import com.feedzai.commons.sql.abstraction.batch.AbstractPdbBatch;
+import com.feedzai.commons.sql.abstraction.batch.BatchEntry;
+import com.feedzai.commons.sql.abstraction.batch.PdbBatch;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
+import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
+import com.feedzai.commons.sql.abstraction.listeners.MetricsListener;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+import javax.inject.Inject;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -38,20 +52,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import javax.inject.Inject;
-import org.apache.commons.lang3.time.DurationFormatUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
-
-import com.feedzai.commons.sql.abstraction.batch.AbstractPdbBatch;
-import com.feedzai.commons.sql.abstraction.batch.BatchEntry;
-import com.feedzai.commons.sql.abstraction.batch.PdbBatch;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
-import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
-import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
-import com.feedzai.commons.sql.abstraction.listeners.MetricsListener;
 
 /**
  * A Batch that periodically flushes pending insertions to the database using multiple threads/connections.
@@ -338,11 +338,6 @@ public class MultithreadedBatch extends AbstractPdbBatch implements PdbBatch {
             flushFuture.completeExceptionally(e);
             return flushFuture;
         }
-    }
-
-    @Override
-    public void flushIgnore() {
-        logger.trace("Flush ignoring not available for MultithreadedBatch. Skipping ...");
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/impl/MultithreadedBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/impl/MultithreadedBatch.java
@@ -341,7 +341,7 @@ public class MultithreadedBatch extends AbstractPdbBatch implements PdbBatch {
     }
 
     @Override
-    public void flushUpsert() {
+    public void flushIgnore() {
         logger.trace("Flush ignoring not available for MultithreadedBatch. Skipping ...");
     }
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/batch/impl/MultithreadedBatch.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/batch/impl/MultithreadedBatch.java
@@ -342,8 +342,7 @@ public class MultithreadedBatch extends AbstractPdbBatch implements PdbBatch {
 
     @Override
     public void flushUpsert() {
-        logger.error("Flush ignoring not available for MultithreadedBatch.");
-        throw new UnsupportedOperationException("Flushing pending batches upserting duplicated entries is not implemented using multiple threads/connections.");
+        logger.trace("Flush ignoring not available for MultithreadedBatch. Skipping ...");
     }
 
     /**

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -15,33 +15,6 @@
  */
 package com.feedzai.commons.sql.abstraction.engine;
 
-import com.feedzai.commons.sql.abstraction.FailureListener;
-import com.feedzai.commons.sql.abstraction.batch.AbstractBatch;
-import com.feedzai.commons.sql.abstraction.batch.BatchConfig;
-import com.feedzai.commons.sql.abstraction.batch.DefaultBatch;
-import com.feedzai.commons.sql.abstraction.batch.PdbBatch;
-import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
-import com.feedzai.commons.sql.abstraction.ddl.DbColumnType;
-import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
-import com.feedzai.commons.sql.abstraction.ddl.DbEntityType;
-import com.feedzai.commons.sql.abstraction.ddl.DbFk;
-import com.feedzai.commons.sql.abstraction.ddl.DbIndex;
-import com.feedzai.commons.sql.abstraction.dml.Expression;
-import com.feedzai.commons.sql.abstraction.dml.dialect.Dialect;
-import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
-import com.feedzai.commons.sql.abstraction.dml.result.ResultIterator;
-import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
-import com.feedzai.commons.sql.abstraction.engine.handler.ExceptionHandler;
-import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
-import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
-import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableException;
-import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableRuntimeException;
-import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
-import com.feedzai.commons.sql.abstraction.util.AESHelper;
-import com.feedzai.commons.sql.abstraction.util.Constants;
-import com.feedzai.commons.sql.abstraction.util.InitiallyReusableByteArrayOutputStream;
-import com.feedzai.commons.sql.abstraction.util.PreparedStatementCapsule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -49,14 +22,6 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Stage;
 import com.google.inject.util.Providers;
-import org.apache.commons.lang3.NotImplementedException;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
-
-import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -85,6 +50,41 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+import com.feedzai.commons.sql.abstraction.FailureListener;
+import com.feedzai.commons.sql.abstraction.batch.AbstractBatch;
+import com.feedzai.commons.sql.abstraction.batch.BatchConfig;
+import com.feedzai.commons.sql.abstraction.batch.DefaultBatch;
+import com.feedzai.commons.sql.abstraction.batch.PdbBatch;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumnType;
+import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
+import com.feedzai.commons.sql.abstraction.ddl.DbEntityType;
+import com.feedzai.commons.sql.abstraction.ddl.DbFk;
+import com.feedzai.commons.sql.abstraction.ddl.DbIndex;
+import com.feedzai.commons.sql.abstraction.dml.Expression;
+import com.feedzai.commons.sql.abstraction.dml.dialect.Dialect;
+import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
+import com.feedzai.commons.sql.abstraction.dml.result.ResultIterator;
+import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
+import com.feedzai.commons.sql.abstraction.engine.handler.ExceptionHandler;
+import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableException;
+import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableRuntimeException;
+import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
+import com.feedzai.commons.sql.abstraction.util.AESHelper;
+import com.feedzai.commons.sql.abstraction.util.Constants;
+import com.feedzai.commons.sql.abstraction.util.InitiallyReusableByteArrayOutputStream;
+import com.feedzai.commons.sql.abstraction.util.PreparedStatementCapsule;
 
 import static com.feedzai.commons.sql.abstraction.batch.AbstractBatch.DEFAULT_RETRY_INTERVAL;
 import static com.feedzai.commons.sql.abstraction.batch.AbstractBatch.NO_RETRY;
@@ -1141,7 +1141,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     /**
      * Creates a new batch that periodically flushes a batch. A flush will also occur when the maximum number of statements in the batch is reached.
      * <p>
-     * Please be sure to call {@link com.feedzai.commons.sql.abstraction.batch.AbstractBatch#destroy() } before closing the session with the database
+     * Please be sure to call {@link AbstractBatch#destroy() } before closing the session with the database
      *
      * @param batchSize    The batch size.
      * @param batchTimeout If inserts do not occur after the specified time, a flush will be performed.
@@ -1940,7 +1940,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     /**
      * Maps the database type to {@link DbColumnType}. If there's no mapping a {@link DbColumnType#UNMAPPED} is returned.
      *
-     * @param type     The SQL type from {@link java.sql.Types}.
+     * @param type     The SQL type from {@link Types}.
      * @param typeName The native database type name.  It provides additional information for
      *                 derived classes to resolve types unmapped here.
      * @return The {@link DbColumnType}.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -503,7 +503,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
             final PreparedStatement insert = mappedEntity.getInsert();
             final PreparedStatement insertReturning = mappedEntity.getInsertReturning();
             final PreparedStatement insertWithAutoInc = mappedEntity.getInsertWithAutoInc();
-            final PreparedStatement insertIgnoring = mappedEntity.getUpsert();
+            final PreparedStatement insertIgnoring = mappedEntity.getInsertIgnoring();
 
             if (!insert.isClosed()) {
                 insert.executeBatch();
@@ -955,19 +955,19 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     }
 
     /**
-     * Flushes the batches for all the registered entities, upserting any following .
+     * Flushes the batches for all the registered entities.
      *
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
     @Override
-    public synchronized void flushUpsert() throws DatabaseEngineException {
+    public synchronized void flushIgnore() throws DatabaseEngineException {
         /*
          * Reconnect on this method does not make sense since a new connection will have nothing to flush.
          */
 
         try {
             for (MappedEntity me : entities.values()) {
-                me.getUpsert().executeBatch();
+                me.getInsertIgnoring().executeBatch();
             }
         } catch (final Exception ex) {
             throw getQueryExceptionHandler().handleException(ex, "Something went wrong while flushing");
@@ -1341,7 +1341,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     }
 
     @Override
-    public synchronized void addBatchUpsert(final String name, final EntityEntry entry) throws DatabaseEngineException {
+    public synchronized void addBatchIgnore(final String name, final EntityEntry entry) throws DatabaseEngineException {
         try {
 
             final MappedEntity me = entities.get(name);
@@ -1350,7 +1350,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
                 throw new DatabaseEngineException(String.format("Unknown entity '%s'", name));
             }
 
-            PreparedStatement ps = me.getUpsert();
+            PreparedStatement ps = me.getInsertIgnoring();
 
             entityToPreparedStatementForBatch(me.getEntity(), ps, entry, true);
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -967,10 +967,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
 
         try {
             for (MappedEntity me : entities.values()) {
-                final PreparedStatement upsert = me.getUpsert();
-                if (upsert != null) {
-                    upsert.executeBatch();
-                }
+                me.getUpsert().executeBatch();
             }
         } catch (final Exception ex) {
             throw getQueryExceptionHandler().handleException(ex, "Something went wrong while flushing");
@@ -1015,9 +1012,6 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
                 mappedEntity.getInsert().clearBatch();
                 mappedEntity.getInsertReturning().clearBatch();
                 mappedEntity.getInsertWithAutoInc().clearBatch();
-                if (mappedEntity.getUpsert() != null) {
-                    mappedEntity.getUpsert().clearBatch();
-                }
             }
             conn.rollback();
             conn.setAutoCommit(true);
@@ -1357,10 +1351,6 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
             }
 
             PreparedStatement ps = me.getUpsert();
-
-            if (ps == null) {
-                throw new DatabaseEngineException(String.format("Error adding to batch: Entity %s has a null merge/upsert statement.", name));
-            }
 
             entityToPreparedStatementForBatch(me.getEntity(), ps, entry, true);
 

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -15,6 +15,33 @@
  */
 package com.feedzai.commons.sql.abstraction.engine;
 
+import com.feedzai.commons.sql.abstraction.FailureListener;
+import com.feedzai.commons.sql.abstraction.batch.AbstractBatch;
+import com.feedzai.commons.sql.abstraction.batch.BatchConfig;
+import com.feedzai.commons.sql.abstraction.batch.DefaultBatch;
+import com.feedzai.commons.sql.abstraction.batch.PdbBatch;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
+import com.feedzai.commons.sql.abstraction.ddl.DbColumnType;
+import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
+import com.feedzai.commons.sql.abstraction.ddl.DbEntityType;
+import com.feedzai.commons.sql.abstraction.ddl.DbFk;
+import com.feedzai.commons.sql.abstraction.ddl.DbIndex;
+import com.feedzai.commons.sql.abstraction.dml.Expression;
+import com.feedzai.commons.sql.abstraction.dml.dialect.Dialect;
+import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
+import com.feedzai.commons.sql.abstraction.dml.result.ResultIterator;
+import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
+import com.feedzai.commons.sql.abstraction.engine.handler.ExceptionHandler;
+import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
+import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableException;
+import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableRuntimeException;
+import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
+import com.feedzai.commons.sql.abstraction.util.AESHelper;
+import com.feedzai.commons.sql.abstraction.util.Constants;
+import com.feedzai.commons.sql.abstraction.util.InitiallyReusableByteArrayOutputStream;
+import com.feedzai.commons.sql.abstraction.util.PreparedStatementCapsule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -22,6 +49,14 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Stage;
 import com.google.inject.util.Providers;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -50,41 +85,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
-import org.apache.commons.lang3.NotImplementedException;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
-
-import com.feedzai.commons.sql.abstraction.FailureListener;
-import com.feedzai.commons.sql.abstraction.batch.AbstractBatch;
-import com.feedzai.commons.sql.abstraction.batch.BatchConfig;
-import com.feedzai.commons.sql.abstraction.batch.DefaultBatch;
-import com.feedzai.commons.sql.abstraction.batch.PdbBatch;
-import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
-import com.feedzai.commons.sql.abstraction.ddl.DbColumnType;
-import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
-import com.feedzai.commons.sql.abstraction.ddl.DbEntityType;
-import com.feedzai.commons.sql.abstraction.ddl.DbFk;
-import com.feedzai.commons.sql.abstraction.ddl.DbIndex;
-import com.feedzai.commons.sql.abstraction.dml.Expression;
-import com.feedzai.commons.sql.abstraction.dml.dialect.Dialect;
-import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
-import com.feedzai.commons.sql.abstraction.dml.result.ResultIterator;
-import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
-import com.feedzai.commons.sql.abstraction.engine.handler.ExceptionHandler;
-import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
-import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
-import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableException;
-import com.feedzai.commons.sql.abstraction.exceptions.DatabaseEngineRetryableRuntimeException;
-import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
-import com.feedzai.commons.sql.abstraction.util.AESHelper;
-import com.feedzai.commons.sql.abstraction.util.Constants;
-import com.feedzai.commons.sql.abstraction.util.InitiallyReusableByteArrayOutputStream;
-import com.feedzai.commons.sql.abstraction.util.PreparedStatementCapsule;
 
 import static com.feedzai.commons.sql.abstraction.batch.AbstractBatch.DEFAULT_RETRY_INTERVAL;
 import static com.feedzai.commons.sql.abstraction.batch.AbstractBatch.NO_RETRY;
@@ -503,7 +503,6 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
             final PreparedStatement insert = mappedEntity.getInsert();
             final PreparedStatement insertReturning = mappedEntity.getInsertReturning();
             final PreparedStatement insertWithAutoInc = mappedEntity.getInsertWithAutoInc();
-            final PreparedStatement insertIgnoring = mappedEntity.getInsertIgnoring();
 
             if (!insert.isClosed()) {
                 insert.executeBatch();
@@ -515,10 +514,6 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
 
             if (insertWithAutoInc != null && !insertWithAutoInc.isClosed()) {
                 insertWithAutoInc.executeBatch();
-            }
-
-            if (insertIgnoring != null && !insertIgnoring.isClosed()) {
-                insertIgnoring.executeBatch();
             }
 
         } catch (final SQLException e) {
@@ -955,26 +950,6 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     }
 
     /**
-     * Flushes the batches for all the registered entities.
-     *
-     * @throws DatabaseEngineException If something goes wrong while persisting data.
-     */
-    @Override
-    public synchronized void flushIgnore() throws DatabaseEngineException {
-        /*
-         * Reconnect on this method does not make sense since a new connection will have nothing to flush.
-         */
-
-        try {
-            for (MappedEntity me : entities.values()) {
-                me.getInsertIgnoring().executeBatch();
-            }
-        } catch (final Exception ex) {
-            throw getQueryExceptionHandler().handleException(ex, "Something went wrong while flushing");
-        }
-    }
-
-    /**
      * Commits the current transaction. You should only call this method if you've previously called {@link AbstractDatabaseEngine#beginTransaction()}.
      *
      * @throws DatabaseEngineRuntimeException If something goes wrong while persisting data.
@@ -1141,7 +1116,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     /**
      * Creates a new batch that periodically flushes a batch. A flush will also occur when the maximum number of statements in the batch is reached.
      * <p>
-     * Please be sure to call {@link AbstractBatch#destroy() } before closing the session with the database
+     * Please be sure to call {@link com.feedzai.commons.sql.abstraction.batch.AbstractBatch#destroy() } before closing the session with the database
      *
      * @param batchSize    The batch size.
      * @param batchTimeout If inserts do not occur after the specified time, a flush will be performed.
@@ -1331,27 +1306,6 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
             }
 
             PreparedStatement ps = me.getInsert();
-            entityToPreparedStatementForBatch(me.getEntity(), ps, entry, true);
-
-            ps.addBatch();
-        } catch (final Exception ex) {
-            throw new DatabaseEngineException("Error adding to batch", ex);
-        }
-
-    }
-
-    @Override
-    public synchronized void addBatchIgnore(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        try {
-
-            final MappedEntity me = entities.get(name);
-
-            if (me == null) {
-                throw new DatabaseEngineException(String.format("Unknown entity '%s'", name));
-            }
-
-            PreparedStatement ps = me.getInsertIgnoring();
-
             entityToPreparedStatementForBatch(me.getEntity(), ps, entry, true);
 
             ps.addBatch();
@@ -1940,7 +1894,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
     /**
      * Maps the database type to {@link DbColumnType}. If there's no mapping a {@link DbColumnType#UNMAPPED} is returned.
      *
-     * @param type     The SQL type from {@link Types}.
+     * @param type     The SQL type from {@link java.sql.Types}.
      * @param typeName The native database type name.  It provides additional information for
      *                 derived classes to resolve types unmapped here.
      * @return The {@link DbColumnType}.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/AbstractDatabaseEngine.java
@@ -503,7 +503,7 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
             final PreparedStatement insert = mappedEntity.getInsert();
             final PreparedStatement insertReturning = mappedEntity.getInsertReturning();
             final PreparedStatement insertWithAutoInc = mappedEntity.getInsertWithAutoInc();
-            final PreparedStatement upsert = mappedEntity.getUpsert();
+            final PreparedStatement insertIgnoring = mappedEntity.getUpsert();
 
             if (!insert.isClosed()) {
                 insert.executeBatch();
@@ -517,8 +517,8 @@ public abstract class AbstractDatabaseEngine implements DatabaseEngine {
                 insertWithAutoInc.executeBatch();
             }
 
-            if (upsert != null && !upsert.isClosed()) {
-                upsert.executeBatch();
+            if (insertIgnoring != null && !insertIgnoring.isClosed()) {
+                insertIgnoring.executeBatch();
             }
 
         } catch (final SQLException e) {

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -15,6 +15,15 @@
  */
 package com.feedzai.commons.sql.abstraction.engine;
 
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+
 import com.feedzai.commons.sql.abstraction.FailureListener;
 import com.feedzai.commons.sql.abstraction.batch.AbstractBatch;
 import com.feedzai.commons.sql.abstraction.batch.BatchConfig;
@@ -30,15 +39,6 @@ import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.ExceptionHandler;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
-import org.slf4j.Logger;
-
-import javax.annotation.Nullable;
-import java.sql.Connection;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
 
 /**
  * Interface with the specific database implementation.
@@ -73,14 +73,14 @@ public interface DatabaseEngine extends AutoCloseable {
     /**
      * Loads an entity into the engine.
      * <p>
-     * No DDL commands will be executed, only prepared statements will be created in order to {@link #persist(String, com.feedzai.commons.sql.abstraction.entry.EntityEntry) persist}
+     * No DDL commands will be executed, only prepared statements will be created in order to {@link #persist(String, EntityEntry) persist}
      * data into the entities.
      *
      * @param entity The entity to load into the connection.
      * @throws DatabaseEngineException If something goes wrong while loading the entity.
      * @implSpec The invocation of this method multiple times is allowed. If the entity already exists, the invocation is a no-op.
-     * @implNote The implementation is similar to the {@link #addEntity(com.feedzai.commons.sql.abstraction.ddl.DbEntity) addEntity} that configured with
-     * {@link com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties#SCHEMA_POLICY SCHEMA_POLICY} of none.
+     * @implNote The implementation is similar to the {@link #addEntity(DbEntity) addEntity} that configured with
+     * {@link PdbProperties#SCHEMA_POLICY SCHEMA_POLICY} of none.
      * @since 2.1.2
      */
     void loadEntity(DbEntity entity) throws DatabaseEngineException;
@@ -90,7 +90,7 @@ public interface DatabaseEngine extends AutoCloseable {
      * Updates an entity in the engine.
      * </p>
      * <p>
-     * If the entity does not exists in the instance, the method {@link #addEntity(com.feedzai.commons.sql.abstraction.ddl.DbEntity)} will be invoked.
+     * If the entity does not exists in the instance, the method {@link #addEntity(DbEntity)} will be invoked.
      * </p>
      * <p>
      * The engine will compare the entity with the {@link #getMetadata(String)} information and update the schema of the table.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -190,14 +190,9 @@ public interface DatabaseEngine extends AutoCloseable {
     /**
      * Flushes the batches for all the registered entities upserting duplicated entries.
      *
-     * @implNote The default implementation of this method throws an {@link UnsupportedOperationException}
-     * for backward-compatibility reasons. If this method is supposed to be called, it must be explicitly overridden.
-     *
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
-    default void flushUpsert() throws DatabaseEngineException {
-        throw new UnsupportedOperationException("Method not implemented.");
-    }
+    void flushUpsert() throws DatabaseEngineException;
 
     /**
      * Commits the current transaction. You should only call this method if you've previously called
@@ -402,15 +397,9 @@ public interface DatabaseEngine extends AutoCloseable {
      *
      * @param name  The entity name.
      * @param entry The entry to persist.
-     *
-     * @implNote The default implementation of this method throws an {@link UnsupportedOperationException}
-     * for backward-compatibility reasons. If this method is supposed to be called, it must be explicitly overridden.
-     *
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
-    default void addBatchUpsert(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        throw new UnsupportedOperationException("Method not implemented.");
-    }
+    void addBatchUpsert(final String name, final EntityEntry entry) throws DatabaseEngineException;
 
     /**
      * Executes the given query.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -15,15 +15,6 @@
  */
 package com.feedzai.commons.sql.abstraction.engine;
 
-import java.sql.Connection;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
-import javax.annotation.Nullable;
-import org.slf4j.Logger;
-
 import com.feedzai.commons.sql.abstraction.FailureListener;
 import com.feedzai.commons.sql.abstraction.batch.AbstractBatch;
 import com.feedzai.commons.sql.abstraction.batch.BatchConfig;
@@ -39,6 +30,15 @@ import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.ExceptionHandler;
 import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
 
 /**
  * Interface with the specific database implementation.
@@ -73,14 +73,14 @@ public interface DatabaseEngine extends AutoCloseable {
     /**
      * Loads an entity into the engine.
      * <p>
-     * No DDL commands will be executed, only prepared statements will be created in order to {@link #persist(String, EntityEntry) persist}
+     * No DDL commands will be executed, only prepared statements will be created in order to {@link #persist(String, com.feedzai.commons.sql.abstraction.entry.EntityEntry) persist}
      * data into the entities.
      *
      * @param entity The entity to load into the connection.
      * @throws DatabaseEngineException If something goes wrong while loading the entity.
      * @implSpec The invocation of this method multiple times is allowed. If the entity already exists, the invocation is a no-op.
-     * @implNote The implementation is similar to the {@link #addEntity(DbEntity) addEntity} that configured with
-     * {@link PdbProperties#SCHEMA_POLICY SCHEMA_POLICY} of none.
+     * @implNote The implementation is similar to the {@link #addEntity(com.feedzai.commons.sql.abstraction.ddl.DbEntity) addEntity} that configured with
+     * {@link com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties#SCHEMA_POLICY SCHEMA_POLICY} of none.
      * @since 2.1.2
      */
     void loadEntity(DbEntity entity) throws DatabaseEngineException;
@@ -90,7 +90,7 @@ public interface DatabaseEngine extends AutoCloseable {
      * Updates an entity in the engine.
      * </p>
      * <p>
-     * If the entity does not exists in the instance, the method {@link #addEntity(DbEntity)} will be invoked.
+     * If the entity does not exists in the instance, the method {@link #addEntity(com.feedzai.commons.sql.abstraction.ddl.DbEntity)} will be invoked.
      * </p>
      * <p>
      * The engine will compare the entity with the {@link #getMetadata(String)} information and update the schema of the table.
@@ -186,13 +186,6 @@ public interface DatabaseEngine extends AutoCloseable {
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
     void flush() throws DatabaseEngineException;
-
-    /**
-     * Flushes the batches for all the registered entities ignoring duplicated entries.
-     *
-     * @throws DatabaseEngineException If something goes wrong while persisting data.
-     */
-    void flushIgnore() throws DatabaseEngineException;
 
     /**
      * Commits the current transaction. You should only call this method if you've previously called
@@ -391,15 +384,6 @@ public interface DatabaseEngine extends AutoCloseable {
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
     void addBatch(final String name, final EntityEntry entry) throws DatabaseEngineException;
-
-    /**
-     * Adds an entry to the batch ignoring duplicate entries.
-     *
-     * @param name  The entity name.
-     * @param entry The entry to persist.
-     * @throws DatabaseEngineException If something goes wrong while persisting data.
-     */
-    void addBatchIgnore(final String name, final EntityEntry entry) throws DatabaseEngineException;
 
     /**
      * Executes the given query.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/DatabaseEngine.java
@@ -188,11 +188,11 @@ public interface DatabaseEngine extends AutoCloseable {
     void flush() throws DatabaseEngineException;
 
     /**
-     * Flushes the batches for all the registered entities upserting duplicated entries.
+     * Flushes the batches for all the registered entities ignoring duplicated entries.
      *
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
-    void flushUpsert() throws DatabaseEngineException;
+    void flushIgnore() throws DatabaseEngineException;
 
     /**
      * Commits the current transaction. You should only call this method if you've previously called
@@ -393,13 +393,13 @@ public interface DatabaseEngine extends AutoCloseable {
     void addBatch(final String name, final EntityEntry entry) throws DatabaseEngineException;
 
     /**
-     * Adds an entry to the batch upserting duplicate entries.
+     * Adds an entry to the batch ignoring duplicate entries.
      *
      * @param name  The entity name.
      * @param entry The entry to persist.
      * @throws DatabaseEngineException If something goes wrong while persisting data.
      */
-    void addBatchUpsert(final String name, final EntityEntry entry) throws DatabaseEngineException;
+    void addBatchIgnore(final String name, final EntityEntry entry) throws DatabaseEngineException;
 
     /**
      * Executes the given query.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/MappedEntity.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/MappedEntity.java
@@ -15,13 +15,13 @@
  */
 package com.feedzai.commons.sql.abstraction.engine;
 
-import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
-import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 
 /**
  * Mapped entity contains information about an entity that has been mapped using the engine.

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/MappedEntity.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/MappedEntity.java
@@ -51,9 +51,9 @@ public class MappedEntity implements AutoCloseable {
      */
     private PreparedStatement insertReturning = null;
     /**
-     * The prepared statement to upsert new values to avoid duplicated keys violation.
+     * The prepared statement to insert new values ignoring duplicated keys.
      */
-    private PreparedStatement upsert = null;
+    private PreparedStatement insertIgnoring = null;
     /**
      * The auto increment column if exists;
      */
@@ -160,23 +160,23 @@ public class MappedEntity implements AutoCloseable {
     }
 
     /**
-     * Gets the prepared statement for upsert operation.
+     * Gets the prepared statement for inserts ignoring duplicated keys.
      *
-     * @return The upsert statement.
+     * @return The insert statement that allows ignoring duplicated keys.
      */
-    public PreparedStatement getUpsert() {
-        return upsert;
+    public PreparedStatement getInsertIgnoring() {
+        return insertIgnoring;
     }
 
     /**
-     * Sets the upsert statement.
+     * Sets the insert that allows ignoring duplicated keys.
      *
-     * @param upsert The upsert statement
+     * @param insertIgnoring The insert statement that allows ignoring duplicated keys
      * @return This mapped entity
      */
-    public MappedEntity setUpsert(final PreparedStatement upsert) {
-        closeQuietly(this.upsert);
-        this.upsert = upsert;
+    public MappedEntity setInsertIgnoring(final PreparedStatement insertIgnoring) {
+        closeQuietly(this.insertIgnoring);
+        this.insertIgnoring = insertIgnoring;
 
         return this;
     }
@@ -241,6 +241,6 @@ public class MappedEntity implements AutoCloseable {
         closeQuietly(this.insert);
         closeQuietly(this.insertWithAutoInc);
         closeQuietly(this.insertReturning);
-        closeQuietly(this.upsert);
+        closeQuietly(this.insertIgnoring);
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/MappedEntity.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/MappedEntity.java
@@ -15,13 +15,13 @@
  */
 package com.feedzai.commons.sql.abstraction.engine;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
-import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 
 /**
  * Mapped entity contains information about an entity that has been mapped using the engine.
@@ -50,10 +50,6 @@ public class MappedEntity implements AutoCloseable {
      * The prepared statement to insert new values.
      */
     private PreparedStatement insertReturning = null;
-    /**
-     * The prepared statement to insert new values ignoring duplicated keys.
-     */
-    private PreparedStatement insertIgnoring = null;
     /**
      * The auto increment column if exists;
      */
@@ -149,35 +145,13 @@ public class MappedEntity implements AutoCloseable {
      * Sets the insert statement auto inc columns.
      *
      * @param insertWithAutoInc The insert statement with auto inc columns.
-     * @return This mapped entity;
+     * @return This mapped entity; 
      * @see DatabaseEngine#persist(String, EntityEntry, boolean)
      */
     public MappedEntity setInsertWithAutoInc(final PreparedStatement insertWithAutoInc) {
         closeQuietly(this.insertWithAutoInc);
         this.insertWithAutoInc = insertWithAutoInc;
-
-        return this;
-    }
-
-    /**
-     * Gets the prepared statement for inserts ignoring duplicated keys.
-     *
-     * @return The insert statement that allows ignoring duplicated keys.
-     */
-    public PreparedStatement getInsertIgnoring() {
-        return insertIgnoring;
-    }
-
-    /**
-     * Sets the insert that allows ignoring duplicated keys.
-     *
-     * @param insertIgnoring The insert statement that allows ignoring duplicated keys
-     * @return This mapped entity
-     */
-    public MappedEntity setInsertIgnoring(final PreparedStatement insertIgnoring) {
-        closeQuietly(this.insertIgnoring);
-        this.insertIgnoring = insertIgnoring;
-
+        
         return this;
     }
 
@@ -241,6 +215,5 @@ public class MappedEntity implements AutoCloseable {
         closeQuietly(this.insert);
         closeQuietly(this.insertWithAutoInc);
         closeQuietly(this.insertReturning);
-        closeQuietly(this.insertIgnoring);
     }
 }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -444,7 +444,8 @@ public class DB2Engine extends AbstractDatabaseEngine {
                         .setUpsert(psUpsert);
 
         } catch (final IllegalArgumentException e) {
-            logger.info("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -469,8 +470,9 @@ public class DB2Engine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created for the entity "
-                                                             + "'%s'.", entity.getName()));
+            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created because the entity "
+                                                             + "'%s' has no primary keys. Skipping statement creation.",
+                                                             entity.getName()));
         }
 
         final List<String> merge = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/DB2Engine.java
@@ -444,8 +444,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
                         .setUpsert(psUpsert);
 
         } catch (final IllegalArgumentException e) {
-            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
-            logger.debug("Stack trace error: ", e);
+            logger.error("Returning entity without an UPSERT/MERGE prepared statement.", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -470,9 +469,7 @@ public class DB2Engine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created because the entity "
-                                                             + "'%s' has no primary keys. Skipping statement creation.",
-                                                             entity.getName()));
+            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
         }
 
         final List<String> merge = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -493,7 +493,8 @@ public class H2Engine extends AbstractDatabaseEngine {
                         .setUpsert(psMerge);
 
         } catch (final IllegalArgumentException e) {
-            logger.info("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -517,8 +518,9 @@ public class H2Engine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created for the entity "
-                                                             + "'%s'.", entity.getName()));
+            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created because the entity "
+                                                             + "'%s' has no primary keys. Skipping statement creation.",
+                                                             entity.getName()));
         }
 
         final List<String> mergeInto = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -493,8 +493,7 @@ public class H2Engine extends AbstractDatabaseEngine {
                         .setUpsert(psMerge);
 
         } catch (final IllegalArgumentException e) {
-            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
-            logger.debug("Stack trace error: ", e);
+            logger.error("Returning entity without an UPSERT/MERGE prepared statement.", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -518,9 +517,7 @@ public class H2Engine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException(String.format("The 'MERGE INTO' prepared statement was not created because the entity "
-                                                             + "'%s' has no primary keys. Skipping statement creation.",
-                                                             entity.getName()));
+            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
         }
 
         final List<String> mergeInto = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -15,21 +15,6 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl;
 
-import java.io.ByteArrayInputStream;
-import java.io.Serializable;
-import java.io.StringReader;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Types;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
 import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
@@ -48,6 +33,21 @@ import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.engine.impl.h2.H2QueryExceptionHandler;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.column;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.max;
@@ -463,7 +463,6 @@ public class H2Engine extends AbstractDatabaseEngine {
         insertIntoWithAutoInc.add("(" + join(columnsWithAutoInc, ", ") + ")");
         insertIntoWithAutoInc.add("VALUES (" + join(valuesWithAutoInc, ", ") + ")");
 
-        final String statementWithMerge = buildMergeStatement(entity, columns, values);
 
         final String statement = join(insertInto, " ");
         // The H2 DB doesn't implement INSERT RETURNING. Therefore, we just create a dummy statement, which will
@@ -473,7 +472,7 @@ public class H2Engine extends AbstractDatabaseEngine {
         logger.trace(statement);
 
 
-        final PreparedStatement ps, psReturn, psWithAutoInc, psMerge;
+        final PreparedStatement ps, psReturn, psWithAutoInc;
         try {
 
             // Generate keys when the table has at least 1 column with auto generate value.
@@ -481,44 +480,17 @@ public class H2Engine extends AbstractDatabaseEngine {
             ps = this.conn.prepareStatement(statement, generateKeys);
             psReturn = this.conn.prepareStatement(insertReturnStatement, generateKeys);
             psWithAutoInc = this.conn.prepareStatement(statementWithAutoInt, generateKeys);
-            psMerge = this.conn.prepareStatement(statementWithMerge, generateKeys);
+
             return new MappedEntity()
                 .setInsert(ps)
                 .setInsertReturning(psReturn)
                 .setInsertWithAutoInc(psWithAutoInc)
                 // The auto incremented column must be set, so when persisting a row, it's possible to retrieve its value
                 // by consulting the column name from this MappedEntity.
-                .setAutoIncColumn(columnWithAutoIncName)
-                .setInsertIgnoring(psMerge);
+                .setAutoIncColumn(columnWithAutoIncName);
         } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }
-    }
-
-    /**
-     * Helper method to create a merge statement for this engine.
-     *
-     * @param entity    The entity.
-     * @param columns   The columns of this entity.
-     * @param values    The values of the entity.
-     *
-     * @return          A merge statement.
-     */
-    private String buildMergeStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
-        final String statementWithMerge;
-        if (!entity.getPkFields().isEmpty() && !columns.isEmpty() && !values.isEmpty()) {
-            final List<String> mergeInto = new ArrayList<>();
-            mergeInto.add("MERGE INTO");
-            mergeInto.add(quotize(entity.getName()));
-
-            mergeInto.add("(" + join(columns, ", ") + ")");
-            mergeInto.add("VALUES (" + join(values, ", ") + ")");
-
-            statementWithMerge = join(mergeInto, " ");
-        } else {
-            statementWithMerge = "";
-        }
-        return statementWithMerge;
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -463,7 +463,7 @@ public class H2Engine extends AbstractDatabaseEngine {
         insertIntoWithAutoInc.add("(" + join(columnsWithAutoInc, ", ") + ")");
         insertIntoWithAutoInc.add("VALUES (" + join(valuesWithAutoInc, ", ") + ")");
 
-        final String statementWithMerge = buildUpsertStatement(entity, columns, values);
+        final String statementWithMerge = buildMergeStatement(entity, columns, values);
 
         final String statement = join(insertInto, " ");
         // The H2 DB doesn't implement INSERT RETURNING. Therefore, we just create a dummy statement, which will
@@ -504,7 +504,7 @@ public class H2Engine extends AbstractDatabaseEngine {
      *
      * @return          A merge statement.
      */
-    private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
+    private String buildMergeStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
             return "";

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -463,6 +463,8 @@ public class H2Engine extends AbstractDatabaseEngine {
         insertIntoWithAutoInc.add("(" + join(columnsWithAutoInc, ", ") + ")");
         insertIntoWithAutoInc.add("VALUES (" + join(valuesWithAutoInc, ", ") + ")");
 
+        final String statementWithMerge = buildUpsertStatement(entity, columns, values);
+
         final String statement = join(insertInto, " ");
         // The H2 DB doesn't implement INSERT RETURNING. Therefore, we just create a dummy statement, which will
         // never be invoked by this implementation.
@@ -471,35 +473,23 @@ public class H2Engine extends AbstractDatabaseEngine {
         logger.trace(statement);
 
 
-        PreparedStatement ps = null, psReturn = null, psWithAutoInc = null, psMerge;
+        final PreparedStatement ps, psReturn, psWithAutoInc, psMerge;
         try {
 
             // Generate keys when the table has at least 1 column with auto generate value.
-            final int generateKeys = columnWithAutoIncName != null ? Statement.RETURN_GENERATED_KEYS : Statement.NO_GENERATED_KEYS;
+            final int generateKeys = columnWithAutoIncName != null? Statement.RETURN_GENERATED_KEYS : Statement.NO_GENERATED_KEYS;
             ps = this.conn.prepareStatement(statement, generateKeys);
             psReturn = this.conn.prepareStatement(insertReturnStatement, generateKeys);
             psWithAutoInc = this.conn.prepareStatement(statementWithAutoInt, generateKeys);
-
-            final String statementWithMerge = buildUpsertStatement(entity, columns, values);
-            psMerge = this.conn.prepareStatement(statementWithMerge);
-
+            psMerge = this.conn.prepareStatement(statementWithMerge, generateKeys);
             return new MappedEntity()
-                        .setInsert(ps)
-                        .setInsertReturning(psReturn)
-                        .setInsertWithAutoInc(psWithAutoInc)
-                        // The auto incremented column must be set, so when persisting a row, it's possible to retrieve its value
-                        // by consulting the column name from this MappedEntity.
-                        .setAutoIncColumn(columnWithAutoIncName)
-                        .setUpsert(psMerge);
-
-        } catch (final IllegalArgumentException e) {
-            logger.error("Returning entity without an UPSERT/MERGE prepared statement.", e);
-            return new MappedEntity()
-                        .setInsert(ps)
-                        .setInsertReturning(psReturn)
-                        .setInsertWithAutoInc(psWithAutoInc)
-                        .setAutoIncColumn(columnWithAutoIncName);
-
+                .setInsert(ps)
+                .setInsertReturning(psReturn)
+                .setInsertWithAutoInc(psWithAutoInc)
+                // The auto incremented column must be set, so when persisting a row, it's possible to retrieve its value
+                // by consulting the column name from this MappedEntity.
+                .setAutoIncColumn(columnWithAutoIncName)
+                .setUpsert(psMerge);
         } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }
@@ -517,7 +507,7 @@ public class H2Engine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
+            return "";
         }
 
         final List<String> mergeInto = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/H2Engine.java
@@ -15,6 +15,21 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl;
 
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
 import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
@@ -33,21 +48,6 @@ import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.engine.impl.h2.H2QueryExceptionHandler;
-
-import java.io.ByteArrayInputStream;
-import java.io.Serializable;
-import java.io.StringReader;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Types;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.column;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.max;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -408,7 +408,8 @@ public class MySqlEngine extends AbstractDatabaseEngine {
                         .setUpsert(psUpsert);
 
         } catch (final IllegalArgumentException e) {
-            logger.info("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -432,7 +433,9 @@ public class MySqlEngine extends AbstractDatabaseEngine {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
             throw new IllegalArgumentException(String.format("The 'INSERT INTO (...) ON DUPLICATE KEY UPDATE' prepared statement was "
-                                                             + "not created for entity '%s.", entity.getName()));
+                                                             + "not created because the entity '%s' has no primary keys. "
+                                                             + "Skipping statement creation.",
+                                                             entity.getName()));
         }
 
         List<String> insertIntoIgnoring = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -408,8 +408,7 @@ public class MySqlEngine extends AbstractDatabaseEngine {
                         .setUpsert(psUpsert);
 
         } catch (final IllegalArgumentException e) {
-            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
-            logger.debug("Stack trace error: ", e);
+            logger.error("Returning entity without an UPSERT/MERGE prepared statement.", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -432,10 +431,7 @@ public class MySqlEngine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException(String.format("The 'INSERT INTO (...) ON DUPLICATE KEY UPDATE' prepared statement was "
-                                                             + "not created because the entity '%s' has no primary keys. "
-                                                             + "Skipping statement creation.",
-                                                             entity.getName()));
+            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
         }
 
         List<String> insertIntoIgnoring = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/MySqlEngine.java
@@ -48,7 +48,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.md5;
 import static com.feedzai.commons.sql.abstraction.util.StringUtils.quotize;
@@ -392,70 +391,16 @@ public class MySqlEngine extends AbstractDatabaseEngine {
         logger.trace(statement);
         logger.trace(statementWithAutoInt);
 
-        PreparedStatement ps = null, psReturn = null, psWithAutoInc = null, psUpsert;
+        final PreparedStatement ps, psReturn, psWithAutoInc;
         try {
             ps = conn.prepareStatement(statement, Statement.RETURN_GENERATED_KEYS);
             psReturn = conn.prepareStatement(insertReturnStatement);
             psWithAutoInc = conn.prepareStatement(statementWithAutoInt);
 
-            final String upsertStatement = buildUpsertStatement(entity, columns, values);
-            psUpsert = conn.prepareStatement(upsertStatement);
-
-            return new MappedEntity()
-                        .setInsert(ps)
-                        .setInsertReturning(psReturn)
-                        .setInsertWithAutoInc(psWithAutoInc)
-                        .setUpsert(psUpsert);
-
-        } catch (final IllegalArgumentException e) {
-            logger.error("Returning entity without an UPSERT/MERGE prepared statement.", e);
-            return new MappedEntity()
-                        .setInsert(ps)
-                        .setInsertReturning(psReturn)
-                        .setInsertWithAutoInc(psWithAutoInc);
-
+            return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc);
         } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }
-    }
-
-    /**
-     * Helper method to create an insert statement on duplicate key conflict for this engine.
-     *
-     * @param entity    The entity.
-     * @param columns   The columns of this entity.
-     * @param values    The values of the entity.
-     *
-     * @return          An insert statement on duplicate key conflict.
-     */
-    private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
-
-        if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
-        }
-
-        List<String> insertIntoIgnoring = new ArrayList<>();
-        insertIntoIgnoring.add("INSERT INTO");
-        insertIntoIgnoring.add(quotize(entity.getName(), escapeCharacter()));
-
-        insertIntoIgnoring.add("(" + join(columns, ", ") + ")");
-        insertIntoIgnoring.add("VALUES (" + join(values, ", ") + ")");
-
-        final List<String> primaryKeys = entity.getPkFields().stream().map(pk -> quotize(pk, escapeCharacter())).collect(Collectors.toList());
-        insertIntoIgnoring.add("ON DUPLICATE KEY UPDATE");
-
-        final List<String> columnsWithoutPKs = new ArrayList<>(columns);
-        columnsWithoutPKs.removeAll(primaryKeys);
-
-        final String columnsToUpdate = columnsWithoutPKs
-                                        .stream()
-                                        .map(column -> String.format("%s = VALUES(%s)", column, column))
-                                        .collect(Collectors.joining(", "));
-
-        insertIntoIgnoring.add(columnsToUpdate);
-
-        return join(insertIntoIgnoring, " ");
-
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -351,15 +351,9 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         List<String> insertInto = new ArrayList<>();
         insertInto.add("INSERT INTO");
         insertInto.add(quotize(entity.getName()));
-
         List<String> insertIntoWithAutoInc = new ArrayList<>();
         insertIntoWithAutoInc.add("INSERT INTO");
         insertIntoWithAutoInc.add(quotize(entity.getName()));
-
-        List<String> insertIntoIgnoring = new ArrayList<>();
-        insertIntoIgnoring.add("INSERT INTO");
-        insertIntoIgnoring.add(quotize(entity.getName()));
-
         List<String> columns = new ArrayList<>();
         List<String> values = new ArrayList<>();
         List<String> columnsWithAutoInc = new ArrayList<>();
@@ -383,10 +377,6 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         insertIntoWithAutoInc.add("(" + join(columnsWithAutoInc, ", ") + ")");
         insertIntoWithAutoInc.add("VALUES (" + join(valuesWithAutoInc, ", ") + ")");
 
-        insertIntoIgnoring.add("(" + join(columns, ", ") + ")");
-        insertIntoIgnoring.add("VALUES (" + join(values, ", ") + ")");
-        insertIntoIgnoring.add("ON CONFLICT DO NOTHING");
-
         List<String> insertIntoReturn = new ArrayList<>(insertInto);
 
 
@@ -397,21 +387,18 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         final String insertStatement = join(insertInto, " ");
         final String insertReturnStatement = join(insertIntoReturn, " ");
         final String statementWithAutoInt = join(insertIntoWithAutoInc, " ");
-        final String insertIgnoring = join(insertIntoIgnoring, " ");;
 
         logger.trace(insertStatement);
         logger.trace(insertReturnStatement);
-        logger.trace(insertIgnoring);
 
-        PreparedStatement ps, psReturn, psWithAutoInc, psWithInsertIgnoring;
+        PreparedStatement ps, psReturn, psWithAutoInc;
         try {
 
             ps = conn.prepareStatement(insertStatement);
             psReturn = conn.prepareStatement(insertReturnStatement);
             psWithAutoInc = conn.prepareStatement(statementWithAutoInt);
-            psWithInsertIgnoring = conn.prepareStatement(insertIgnoring);
 
-            return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc).setInsertIgnoring(psWithInsertIgnoring).setAutoIncColumn(returning);
+            return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc).setAutoIncColumn(returning);
         } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -413,7 +413,8 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                         .setAutoIncColumn(returning);
 
         } catch (final IllegalArgumentException e) {
-            logger.info("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
+            logger.debug("Stack trace error: ", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -437,8 +438,10 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException(String.format("The 'INSERT INTO (...) ON CONFLICT DO UPDATE' prepared "
-                                                             + "statement was not created for entity '%s'.", entity.getName()));
+            throw new IllegalArgumentException(String.format("The 'INSERT INTO (...) ON CONFLICT DO UPDATE' prepared statement was not "
+                                                             + "created because the entity '%s' has no primary keys. "
+                                                             + "Skipping statement creation.",
+                                                             entity.getName()));
         }
 
         List<String> insertIntoIgnoring = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -413,8 +413,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
                         .setAutoIncColumn(returning);
 
         } catch (final IllegalArgumentException e) {
-            logger.warn("{} Returning an entity without an UPSERT/MERGE prepared statement.", e.getMessage());
-            logger.debug("Stack trace error: ", e);
+            logger.error("Returning entity without an UPSERT/MERGE prepared statement.", e);
             return new MappedEntity()
                         .setInsert(ps)
                         .setInsertReturning(psReturn)
@@ -438,10 +437,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
     private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
-            throw new IllegalArgumentException(String.format("The 'INSERT INTO (...) ON CONFLICT DO UPDATE' prepared statement was not "
-                                                             + "created because the entity '%s' has no primary keys. "
-                                                             + "Skipping statement creation.",
-                                                             entity.getName()));
+            throw new IllegalArgumentException("The MERGE command was not created because the entity has no primary keys. Skipping statement creation.");
         }
 
         List<String> insertIntoIgnoring = new ArrayList<>();

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -15,6 +15,27 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.postgresql.Driver;
+import org.postgresql.PGProperty;
+import org.postgresql.util.PGobject;
+
 import com.feedzai.commons.sql.abstraction.ddl.DbColumn;
 import com.feedzai.commons.sql.abstraction.ddl.DbColumnConstraint;
 import com.feedzai.commons.sql.abstraction.ddl.DbColumnType;
@@ -35,29 +56,6 @@ import com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties;
 import com.feedzai.commons.sql.abstraction.engine.handler.OperationFault;
 import com.feedzai.commons.sql.abstraction.engine.handler.QueryExceptionHandler;
 import com.feedzai.commons.sql.abstraction.engine.impl.postgresql.PostgresSqlQueryExceptionHandler;
-
-import java.time.Duration;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-import org.postgresql.Driver;
-import org.postgresql.PGProperty;
-import org.postgresql.util.PGobject;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Types;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
 
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.column;
 import static com.feedzai.commons.sql.abstraction.dml.dialect.SqlBuilder.max;

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/impl/PostgreSqlEngine.java
@@ -390,21 +390,21 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
         final String insertStatement = join(insertInto, " ");
         final String insertReturnStatement = join(insertIntoReturn, " ");
         final String statementWithAutoInt = join(insertIntoWithAutoInc, " ");
-        final String upsert = buildUpsertStatement(entity, columns, values);
+        final String insertIgnoring = buildInsertOnConflictStatement(entity, columns, values);
 
         logger.trace(insertStatement);
         logger.trace(insertReturnStatement);
-        logger.trace(upsert);
+        logger.trace(insertIgnoring);
 
-        PreparedStatement ps, psReturn, psWithAutoInc, psUpsert;
+        PreparedStatement ps, psReturn, psWithAutoInc, psWithInsertIgnoring;
         try {
 
             ps = conn.prepareStatement(insertStatement);
             psReturn = conn.prepareStatement(insertReturnStatement);
             psWithAutoInc = conn.prepareStatement(statementWithAutoInt);
-            psUpsert = conn.prepareStatement(upsert);
+            psWithInsertIgnoring = conn.prepareStatement(insertIgnoring);
 
-            return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc).setUpsert(psUpsert).setAutoIncColumn(returning);
+            return new MappedEntity().setInsert(ps).setInsertReturning(psReturn).setInsertWithAutoInc(psWithAutoInc).setUpsert(psWithInsertIgnoring).setAutoIncColumn(returning);
         } catch (final SQLException ex) {
             throw new DatabaseEngineException("Something went wrong handling statement", ex);
         }
@@ -419,7 +419,7 @@ public class PostgreSqlEngine extends AbstractDatabaseEngine {
      *
      * @return          A insert on conflict statement.
      */
-    private String buildUpsertStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
+    private String buildInsertOnConflictStatement(final DbEntity entity, final List<String> columns, final List<String> values) {
 
         if (entity.getPkFields().isEmpty() || columns.isEmpty() || values.isEmpty()) {
             return "";

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/pool/PooledDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/pool/PooledDatabaseEngine.java
@@ -155,8 +155,8 @@ class PooledDatabaseEngine implements DatabaseEngine {
     }
 
     @Override
-    public void flushUpsert() throws DatabaseEngineException {
-        engine.flushUpsert();
+    public void flushIgnore() throws DatabaseEngineException {
+        engine.flushIgnore();
     }
 
     @Override
@@ -235,8 +235,8 @@ class PooledDatabaseEngine implements DatabaseEngine {
     }
 
     @Override
-    public void addBatchUpsert(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        engine.addBatchUpsert(name, entry);
+    public void addBatchIgnore(final String name, final EntityEntry entry) throws DatabaseEngineException {
+        engine.addBatchIgnore(name, entry);
     }
 
     @Override

--- a/src/main/java/com/feedzai/commons/sql/abstraction/engine/pool/PooledDatabaseEngine.java
+++ b/src/main/java/com/feedzai/commons/sql/abstraction/engine/pool/PooledDatabaseEngine.java
@@ -155,11 +155,6 @@ class PooledDatabaseEngine implements DatabaseEngine {
     }
 
     @Override
-    public void flushIgnore() throws DatabaseEngineException {
-        engine.flushIgnore();
-    }
-
-    @Override
     public void commit() throws DatabaseEngineRuntimeException {
         engine.commit();
     }
@@ -232,11 +227,6 @@ class PooledDatabaseEngine implements DatabaseEngine {
     @Override
     public void addBatch(final String name, final EntityEntry entry) throws DatabaseEngineException {
         engine.addBatch(name, entry);
-    }
-
-    @Override
-    public void addBatchIgnore(final String name, final EntityEntry entry) throws DatabaseEngineException {
-        engine.addBatchIgnore(name, entry);
     }
 
     @Override

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -15,40 +15,12 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
-import com.feedzai.commons.sql.abstraction.batch.AbstractBatch;
-import com.feedzai.commons.sql.abstraction.batch.AbstractBatchConfig;
-import com.feedzai.commons.sql.abstraction.batch.BatchEntry;
-import com.feedzai.commons.sql.abstraction.batch.PdbBatch;
-import com.feedzai.commons.sql.abstraction.batch.impl.DefaultBatch;
-import com.feedzai.commons.sql.abstraction.batch.impl.DefaultBatchConfig;
-import com.feedzai.commons.sql.abstraction.batch.impl.MultithreadedBatchConfig;
-import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
-import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
-import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
-import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
-import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
-import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
-import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
-import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
-import com.feedzai.commons.sql.abstraction.listeners.MetricsListener;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
-import mockit.Invocation;
-import mockit.Mock;
-import mockit.MockUp;
-import org.assertj.core.api.ObjectAssert;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -70,6 +42,38 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
+import org.assertj.core.api.ObjectAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.LoggerFactory;
+
+import com.feedzai.commons.sql.abstraction.batch.AbstractBatch;
+import com.feedzai.commons.sql.abstraction.batch.AbstractBatchConfig;
+import com.feedzai.commons.sql.abstraction.batch.BatchEntry;
+import com.feedzai.commons.sql.abstraction.batch.PdbBatch;
+import com.feedzai.commons.sql.abstraction.batch.impl.DefaultBatch;
+import com.feedzai.commons.sql.abstraction.batch.impl.DefaultBatchConfig;
+import com.feedzai.commons.sql.abstraction.batch.impl.MultithreadedBatchConfig;
+import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
+import com.feedzai.commons.sql.abstraction.dml.result.ResultColumn;
+import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineException;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseEngineRuntimeException;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactory;
+import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
+import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
+import com.feedzai.commons.sql.abstraction.entry.EntityEntry;
+import com.feedzai.commons.sql.abstraction.listeners.BatchListener;
+import com.feedzai.commons.sql.abstraction.listeners.MetricsListener;
 
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.BOOLEAN;
 import static com.feedzai.commons.sql.abstraction.ddl.DbColumnType.DOUBLE;
@@ -133,6 +137,11 @@ public class BatchUpdateTest {
 
     @Parameterized.Parameter(1)
     public Supplier<AbstractBatchConfig.Builder<?, ?, ?>> batchConfigBuilderSupplier;
+
+    @BeforeClass
+    public static void initStatic() {
+        ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.TRACE);
+    }
 
     @Before
     public void init() throws DatabaseFactoryException {

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -845,19 +845,10 @@ public class BatchUpdateTest {
         final int idx = 0;
         final EntityEntry testEntry = getTestEntry(idx);
         batch.add("TEST", testEntry);
-
-        final Object testEntryKey = testEntry.get("COL1");
-        final  EntityEntry testEntryDuplicatedKey = entry()
-                                                    .set("COL1", testEntryKey)
-                                                    .set("COL2", true)
-                                                    .set("COL3", 250D)
-                                                    .set("COL4", 350L)
-                                                    .set("COL5", "OLA")
-                                                    .build();
-        batch.add("TEST", testEntryDuplicatedKey);
+        batch.add("TEST", testEntry);
 
         // Explicit flush, but ignoring the duplicate entries in the batch.
-        batch.flushUpsert();
+        batch.flushIgnore();
 
         // Check that entries were not added to onFlushFailure().
         assertTrue("Entries should not be added to failed", batchListener.failed.isEmpty());
@@ -865,10 +856,8 @@ public class BatchUpdateTest {
         // Check that all entries succeeded
         assertEquals("Entries should have all succeeded to be persisted", numTestEntries, batchListener.succeeded.size());
 
-        // Check if only the second entry was persisted in the DB, e.g. performed the upsert.
-        final List<Map<String, ResultColumn>> result = engine.query(select(all()).from(table("TEST")).orderby(column("COL1").asc()));
-        assertEquals("Inserted entries not as expected", 1, result.size());
-        checkTestEntry(result.get(0), testEntryDuplicatedKey);
+        // Considering they are the same entry, only one should be inserted in the database.
+        checkTestEntriesInDB(1);
     }
 
     /**
@@ -988,16 +977,6 @@ public class BatchUpdateTest {
         assertTrue("COL5 exists", row.containsKey("COL5"));
 
         EntityEntry expectedEntry = getTestEntry(idx);
-        checkTestEntry(row, expectedEntry);
-    }
-
-    /**
-     * Checks that a DB row matches the expected entry row for that position.
-     *
-     * @param row The DB row.
-     * @param expectedEntry The expected entry.
-     */
-    private void checkTestEntry(final Map<String, ResultColumn> row, final EntityEntry expectedEntry) {
         assertEquals("COL1 ok?", expectedEntry.get("COL1"), row.get("COL1").toInt());
         assertEquals("COL2 ok?", expectedEntry.get("COL2"), row.get("COL2").toBoolean());
         assertEquals("COL3 ok?", (double) expectedEntry.get("COL3"), row.get("COL3").toDouble(), 0);

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -821,12 +821,12 @@ public class BatchUpdateTest {
     }
 
     /**
-     * Tests if a batch with entries having duplicate upserts the entry when flushing.
+     * Tests if a batch with entries having duplicate ignores when there is an error.
      *
      * @throws Exception if any operations on the batch fail.
      */
     @Test
-    public void batchUpsertDuplicateFlushTest() throws Exception {
+    public void batchInsertOnIgnoreDuplicateFlushTest() throws Exception {
         assumeTrue(ImmutableList.of("postresql", "mysql", "cockroach", "db2").contains(dbConfig.vendor) && dbConfig.vendor.startsWith("h2"));
         final TestBatchListener batchListener = new TestBatchListener();
         final int numTestEntries = 2;
@@ -834,12 +834,13 @@ public class BatchUpdateTest {
         addTestEntityWithPrimaryKey();
 
         final DefaultBatch batch = engine.createBatch(DefaultBatchConfig.builder()
-                                                                        .withName("batchUpsertDuplicateFlushTest")
-                                                                        .withBatchSize(numTestEntries + 1)
-                                                                        .withBatchTimeout(Duration.ofSeconds(100))
-                                                                        .withMaxAwaitTimeShutdown(Duration.ofSeconds(1000))
-                                                                        .withBatchListener(batchListener)
-                                                                        .build());
+                                                             .withName("batchInsertOnIgnoreDuplicateFlushTest")
+                                                             .withBatchSize(numTestEntries + 1)
+                                                             .withBatchTimeout(Duration.ofSeconds(100))
+                                                             .withMaxAwaitTimeShutdown(Duration.ofSeconds(1000))
+                                                             .withBatchListener(batchListener)
+                                                             .build()
+        );
 
         // Add entries to batch, no flush should take place because numTestEntries < batch size and batch timeout is huge
         final int idx = 0;

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -827,7 +827,7 @@ public class BatchUpdateTest {
      */
     @Test
     public void batchInsertOnIgnoreDuplicateFlushTest() throws Exception {
-        assumeTrue(ImmutableList.of("postresql", "mysql", "cockroach", "db2").contains(dbConfig.vendor) && dbConfig.vendor.startsWith("h2"));
+        assumeTrue(ImmutableList.of("h2", "postresql").contains(dbConfig.vendor));
         final TestBatchListener batchListener = new TestBatchListener();
         final int numTestEntries = 2;
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/BatchUpdateTest.java
@@ -827,7 +827,6 @@ public class BatchUpdateTest {
      */
     @Test
     public void batchInsertOnIgnoreDuplicateFlushTest() throws Exception {
-        assumeTrue(ImmutableList.of("h2", "postresql").contains(dbConfig.vendor));
         final TestBatchListener batchListener = new TestBatchListener();
         final int numTestEntries = 2;
 

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
@@ -15,6 +15,26 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+import mockit.Capturing;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Verifications;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.LoggerFactory;
+
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
 import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
@@ -24,22 +44,6 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.NameAlreadyExistsException;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
-import mockit.Capturing;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Verifications;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.engine.EngineTestUtils.buildEntity;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
@@ -47,6 +51,7 @@ import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProper
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
+
 
 /**
  * Tests closing a {@link DatabaseEngine} to make sure all resources are cleaned up correctly.
@@ -92,6 +97,11 @@ public class EngineCloseTest {
         this.schemaPolicy = schemaPolicy;
     }
 
+    @BeforeClass
+    public static void initStatic() {
+        ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.TRACE);
+    }
+
     @Before
     public void setUp() throws DatabaseFactoryException {
         properties = new Properties() {{
@@ -108,7 +118,7 @@ public class EngineCloseTest {
     /**
      * Test that closing a database engine with multiple entities closes all insert statements associated with each
      * entity, regardless of the schema policy used.
-     * <p>
+     *
      * Each entity is associated with 3 prepared statements. This test ensures that 3 PSs per entity are closed.
      *
      * @param preparedStatementMock       The mock to check number of closed prepared statements.

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
@@ -15,26 +15,6 @@
  */
 package com.feedzai.commons.sql.abstraction.engine.impl.abs;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Properties;
-import mockit.Capturing;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Verifications;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.slf4j.LoggerFactory;
-
 import com.feedzai.commons.sql.abstraction.ddl.DbEntity;
 import com.feedzai.commons.sql.abstraction.engine.AbstractDatabaseEngine;
 import com.feedzai.commons.sql.abstraction.engine.DatabaseEngine;
@@ -44,6 +24,22 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.NameAlreadyExistsException;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
+import mockit.Capturing;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Verifications;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
 
 import static com.feedzai.commons.sql.abstraction.engine.EngineTestUtils.buildEntity;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.ENGINE;
@@ -51,7 +47,6 @@ import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProper
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
-
 
 /**
  * Tests closing a {@link DatabaseEngine} to make sure all resources are cleaned up correctly.
@@ -97,11 +92,6 @@ public class EngineCloseTest {
         this.schemaPolicy = schemaPolicy;
     }
 
-    @BeforeClass
-    public static void initStatic() {
-        ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.TRACE);
-    }
-
     @Before
     public void setUp() throws DatabaseFactoryException {
         properties = new Properties() {{
@@ -118,7 +108,7 @@ public class EngineCloseTest {
     /**
      * Test that closing a database engine with multiple entities closes all insert statements associated with each
      * entity, regardless of the schema policy used.
-     *
+     * <p>
      * Each entity is associated with 3 prepared statements. This test ensures that 3 PSs per entity are closed.
      *
      * @param preparedStatementMock       The mock to check number of closed prepared statements.
@@ -149,8 +139,8 @@ public class EngineCloseTest {
         engine.close();
 
         new Verifications() {{
-            preparedStatementMock.close(); times = 2 * 4 + 2;   // {2 entities} x {PSs per entity} + {cached PSs}
-            preparedStatementMock.executeBatch(); times = 2 * 4;   // {2 entities} x {PSs per entity}
+            preparedStatementMock.close(); times = 2 * 3 + 2;   // {2 entities} x {PSs per entity} + {cached PSs}
+            preparedStatementMock.executeBatch(); times = 2 * 3;   // {2 entities} x {PSs per entity}
         }};
 
     }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
@@ -123,7 +123,7 @@ public class EngineCloseTest {
     @Test
     public void closingAnEngineShouldFlushAndCloseInsertPSsAndCloseCachedPSs(@Capturing final Statement preparedStatementMock)
             throws DatabaseEngineException, SQLException, NameAlreadyExistsException {
-        assumeTrue(!ImmutableList.of("postgresql", "cockroach").contains(config.vendor) && !config.vendor.startsWith("h2"));
+        assumeTrue(!ImmutableList.of("h2", "postgresql", "cockroach").contains(config.vendor));
 
         engine.addEntity(buildEntity("ENTITY-1"));
         engine.addEntity(buildEntity("ENTITY-2"));

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
@@ -123,7 +123,7 @@ public class EngineCloseTest {
     @Test
     public void closingAnEngineShouldFlushAndCloseInsertPSsAndCloseCachedPSs(@Capturing final Statement preparedStatementMock)
             throws DatabaseEngineException, SQLException, NameAlreadyExistsException {
-        assumeTrue(!ImmutableList.of("h2", "postgresql", "cockroach").contains(config.vendor));
+        assumeTrue(!ImmutableList.of("h2", "postgresql").contains(config.vendor));
 
         engine.addEntity(buildEntity("ENTITY-1"));
         engine.addEntity(buildEntity("ENTITY-2"));

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
@@ -24,8 +24,6 @@ import com.feedzai.commons.sql.abstraction.engine.DatabaseFactoryException;
 import com.feedzai.commons.sql.abstraction.engine.NameAlreadyExistsException;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseConfiguration;
 import com.feedzai.commons.sql.abstraction.engine.testconfig.DatabaseTestUtil;
-
-import com.google.common.collect.ImmutableList;
 import mockit.Capturing;
 import mockit.Expectations;
 import mockit.Mock;
@@ -49,7 +47,6 @@ import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProper
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.PASSWORD;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.SCHEMA_POLICY;
 import static com.feedzai.commons.sql.abstraction.engine.configuration.PdbProperties.USERNAME;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Tests closing a {@link DatabaseEngine} to make sure all resources are cleaned up correctly.
@@ -123,7 +120,6 @@ public class EngineCloseTest {
     @Test
     public void closingAnEngineShouldFlushAndCloseInsertPSsAndCloseCachedPSs(@Capturing final Statement preparedStatementMock)
             throws DatabaseEngineException, SQLException, NameAlreadyExistsException {
-        assumeTrue(!ImmutableList.of("h2", "postgresql").contains(config.vendor));
 
         engine.addEntity(buildEntity("ENTITY-1"));
         engine.addEntity(buildEntity("ENTITY-2"));
@@ -143,8 +139,8 @@ public class EngineCloseTest {
         engine.close();
 
         new Verifications() {{
-            preparedStatementMock.close(); times = 2 * 3 + 2;   // {2 entities} x {PSs per entity} + {cached PSs}
-            preparedStatementMock.executeBatch(); times = 2 * 3;   // {2 entities} x {PSs per entity}
+            preparedStatementMock.close(); times = 2 * 4 + 2;   // {2 entities} x {PSs per entity} + {cached PSs}
+            preparedStatementMock.executeBatch(); times = 2 * 4;   // {2 entities} x {PSs per entity}
         }};
 
     }

--- a/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
+++ b/src/test/java/com/feedzai/commons/sql/abstraction/engine/impl/abs/EngineCloseTest.java
@@ -123,7 +123,7 @@ public class EngineCloseTest {
     @Test
     public void closingAnEngineShouldFlushAndCloseInsertPSsAndCloseCachedPSs(@Capturing final Statement preparedStatementMock)
             throws DatabaseEngineException, SQLException, NameAlreadyExistsException {
-        assumeTrue(!ImmutableList.of("postgresql", "cockroach", "mysql", "db2").contains(config.vendor) && !config.vendor.startsWith("h2"));
+        assumeTrue(!ImmutableList.of("postgresql", "cockroach").contains(config.vendor) && !config.vendor.startsWith("h2"));
 
         engine.addEntity(buildEntity("ENTITY-1"));
         engine.addEntity(buildEntity("ENTITY-2"));


### PR DESCRIPTION
Recently, it was added a support for the _upsert of entries_ in the `pdb` library. 

The feature added supported for entities to, when applicable, be able to be _upserted_ or depending on the engine implementation, an _insert ignore_ or even _merge_. The feature also enabled the upsert feature for batch processing, i.e. entries could now use the new upsert API. However, after its usage it was possible to conclude it decreased performance when client application used this new API. Giving the degrading performance and also the log messages some of the entities generated for not having the upsert statement available, it was decided to **remove** this **feature** entirely from the `pdb` code-base.

This series of commit reverts the feature to upsert entries on `pdb`. The reverted commits reverted are as follows.

- 94ba1a5
- 46f29b2
- 963cd30
- d4f7c4e
- d626297
- 36a434c
- 1658965
- d2f153b
- 2f0d1ff
- 348a22d
- e100a51


